### PR TITLE
Give fresh names to Operations created from types or Operations

### DIFF
--- a/effectful/internals/base_impl.py
+++ b/effectful/internals/base_impl.py
@@ -175,7 +175,7 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
         return ret
 
     def __repr__(self):
-        return self.signature.__name__
+        return self.__name__
 
 
 class _BaseTerm(Generic[T], Term[T]):

--- a/effectful/internals/base_impl.py
+++ b/effectful/internals/base_impl.py
@@ -45,7 +45,7 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
     def __eq__(self, other):
         if not isinstance(other, Operation):
             return NotImplemented
-        return self.signature == other.signature
+        return self is other
 
     def __hash__(self):
         return hash(self.signature)

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -3,6 +3,7 @@ import dataclasses
 import functools
 import types
 import typing
+import uuid
 from typing import (
     Annotated,
     Callable,
@@ -180,10 +181,13 @@ def _(t: Callable[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
 
 @defop.register(Operation)
 def _(t: Operation[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
+
+    @functools.wraps(t)
     def func(*args, **kwargs):
         raise NotImplementedError
 
-    functools.update_wrapper(func, t)
+    if name is None:
+        name = t.__name__ + "__SYM_" + uuid.uuid4().hex.split("-")[0]
     return defop(func, name=name)
 
 
@@ -192,7 +196,8 @@ def _(t: Type[T], *, name: Optional[str] = None) -> Operation[[], T]:
     def func() -> t:  # type: ignore
         raise NotImplementedError
 
-    func.__name__ = name or t.__name__
+    if name is None:
+        name = t.__name__ + "__SYM_" + uuid.uuid4().hex.split("-")[0]
     return typing.cast(Operation[[], T], defop(func, name=name))
 
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -188,7 +188,9 @@ def _(t: Operation[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
 
     if name is None:
         name = (
-            getattr(t, "__name__", str(t)) + "__SYM_" + uuid.uuid4().hex.split("-")[0]
+            getattr(t, "__name__", str(t))[:10000]
+            + "__"
+            + uuid.uuid4().hex.split("-")[0]
         )
     return defop(func, name=name)
 
@@ -199,7 +201,7 @@ def _(t: Type[T], *, name: Optional[str] = None) -> Operation[[], T]:
         raise NotImplementedError
 
     if name is None:
-        name = t.__name__ + "__SYM_" + uuid.uuid4().hex.split("-")[0]
+        name = t.__name__ + "__" + uuid.uuid4().hex.split("-")[0]
     return typing.cast(Operation[[], T], defop(func, name=name))
 
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -1,9 +1,9 @@
 import collections.abc
 import dataclasses
 import functools
+import random
 import types
 import typing
-import uuid
 from typing import (
     Annotated,
     Callable,
@@ -188,9 +188,7 @@ def _(t: Operation[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
 
     if name is None:
         name = (
-            getattr(t, "__name__", str(t))[:10000]
-            + "__"
-            + uuid.uuid4().hex.split("-")[0]
+            getattr(t, "__name__", str(t))[:10000] + f"__{random.randint(0, 1 << 32)}"
         )
     return defop(func, name=name)
 
@@ -201,7 +199,7 @@ def _(t: Type[T], *, name: Optional[str] = None) -> Operation[[], T]:
         raise NotImplementedError
 
     if name is None:
-        name = t.__name__ + "__" + uuid.uuid4().hex.split("-")[0]
+        name = t.__name__ + f"__{random.randint(0, 1 << 32)}"
     return typing.cast(Operation[[], T], defop(func, name=name))
 
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -187,7 +187,9 @@ def _(t: Operation[P, T], *, name: Optional[str] = None) -> Operation[P, T]:
         raise NotImplementedError
 
     if name is None:
-        name = t.__name__ + "__SYM_" + uuid.uuid4().hex.split("-")[0]
+        name = (
+            getattr(t, "__name__", str(t)) + "__SYM_" + uuid.uuid4().hex.split("-")[0]
+        )
     return defop(func, name=name)
 
 

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -89,7 +89,7 @@ def test_operation_metadata():
     assert f.__doc__ == f_op.__doc__
     assert f.__name__ == f_op.__name__
     assert hash(f) == hash(f_op)
-    assert f_op == ff_op
+    assert f_op != ff_op
 
 
 def test_no_default_tracing():

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -44,10 +44,10 @@ def test_gensym_operation_2():
     def op(x: int) -> int:
         return x
 
-    # passing an operation to gensym should return a new operation, but preserve the name
+    # passing an operation to gensym should return a new operation
     g_op = defop(op)
-    assert g_op != op
-    assert g_op.__name__ == op.__name__
+    assert g_op != defop(g_op) != defop(op, name=op.__name__) != op
+    assert str(g_op) != str(op) == str(defop(op, name=op.__name__))
 
     # the new operation should have no default rule
     t = g_op(0)


### PR DESCRIPTION
Addresses #161 

This PR makes `defop` create a fresh name string when it is passed an `Operation` or a `type`. As noted in #161, `Operation` names have no semantics; this is purely a usability change to make the results of printing a `Term` easier to interpret.

It also fixes a bug in `_BaseOperation.__eq__` that violates the freshness condition of `defop`.