### PR TITLE
Add Minipyro Example

### DIFF
--- a/effectful/ops/core.py
+++ b/effectful/ops/core.py
@@ -14,11 +14,9 @@ T_co = TypeVar("T_co", covariant=True)
 
 @typing.runtime_checkable
 class Operation(Protocol[P, T_co]):
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T_co:
-        ...
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T_co: ...
 
-    def default(self, *args: P.args, **kwargs: P.kwargs) -> T_co:
-        ...
+    def default(self, *args: P.args, **kwargs: P.kwargs) -> T_co: ...
 
 
 Interpretation = Mapping[Operation[..., T], Callable[..., V]]

--- a/effectful/ops/handler.py
+++ b/effectful/ops/handler.py
@@ -21,9 +21,9 @@ def fwd(__result: Optional[T]) -> T:
 
 @define(Operation)
 def coproduct(
-        intp: Interpretation[S, T],
-        *intps: Interpretation[S, T],
-        prompt: Prompt[T] = fwd,
+    intp: Interpretation[S, T],
+    *intps: Interpretation[S, T],
+    prompt: Prompt[T] = fwd,
 ) -> Interpretation[S, T]:
     if len(intps) == 0:  # unit
         return intp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,18 @@
 import pytest
 
+UNIMPLEMENTED_SUBSTRINGS = [
+    "infer.JitTrace_ELBO",
+    "the event_dim arg",
+    "optim.ClippedAdam",
+    "infer.TraceMeanField_ELBO",
+]
+
 
 def pytest_runtest_call(item):
     try:
         item.runtest()
     except NotImplementedError as e:
-        pytest.xfail(str(e))
+        if any(s in str(e) for s in UNIMPLEMENTED_SUBSTRINGS):
+            pytest.xfail(str(e))
+        else:
+            raise e

--- a/tests/test_minipyro.py
+++ b/tests/test_minipyro.py
@@ -1,7 +1,7 @@
 import pytest
-from effectful.handlers.minipyro import default_runner
 from pyroapi import pyro_backend
 
+from effectful.handlers.minipyro import default_runner
 from effectful.ops.interpreter import interpreter
 
 


### PR DESCRIPTION
This re-implements the minipyro example from pyro on top of the effectful library. The pyro-api tests for the parts we've implemented are all passing.