### PR TITLE
Downgrading Type Annotations

### DIFF
--- a/effectful/internals/prompts.py
+++ b/effectful/internals/prompts.py
@@ -67,7 +67,7 @@ def bind_result(fn: Callable[Concatenate[Optional[T], P], T]) -> Callable[P, T]:
     return _wrapper
 
 
-Prompt = Operation[[Optional[T]], T]
+Prompt = Operation[Optional[T], T]
 
 
 def bind_prompts(

--- a/tests/test_ops_handler.py
+++ b/tests/test_ops_handler.py
@@ -33,11 +33,11 @@ def times_plus_1(x: int, y: int) -> int:
     return x * y + 1
 
 
-def defaults(*ops: Operation[..., int]) -> Interpretation[int, int]:
+def defaults(*ops: Operation[int, int]) -> Interpretation[int, int]:
     return {op: bind_result(value_or_result(op.default)) for op in ops}
 
 
-def times_n_handler(n: int, *ops: Operation[..., int]) -> Interpretation[int, int]:
+def times_n_handler(n: int, *ops: Operation[int, int]) -> Interpretation[int, int]:
     return {op: bind_result(lambda v, *args, **kwargs: fwd(v) * n) for op in ops}
 
 

--- a/tests/test_ops_interpreter.py
+++ b/tests/test_ops_interpreter.py
@@ -34,9 +34,9 @@ def times_plus_1(x: int, y: int) -> int:
     return x * y + 1
 
 
-def times_n(n: int, *ops: Operation[..., int]) -> Interpretation[int, int]:
+def times_n(n: int, *ops: Operation[int, int]) -> Interpretation[int, int]:
     def _op_times_n(
-        n: int, op: Operation[..., int], result: Optional[int], *args: int
+        n: int, op: Operation[int, int], result: Optional[int], *args: int
     ) -> int:
         return value_or_result(op.default)(result, *args) * n
 

--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -34,15 +34,15 @@ def times_plus_1(x: int, y: int) -> int:
     return x * y + 1
 
 
-def block(*ops: Operation[..., int]) -> Interpretation[int, int]:
+def block(*ops: Operation[int, int]) -> Interpretation[int, int]:
     return {op: bind_result(lambda v, *args, **kwargs: reflect(v)) for op in ops}
 
 
-def defaults(*ops: Operation[..., int]) -> Interpretation[int, int]:
+def defaults(*ops: Operation[int, int]) -> Interpretation[int, int]:
     return {op: bind_result(value_or_result(op.default)) for op in ops}
 
 
-def times_n_handler(n: int, *ops: Operation[..., int]) -> Interpretation[int, int]:
+def times_n_handler(n: int, *ops: Operation[int, int]) -> Interpretation[int, int]:
     return {op: bind_result(lambda v, *args, **kwargs: fwd(v) * n) for op in ops}
 
 


### PR DESCRIPTION
This downgrades the type annotations to ones which work on python 3.8. The changes are mainly turning `A | B` types into `typing.Union[A, B]` and removing ellipses from type parameters.