### PR TITLE
Change NoDefaultRule to NotImplementedError

### DIFF
--- a/docs/source/lambda_.py
+++ b/docs/source/lambda_.py
@@ -6,7 +6,7 @@ from typing_extensions import ParamSpec
 
 from effectful.handlers.numbers import add
 from effectful.ops.semantics import coproduct, evaluate, fvsof, fwd, handler
-from effectful.ops.syntax import Bound, NoDefaultRule, Scoped, defop
+from effectful.ops.syntax import Bound, Scoped, defop
 from effectful.ops.types import Expr, Interpretation, Operation, Term
 
 P = ParamSpec("P")
@@ -16,12 +16,12 @@ T = TypeVar("T")
 
 @defop
 def App(f: Callable[[S], T], arg: S) -> T:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
 def Lam(var: Annotated[Operation[[], S], Bound()], body: T) -> Callable[[S], T]:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
@@ -30,7 +30,7 @@ def Let(
     val: Annotated[S, Scoped(1)],
     body: Annotated[T, Scoped(0)],
 ) -> T:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 def beta_add(x: Expr[int], y: Expr[int]) -> Expr[int]:

--- a/docs/source/semi_ring.py
+++ b/docs/source/semi_ring.py
@@ -5,7 +5,7 @@ from typing import Annotated, ParamSpec, Tuple, TypeVar, Union, cast, overload
 
 import effectful.handlers.numbers  # noqa: F401
 from effectful.ops.semantics import coproduct, evaluate, fwd, handler
-from effectful.ops.syntax import Bound, NoDefaultRule, Scoped, defop
+from effectful.ops.syntax import Bound, Scoped, defop
 from effectful.ops.types import Interpretation, Operation, Term
 
 P = ParamSpec("P")
@@ -55,7 +55,7 @@ def Sum(
     v: Annotated[Operation[[], V], Bound(0)],
     e2: Annotated[SemiRingDict[S, T], Scoped(0)],
 ) -> SemiRingDict[S, T]:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
@@ -64,22 +64,22 @@ def Let(
     x: Annotated[Operation[[], T], Bound(0)],
     e2: Annotated[S, Scoped(0)],
 ) -> S:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
 def Record(**kwargs: T) -> dict[str, T]:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
 def Field(record: dict[str, T], key: str) -> T:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
 def Dict(*contents: Union[K, V]) -> SemiRingDict[K, V]:
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
@@ -87,7 +87,7 @@ def add(x: T, y: T) -> T:
     if not any(isinstance(a, Term) for a in (x, y)):
         return operator.add(x, y)
     else:
-        raise NoDefaultRule
+        raise NotImplementedError
 
 
 ops = types.SimpleNamespace()

--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -4,7 +4,7 @@ from typing import Any, TypeVar
 
 from typing_extensions import ParamSpec
 
-from effectful.ops.syntax import NoDefaultRule, defdata, defop, syntactic_eq
+from effectful.ops.syntax import defdata, defop, syntactic_eq
 from effectful.ops.types import Operation, Term
 
 P = ParamSpec("P")
@@ -56,7 +56,7 @@ def _wrap_cmp(op):
         if not any(isinstance(a, Term) for a in (x, y)):
             return op(x, y)
         else:
-            raise NoDefaultRule
+            raise NotImplementedError
 
     _wrapped_op.__name__ = op.__name__
     return _wrapped_op
@@ -67,7 +67,7 @@ def _wrap_binop(op):
         if not any(isinstance(a, Term) for a in (x, y)):
             return op(x, y)
         else:
-            raise NoDefaultRule
+            raise NotImplementedError
 
     _wrapped_op.__name__ = op.__name__
     return _wrapped_op
@@ -78,7 +78,7 @@ def _wrap_unop(op):
         if not isinstance(x, Term):
             return op(x)
         else:
-            raise NoDefaultRule
+            raise NotImplementedError
 
     _wrapped_op.__name__ = op.__name__
     return _wrapped_op

--- a/effectful/handlers/torch.py
+++ b/effectful/handlers/torch.py
@@ -15,7 +15,7 @@ import effectful.handlers.numbers  # noqa: F401
 from effectful.internals.base_impl import _BaseTerm
 from effectful.internals.runtime import interpreter
 from effectful.ops.semantics import apply, evaluate, fvsof, typeof
-from effectful.ops.syntax import NoDefaultRule, defdata, defop
+from effectful.ops.syntax import defdata, defop
 from effectful.ops.types import Expr, Operation, Term
 
 P = ParamSpec("P")
@@ -214,7 +214,7 @@ def _register_torch_op(torch_fn: Callable[P, T]):
             and args[1]
             and all(isinstance(k, Term) and k.op in sized_fvs for k in args[1])
         ):
