### PR TITLE
Install docs deps with requirements file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,3 @@
-|Build Status|
 
 .. index-inclusion-marker
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==7.1.2
+sphinx
 sphinxcontrib-bibtex
-sphinx_rtd_theme==1.3.0
+sphinx_rtd_theme
 myst_parser
 nbsphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+sphinx==7.1.2
+sphinxcontrib-bibtex
+sphinx_rtd_theme==1.3.0
+myst_parser
+nbsphinx


### PR DESCRIPTION
The github action doesn't actually work with extras specs unless a pyproject.toml is present. Use a requirements file instead.