### PR TITLE
Make `apply` and `get_runtime` host functions rather than operations

### DIFF
--- a/effectful/internals/bootstrap.py
+++ b/effectful/internals/bootstrap.py
@@ -30,15 +30,8 @@ class _BaseOperation(Generic[P, T_co]):
     default: Callable[P, T_co]
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T_co:
-        if self is runtime.get_runtime:
-            intp = self.default(*args, **kwargs).interpretation
-            return core.apply.default(intp, core.apply, intp, self, *args, **kwargs)
-        elif self is core.apply:
-            intp = runtime.get_interpretation()
-            return core.apply.default(intp, self, *args, **kwargs)
-        else:
-            intp = runtime.get_interpretation()
-            return core.apply(intp, self, *args, **kwargs)
+        intp = runtime.get_interpretation()
+        return core.apply(intp, self, *args, **kwargs)
 
 
 @dataclasses.dataclass
@@ -80,10 +73,8 @@ def base_define(m: Type[T] | Callable[Q, T]) -> Operation[..., T]:
 
 
 # bootstrap
-core.apply = _BaseOperation(core.apply)
 core.define = _BaseOperation(core.define)
 core.register = _BaseOperation(core.register)
-runtime.get_runtime = _BaseOperation(runtime.get_runtime)
 
 core.register(core.define(Operation), None, _BaseOperation)
 core.register(core.define(Term), None, _BaseTerm)

--- a/tests/test_ops_handler.py
+++ b/tests/test_ops_handler.py
@@ -1,15 +1,13 @@
 import contextlib
 import itertools
 import logging
-from collections import defaultdict
 from typing import TypeVar
 
 import pytest
 from typing_extensions import ParamSpec
 
 from effectful.internals.prompts import bind_result, value_or_result
-from effectful.internals.runtime import get_runtime
-from effectful.ops.core import Interpretation, Operation, apply, define
+from effectful.ops.core import Interpretation, Operation, define
 from effectful.ops.handler import coproduct, fwd, handler
 from effectful.ops.interpreter import interpreter
 
@@ -139,21 +137,3 @@ def test_stop_without_fwd(op, args, n, depth):
         stack.enter_context(handler(defaults(op)))
 
         assert f() == expected
-
-
-def test_handling_internal_operations():
-    log = defaultdict(list)
-
-    def logged(op):
-        def wrapped(*args, **kwargs):
-            log[op].append((args, kwargs))
-            return op.default(*args, **kwargs)
-
-        return wrapped
-
-    with handler({apply: logged(apply), get_runtime: logged(get_runtime)}):
-        assert plus_1(1) == 2
-
-        assert apply in log
-        assert get_runtime in log
-        assert any(get_runtime in args for (args, kwargs) in log[apply])


### PR DESCRIPTION
Does what it says on the tin. It passes all the tests at time of writing (except the one that tests that `apply` and `get_runtime` are operations, which is removed). Closes #23