-            raise NoDefaultRule
+            raise NotImplementedError
         elif sized_fvs and set(sized_fvs.keys()) == fvsof(tm) - {
             torch_getitem,
             _torch_op,
@@ -230,7 +230,7 @@ def _register_torch_op(torch_fn: Callable[P, T]):
         ):
             return typing.cast(torch.Tensor, torch_fn(*args, **kwargs))
         else:
-            raise NoDefaultRule
+            raise NotImplementedError
 
     functools.update_wrapper(_torch_op, torch_fn)
     return _torch_op

--- a/effectful/internals/base_impl.py
+++ b/effectful/internals/base_impl.py
@@ -51,11 +51,9 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
         return hash(self.signature)
 
     def __default_rule__(self, *args: Q.args, **kwargs: Q.kwargs) -> "Expr[V]":
-        from effectful.ops.syntax import NoDefaultRule
-
         try:
             return self.signature(*args, **kwargs)
-        except NoDefaultRule:
+        except NotImplementedError:
             return self.__free_rule__(*args, **kwargs)
 
     def __free_rule__(self, *args: Q.args, **kwargs: Q.kwargs) -> "Expr[V]":
@@ -237,9 +235,7 @@ def _unembed_callable(value: Callable[P, T]) -> Expr[Callable[P, T]]:
             inspect.Parameter.VAR_POSITIONAL,
             inspect.Parameter.VAR_KEYWORD,
         ):
