### PR TITLE
Remove unused `ops.core.register`

### DIFF
--- a/effectful/ops/core.py
+++ b/effectful/ops/core.py
@@ -1,5 +1,4 @@
-import collections.abc
-from typing import Callable, Generic, Iterable, Mapping, Optional, Type, TypeVar, Union
+from typing import Callable, Generic, Iterable, Mapping, Type, TypeVar, Union
 
 from typing_extensions import ParamSpec, dataclass_transform
 
@@ -75,18 +74,3 @@ def evaluate(term: Term[T]) -> T:
             for k, v in term.kwargs.items()
         },
     )
-
-
-@Operation
-def register(
-    op: Operation[P, T],
-    intp: Optional[Interpretation[T, V]],
-    interpret_op: Callable[Q, V],
-) -> Callable[Q, V]:
-    if intp is None:
-        setattr(op, "default", interpret_op)
-        return interpret_op
-    elif isinstance(intp, collections.abc.MutableMapping):
-        intp.__setitem__(op, interpret_op)
-        return interpret_op
-    raise NotImplementedError(f"Cannot register {op} in {intp}")

--- a/tests/test_ops_interpreter.py
+++ b/tests/test_ops_interpreter.py
@@ -9,7 +9,7 @@ from typing_extensions import ParamSpec
 
 from effectful.internals.prompts import bind_result
 from effectful.internals.sugar import ObjectInterpretation, implements
-from effectful.ops.core import Interpretation, Operation, define, register
+from effectful.ops.core import Interpretation, Operation, define
 from effectful.ops.interpreter import interpreter
 
 logger = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ def test_op_register_new_op(op, args, n):
         new_value = new_op(*args)
         assert new_value == op.default(*args) * n + 3
 
-        register(new_op, intp, times_n(n, new_op)[new_op])
+        intp[new_op] = times_n(n, new_op)[new_op]
         assert new_op(*args) == new_value
 
     with interpreter(intp):


### PR DESCRIPTION
This small refactoring PR removes the vestigial operation `effectful.ops.core.register` intended for in-place updates to `Interpretation`s. It was never used except for one unit test, and I'm not sure it makes sense as part of the core API regardless. We can always add something like this as syntactic sugar later on.

This change is part of #52 but I'm moving it out for ease of review.