### PR TITLE
Remove obsolete `ops.core.define`

### DIFF
--- a/effectful/internals/sugar.py
+++ b/effectful/internals/sugar.py
@@ -48,7 +48,6 @@ class ObjectInterpretation(Generic[T, V], Interpretation[T, V]):
     using the :func:`implements` decorator. The :class:`ObjectInterpretation` object itself is an :type:`Interpretation`
     (mapping from :type:`Operation` to :type:`Callable`)
 
-    >>> from effectful.ops.core import define
     >>> from effectful.ops.handler import handler
     >>> @Operation
     ... def read_box():

--- a/effectful/ops/core.py
+++ b/effectful/ops/core.py
@@ -21,7 +21,6 @@ from effectful.internals.runtime import (
     bind_interpretation,
     get_interpretation,
     interpreter,
-    weak_memoize,
 )
 
 P = ParamSpec("P")
@@ -29,18 +28,6 @@ Q = ParamSpec("Q")
 S = TypeVar("S")
 T = TypeVar("T")
 V = TypeVar("V")
-
-
-@weak_memoize
-def define(m: Type[T]) -> "Operation[..., T]":
-    """
-    Scott encoding of a type as its constructor.
-    """
-    if not typing.TYPE_CHECKING:
-        if typing.get_origin(m) not in (m, None):
-            return define(typing.get_origin(m))
-
-    return m(m) if m is Operation else define(Operation[..., m])(m)  # type: ignore
 
 
 @dataclasses.dataclass(frozen=True, eq=True, repr=True, unsafe_hash=True)

--- a/tests/test_ops_interpreter.py
+++ b/tests/test_ops_interpreter.py
@@ -9,7 +9,7 @@ from typing_extensions import ParamSpec
 
 from effectful.internals.prompts import bind_result
 from effectful.internals.sugar import ObjectInterpretation, implements
-from effectful.ops.core import Interpretation, Operation, define
+from effectful.ops.core import Interpretation, Operation
 from effectful.ops.handler import closed_handler
 
 logger = logging.getLogger(__name__)
@@ -50,20 +50,6 @@ OPERATION_CASES = (
 )
 N_CASES = [1, 2, 3]
 DEPTH_CASES = [1, 2, 3]
-
-
-def test_memoized_define():
-    assert define(Interpretation) is define(Interpretation)
-    assert define(Interpretation[int, int]) is define(Interpretation[int, int])
-    assert define(Interpretation[int, int]) is define(Interpretation[int, float])
-    assert define(Interpretation[int, int]) is define(Interpretation)
-
-    assert define(Operation) is define(Operation)
-    assert define(Operation[P, int]) is define(Operation[P, int])
-    assert define(Operation[P, int]) is define(Operation[P, float])
-    assert define(Operation[P, int]) is define(Operation)
-
-    assert define(Operation) is not define(Interpretation)
 
 
 @pytest.mark.parametrize("op,args", OPERATION_CASES)


### PR DESCRIPTION
Blocked by #77 

This small pure refactoring PR removes `effectful.ops.core.define`, which was already largely unused and no longer has an obvious purpose following the changes in #77.