-            raise NotImplementedError(
-                f"cannot unembed {value}: parameter {name} is variadic"
-            )
+            raise ValueError(f"cannot unembed {value}: parameter {name} is variadic")
 
     bound_sig = sig.bind(
         **{name: defop(param.annotation) for name, param in sig.parameters.items()}

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Optional, Set, Type, TypeVar
 import tree
 from typing_extensions import ParamSpec
 
-from effectful.ops.syntax import NoDefaultRule, deffn, defop
+from effectful.ops.syntax import deffn, defop
 from effectful.ops.types import Expr, Interpretation, Operation, Term
 
 P = ParamSpec("P")
@@ -73,7 +73,7 @@ def call(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
     elif not any(isinstance(a, Term) for a in tree.flatten((fn, args, kwargs))):
         return fn(*args, **kwargs)
     else:
-        raise NoDefaultRule
+        raise NotImplementedError
 
 
 @defop
@@ -244,7 +244,7 @@ def evaluate(expr: Expr[T], *, intp: Optional[Interpretation[S, T]] = None) -> E
 
     >>> @defop
     ... def add(x: int, y: int) -> int:
-    ...     raise NoDefaultRule
+    ...     raise NotImplementedError
     >>> expr = add(1, add(2, 3))
     >>> expr
     add(1, add(2, 3))
@@ -277,7 +277,7 @@ def typeof(term: Expr[T]) -> Type[T]:
 
     >>> @defop
     ... def cmp(x: int, y: int) -> bool:
-    ...     raise NoDefaultRule
+    ...     raise NotImplementedError
     >>> typeof(cmp(1, 2))
     <class 'bool'>
 
@@ -287,7 +287,7 @@ def typeof(term: Expr[T]) -> Type[T]:
     >>> T = TypeVar('T')
     >>> @defop
     ... def if_then_else(x: bool, a: T, b: T) -> T:
-    ...     raise NoDefaultRule
+    ...     raise NotImplementedError
     >>> typeof(if_then_else(True, 0, 1))
     <class 'int'>
 
@@ -305,7 +305,7 @@ def fvsof(term: Expr[S]) -> Set[Operation]:
 
     >>> @defop
     ... def f(x: int, y: int) -> int:
-    ...     raise NoDefaultRule
+    ...     raise NotImplementedError
     >>> fvsof(f(1, 2))
     {f}
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -36,12 +36,6 @@ class Scoped(ArgAnnotation):
     scope: int = 0
 
 
-class NoDefaultRule(Exception):
-    """Raised in an operation's signature to indicate that the operation has no default rule."""
-
-    pass
-
-
 @functools.singledispatch
 def defop(t: Callable[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
     """Creates a fresh :class:`Operation`.
@@ -84,12 +78,12 @@ def defop(t: Callable[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
     * Defining an operation with no default rule:
 
       We can use :func:`defop` and the
-      :exc:`effectful.internals.sugar.NoDefaultRule` exception to define an
+      :exc:`NotImplementedError` exception to define an
       operation with no default rule:
 
       >>> @defop
       ... def add(x: int, y: int) -> int:
-      ...     raise NoDefaultRule
+      ...     raise NotImplementedError
       >>> add(1, 2)
       add(1, 2)
 
@@ -187,7 +181,7 @@ def _(t: Callable[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
 @defop.register(Operation)
 def _(t: Operation[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
     def func(*args, **kwargs):
-        raise NoDefaultRule
+        raise NotImplementedError
 
     functools.update_wrapper(func, t)
     return defop(func, name=name)
@@ -196,7 +190,7 @@ def _(t: Operation[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
 @defop.register(type)
 def _(t: Type[T], *, name: Optional[str] = None) -> Operation[[], T]:
     def func() -> t:  # type: ignore
-        raise NoDefaultRule
+        raise NotImplementedError
 
     func.__name__ = name or t.__name__
     return typing.cast(Operation[[], T], defop(func, name=name))
@@ -210,7 +204,7 @@ def _(t: Callable[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
         if not any(isinstance(a, Term) for a in tree.flatten((args, kwargs))):
             return t(*args, **kwargs)
         else:
-            raise NoDefaultRule
+            raise NotImplementedError
 
     return defop(func, name=name)
 
@@ -255,7 +249,7 @@ def deffn(
       automatically create the right free variables.
 
     """
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 class _CustomSingleDispatchCallable(Generic[P, T]):

--- a/tests/test_handlers_numbers.py
+++ b/tests/test_handlers_numbers.py
@@ -225,16 +225,16 @@ def test_defun_4():
 
 def test_defun_5():
 
-    with pytest.raises(NotImplementedError, match="variadic"):
+    with pytest.raises(ValueError, match="variadic"):
         defterm(lambda *xs: None)
 
-    with pytest.raises(NotImplementedError, match="variadic"):
+    with pytest.raises(ValueError, match="variadic"):
         defterm(lambda **ys: None)
 
-    with pytest.raises(NotImplementedError, match="variadic"):
+    with pytest.raises(ValueError, match="variadic"):
         defterm(lambda y=1, **ys: None)
 
-    with pytest.raises(NotImplementedError, match="variadic"):
+    with pytest.raises(ValueError, match="variadic"):
         defterm(lambda x, *xs, y=1, **ys: None)
 
 

--- a/tests/test_ops_semantics.py
+++ b/tests/test_ops_semantics.py
@@ -7,7 +7,7 @@ import pytest
 from typing_extensions import ParamSpec
 
 from effectful.ops.semantics import coproduct, evaluate, fvsof, fwd, handler, product
-from effectful.ops.syntax import NoDefaultRule, ObjectInterpretation, defop, implements
+from effectful.ops.syntax import ObjectInterpretation, defop, implements
 from effectful.ops.types import Interpretation, Operation
 
 logger = logging.getLogger(__name__)
@@ -424,7 +424,7 @@ def test_fwd_default():
 def test_product_resets_fwd():
     @defop
     def do_stuff():
-        raise NoDefaultRule
+        raise NotImplementedError
 
     @defop
     def do_other_stuff():
@@ -443,17 +443,17 @@ def test_product_resets_fwd():
 
 @defop
 def op0():
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
 def op1():
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 @defop
 def op2():
-    raise NoDefaultRule
+    raise NotImplementedError
 
 
 def f_op2():
@@ -530,7 +530,7 @@ def test_product_distributive():
 def test_evaluate():
     @defop
     def Nested(*args, **kwargs):
-        raise NoDefaultRule
+        raise NotImplementedError
 
     x = defop(int, name="x")
     y = defop(int, name="y")
@@ -546,7 +546,7 @@ def test_ctxof():
 
     @defop
     def Nested(*args, **kwargs):
-        raise NoDefaultRule
+        raise NotImplementedError
 
     assert fvsof(Nested(x(), y())) >= {x, y}
     assert fvsof(Nested([x()], y())) >= {x, y}

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Callable, TypeVar
 
 from effectful.ops.semantics import call, evaluate, fvsof
-from effectful.ops.syntax import Bound, NoDefaultRule, defop, defterm
+from effectful.ops.syntax import Bound, defop, defterm
 from effectful.ops.types import Operation, Term
 
 
@@ -62,7 +62,7 @@ def test_gensym_annotations():
 
     @defop
     def Lam(var: Annotated[Operation[[], S], Bound()], body: T) -> Callable[[S], T]:
-        raise NoDefaultRule
+        raise NotImplementedError
 
     x = defop(int)
     y = defop(int)
@@ -98,7 +98,7 @@ def test_no_default_tracing():
 
     @defop
     def add(x: int, y: int) -> int:
-        raise NoDefaultRule
+        raise NotImplementedError
 
     def f1(x: int) -> int:
         return add(x, add(y(), 1))


### PR DESCRIPTION
Blocked by #178 
Addresses #88 

This refactoring PR removes the custom `NoDefaultRule` exception in favor of the more Pythonic built-in `NotImplementedError`. This should be safe to do following the changes in #178.