### PR TITLE
Add new type bounds for `ObjectInterpretation`

### DIFF
--- a/effectful/internals/sugar.py
+++ b/effectful/internals/sugar.py
@@ -97,7 +97,7 @@ class _ImplementedOperation(Generic[P1, P2, T, V]):
         self.impl = None
 
     def __get__(
-            self, instance: ObjectInterpretation[T, V], owner: type
+        self, instance: ObjectInterpretation[T, V], owner: type
     ) -> Callable[..., V]:
         assert self.impl is not None
 


### PR DESCRIPTION
This adds more aggressive type bounds for `ObjectInterpretation`, as well as fixing a few typos in the documentation. This should fix #40 (if I understand the issue correctly).