### PR TITLE
Compute sizesof(Distribution) without sampling

### DIFF
--- a/effectful/handlers/indexed.py
+++ b/effectful/handlers/indexed.py
@@ -156,7 +156,7 @@ def indices_of(value: Any) -> IndexSet:
     :param kwargs: Additional keyword arguments used by specific implementations.
     :return: A :class:`IndexSet` containing the indices on which the value is supported.
     """
-    return IndexSet(**{k.__name__: set(range(v)) for (k, v) in sizesof(value).items()})
+    return IndexSet(**{getattr(k, "__name__"): set(range(v)) for (k, v) in sizesof(value).items()})
 
 
 @functools.lru_cache(maxsize=None)

--- a/effectful/handlers/indexed.py
+++ b/effectful/handlers/indexed.py
@@ -6,7 +6,7 @@ import torch
 
 from effectful.handlers.torch import Indexable, sizesof
 from effectful.ops.syntax import deffn, defop
-from effectful.ops.types import Operation, Term
+from effectful.ops.types import Operation
 
 K = TypeVar("K")
 T = TypeVar("T")
@@ -60,16 +60,6 @@ class IndexSet(Dict[str, Set[int]]):
 
     def __hash__(self):
         return hash(frozenset((k, frozenset(vs)) for k, vs in self.items()))
-
-    def _to_handler(self):
-        """Return an effectful handler that binds each index variable to a
-        tensor of its possible index values.
-
-        """
-        return {
-            name_to_sym(k): functools.partial(lambda v: v, torch.tensor(list(v)))
-            for k, v in self.items()
-        }
 
 
 def union(*indexsets: IndexSet) -> IndexSet:
@@ -166,17 +156,7 @@ def indices_of(value: Any) -> IndexSet:
     :param kwargs: Additional keyword arguments used by specific implementations.
     :return: A :class:`IndexSet` containing the indices on which the value is supported.
     """
-    if isinstance(value, Term):
-        return IndexSet(
-            **{
-                k.__name__: set(range(v))  # type:ignore
-                for (k, v) in sizesof(value).items()
-            }
-        )
-    elif isinstance(value, torch.distributions.Distribution):
-        return indices_of(value.sample())
-
-    return IndexSet()
+    return IndexSet(**{k.__name__: set(range(v)) for (k, v) in sizesof(value).items()})
 
 
 @functools.lru_cache(maxsize=None)

--- a/effectful/handlers/indexed.py
+++ b/effectful/handlers/indexed.py
@@ -156,7 +156,9 @@ def indices_of(value: Any) -> IndexSet:
     :param kwargs: Additional keyword arguments used by specific implementations.
     :return: A :class:`IndexSet` containing the indices on which the value is supported.
     """
-    return IndexSet(**{getattr(k, "__name__"): set(range(v)) for (k, v) in sizesof(value).items()})
+    return IndexSet(
+        **{getattr(k, "__name__"): set(range(v)) for (k, v) in sizesof(value).items()}
+    )
 
 
 @functools.lru_cache(maxsize=None)

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -264,7 +264,7 @@ class PositionalDistribution(pyro.distributions.torch_distribution.TorchDistribu
         self, base_dist: pyro.distributions.torch_distribution.TorchDistribution
     ):
         self.base_dist = base_dist
-        self.indices = sizesof(base_dist.sample())
+        self.indices = sizesof(base_dist)
 
         n_base = len(base_dist.batch_shape) + len(base_dist.event_shape)
         self.naming = Naming.from_shape(self.indices.keys(), n_base)
@@ -361,7 +361,7 @@ class NamedDistribution(pyro.distributions.torch_distribution.TorchDistribution)
         self.names = names
 
         assert 1 <= len(names) <= len(base_dist.batch_shape)
-        base_indices = sizesof(base_dist.sample())
+        base_indices = sizesof(base_dist)
         assert not any(n in base_indices for n in names)
 
         n_base = len(base_dist.batch_shape) + len(base_dist.event_shape)

--- a/effectful/handlers/torch.py
+++ b/effectful/handlers/torch.py
@@ -90,6 +90,11 @@ def sizesof(value: Expr) -> Mapping[Operation[[], int], int]:
     >>> sizesof(Indexable(torch.ones(2, 3))[a(), b()])
     {a: 2, b: 3}
     """
+    if isinstance(value, torch.distributions.Distribution) and not isinstance(
+        value, Term
+    ):
+        return {v: s for a in value.__dict__.values() for v, s in sizesof(a).items()}
+
     sizes: dict[Operation[[], int], int] = {}
 
     def _torch_getitem_sizeof(


### PR DESCRIPTION
This PR adds a case for `torch.distributions.Distribution` atoms in `handlers.torch.sizesof` so that the free variables of a distribution can be computed without drawing a sample, which may be expensive in general. It also simplifies corresponding logic and removes some dead code in `handlers.indexed`.