### PR TITLE
Fix edge-case with application of `get_runtime`

### DIFF
--- a/effectful/internals/bootstrap.py
+++ b/effectful/internals/bootstrap.py
@@ -31,7 +31,7 @@ class _BaseOperation(Generic[P, T_co]):
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T_co:
         if self is runtime.get_runtime:
             intp = self.default(*args, **kwargs).interpretation
-            return core.apply.default(intp, self, *args, **kwargs)
+            return core.apply.default(intp, core.apply, intp, self, *args, **kwargs)
         elif self is core.apply:
             intp = runtime.get_interpretation()
             return core.apply.default(intp, self, *args, **kwargs)

--- a/tests/test_ops_handler.py
+++ b/tests/test_ops_handler.py
@@ -1,13 +1,15 @@
 import contextlib
 import itertools
 import logging
+from collections import defaultdict
 from typing import TypeVar
 
 import pytest
 from typing_extensions import ParamSpec
 
 from effectful.internals.prompts import bind_result, value_or_result
-from effectful.ops.core import Interpretation, Operation, define
+from effectful.internals.runtime import get_runtime
+from effectful.ops.core import Interpretation, Operation, apply, define
 from effectful.ops.handler import coproduct, fwd, handler
 from effectful.ops.interpreter import interpreter
 
@@ -137,3 +139,21 @@ def test_stop_without_fwd(op, args, n, depth):
         stack.enter_context(handler(defaults(op)))
 
         assert f() == expected
+
+
+def test_handling_internal_operations():
+    log = defaultdict(list)
+
+    def logged(op):
+        def wrapped(*args, **kwargs):
+            log[op].append((args, kwargs))
+            return op.default(*args, **kwargs)
+
+        return wrapped
+
+    with handler({apply: logged(apply), get_runtime: logged(get_runtime)}):
+        assert plus_1(1) == 2
+
+        assert apply in log
+        assert get_runtime in log
+        assert any(get_runtime in args for (args, kwargs) in log[apply])


### PR DESCRIPTION
I was poking around while working on removing defaults and I was a bit confused about this weird edge-case: `get_runtime` is never `apply`'ed, only ever `apply.default`'ed. It doesn't seem like that semantics was intended, so I added a test and a possible patch.