### PR TITLE
Rewrite dictionary merge

### DIFF
--- a/effectful/ops/handler.py
+++ b/effectful/ops/handler.py
@@ -1,5 +1,4 @@
 import contextlib
-from copy import copy
 from typing import Optional, TypeVar
 
 from typing_extensions import ParamSpec
@@ -34,10 +33,11 @@ def coproduct(
 
     (intp2,) = intps
 
-    res = copy(intp)
+    res = dict(intp)
 
     for op, i2 in intp2.items():
-        if i1 := intp.get(op):
+        i1 = intp.get(op)
+        if i1:
             res[op] = bind_prompts({prompt: i1})(i2)
         else:
             res[op] = i2


### PR DESCRIPTION
This is a small patch which fixes the performance of code which makes heavy use of `coproduct`. It merges two interpretations without creating intermediate objects by mutating the dictionaries instead of combining them functionally. In the current branch I'm working on, which makes heavy use of `coproduct`, it speeds up the test runner by 3x. If this seems like premature optimization, I could also add it to the PR for that branch.