### PR TITLE
Weaken type bounds on `minipyro.block`

### DIFF
--- a/effectful/handlers/minipyro.py
+++ b/effectful/handlers/minipyro.py
@@ -257,7 +257,7 @@ default_runner = product(
 
 
 def block(
-    hide_fn: Callable[Concatenate[Operation, object, ...], bool] = lambda *_, **__: True
+    hide_fn: Callable[Concatenate[Operation, object, P], bool] = lambda *_, **__: True
 ):
     def blocking(fn: Operation, result, *args, **kwargs):
         if hide_fn(fn, result, *args, **kwargs):


### PR DESCRIPTION
[An update to mypy](https://mypy-lang.blogspot.com/2024/07/mypy-111-released.html) seems to have caught some issues with the implementation of `block` in minipyro, causing the type checker to fail. This just loosens the bounds of the provided arguments.