### PR TITLE
Fix bugs in `PositionalDistribution` and add `NamedDistribution`

### DIFF
--- a/effectful/indexed/ops/impl.py
+++ b/effectful/indexed/ops/impl.py
@@ -8,7 +8,7 @@ import effectful.indexed.internals.utils
 import effectful.internals.sugar
 
 from ...internals.sugar import partial_eval, sizesof
-from ...ops.core import Expr, Operation, Term
+from ...ops.core import Operation, Term
 from ...ops.function import defun
 
 K = TypeVar("K")
@@ -325,7 +325,7 @@ def cond_n(values: Dict[IndexSet, torch.Tensor], case: torch.Tensor) -> torch.Te
     return result
 
 
-def to_tensor(t: Expr[torch.Tensor], indexes=None) -> Expr[torch.Tensor]:
+def to_tensor(t: torch.Tensor, indexes=None) -> torch.Tensor:
     return partial_eval(t, order=indexes)
 
 

--- a/tests/test_indexed_handlers.py
+++ b/tests/test_indexed_handlers.py
@@ -5,9 +5,9 @@ from pyro.poutine.indep_messenger import CondIndepStackFrame
 
 from effectful.handlers.pyro import PyroShim
 from effectful.indexed.handlers import (
-    indexed,
     NamedDistribution,
     PositionalDistribution,
+    indexed,
 )
 from effectful.indexed.ops import Indexable, IndexSet, indices_of
 from effectful.internals.sugar import gensym


### PR DESCRIPTION
`NamedDistribution` is a kind of inverse to `PositionalDistribution`. It lazily names dimensions.

`PositionalDistribution` is modified to correctly account for expansion and nontrivial sample shapes.

Tests are added for both.