### PR TITLE
Simplify binding annotation syntax and semantics

### DIFF
--- a/docs/source/effectful.rst
+++ b/docs/source/effectful.rst
@@ -15,7 +15,7 @@ Syntax
    :members:
    :undoc-members:
 
-   .. autofunction:: effectful.ops.syntax.deffn(body: T, *args: Annotated[Operation, Bound()], **kwargs: Annotated[Operation, Bound()]) -> Callable[..., T])
+   .. autofunction:: effectful.ops.syntax.deffn(body: T, *args: Operation, **kwargs: Operation) -> Callable[..., T])
    .. autofunction:: effectful.ops.syntax.defterm(value: T) -> Expr[T]
    .. autofunction:: effectful.ops.syntax.defdata(value: Term[T]) -> Expr[T]
    .. autofunction:: effectful.ops.semantics.fwd

--- a/docs/source/lambda_.py
+++ b/docs/source/lambda_.py
@@ -6,12 +6,15 @@ from typing_extensions import ParamSpec
 
 from effectful.handlers.numbers import add
 from effectful.ops.semantics import coproduct, evaluate, fvsof, fwd, handler
-from effectful.ops.syntax import Bound, Scoped, defop
+from effectful.ops.syntax import Scoped, defop
 from effectful.ops.types import Expr, Interpretation, Operation, Term
 
 P = ParamSpec("P")
 S = TypeVar("S")
 T = TypeVar("T")
+A = TypeVar("A")
+B = TypeVar("B")
+C = TypeVar("C")
 
 
 @defop
@@ -20,15 +23,17 @@ def App(f: Callable[[S], T], arg: S) -> T:
 
 
 @defop
-def Lam(var: Annotated[Operation[[], S], Bound()], body: T) -> Callable[[S], T]:
+def Lam(
+    var: Annotated[Operation[[], S], Scoped[A]], body: Annotated[T, Scoped[A]]
+) -> Callable[[S], T]:
     raise NotImplementedError
 
 
 @defop
 def Let(
-    var: Annotated[Operation[[], S], Bound(0)],
-    val: Annotated[S, Scoped(1)],
-    body: Annotated[T, Scoped(0)],
+    var: Annotated[Operation[[], S], Scoped[A]],
+    val: S,
+    body: Annotated[T, Scoped[A]],
 ) -> T:
     raise NotImplementedError
 

--- a/docs/source/semi_ring.py
+++ b/docs/source/semi_ring.py
@@ -5,7 +5,7 @@ from typing import Annotated, ParamSpec, Tuple, TypeVar, Union, cast, overload
 
 import effectful.handlers.numbers  # noqa: F401
 from effectful.ops.semantics import coproduct, evaluate, fwd, handler
-from effectful.ops.syntax import Bound, Scoped, defop
+from effectful.ops.syntax import Bound, Scoped_, defop
 from effectful.ops.types import Interpretation, Operation, Term
 
 P = ParamSpec("P")
@@ -50,19 +50,19 @@ class SemiRingDict(collections.abc.Mapping[K, V]):
 
 @defop
 def Sum(
-    e1: Annotated[SemiRingDict[K, V], Scoped(1)],
+    e1: Annotated[SemiRingDict[K, V], Scoped_(1)],
     k: Annotated[Operation[[], K], Bound(0)],
     v: Annotated[Operation[[], V], Bound(0)],
-    e2: Annotated[SemiRingDict[S, T], Scoped(0)],
+    e2: Annotated[SemiRingDict[S, T], Scoped_(0)],
 ) -> SemiRingDict[S, T]:
     raise NotImplementedError
 
 
 @defop
 def Let(
-    e1: Annotated[T, Scoped(1)],
+    e1: Annotated[T, Scoped_(1)],
     x: Annotated[Operation[[], T], Bound(0)],
-    e2: Annotated[S, Scoped(0)],
+    e2: Annotated[S, Scoped_(0)],
 ) -> S:
     raise NotImplementedError
 

--- a/docs/source/semi_ring.py
+++ b/docs/source/semi_ring.py
@@ -5,7 +5,7 @@ from typing import Annotated, ParamSpec, Tuple, TypeVar, Union, cast, overload
 
 import effectful.handlers.numbers  # noqa: F401
 from effectful.ops.semantics import coproduct, evaluate, fwd, handler
-from effectful.ops.syntax import Bound, Scoped_, defop
+from effectful.ops.syntax import Scoped, defop
 from effectful.ops.types import Interpretation, Operation, Term
 
 P = ParamSpec("P")
@@ -13,6 +13,8 @@ S = TypeVar("S")
 T = TypeVar("T")
 K = TypeVar("K")
 V = TypeVar("V")
+A = TypeVar("A")
+B = TypeVar("B")
 
 
 # https://stackoverflow.com/questions/2703599/what-would-a-frozen-dict-be
@@ -50,19 +52,19 @@ class SemiRingDict(collections.abc.Mapping[K, V]):
 
 @defop
 def Sum(
-    e1: Annotated[SemiRingDict[K, V], Scoped_(1)],
-    k: Annotated[Operation[[], K], Bound(0)],
-    v: Annotated[Operation[[], V], Bound(0)],
-    e2: Annotated[SemiRingDict[S, T], Scoped_(0)],
+    e1: SemiRingDict[K, V],
+    k: Annotated[Operation[[], K], Scoped[A]],
+    v: Annotated[Operation[[], V], Scoped[A]],
+    e2: Annotated[SemiRingDict[S, T], Scoped[A]],
 ) -> SemiRingDict[S, T]:
     raise NotImplementedError
 
 
 @defop
 def Let(
-    e1: Annotated[T, Scoped_(1)],
-    x: Annotated[Operation[[], T], Bound(0)],
-    e2: Annotated[S, Scoped_(0)],
+    e1: Annotated[T, Scoped[A]],
+    x: Annotated[Operation[[], T], Scoped[B]],
+    e2: Annotated[S, Scoped[B]],
 ) -> S:
     raise NotImplementedError
 

--- a/effectful/handlers/indexed.py
+++ b/effectful/handlers/indexed.py
@@ -168,10 +168,7 @@ def indices_of(value: Any) -> IndexSet:
     """
     if isinstance(value, Term):
         return IndexSet(
-            **{
-                k.__name__: set(range(v))  # type:ignore
-                for (k, v) in sizesof(value).items()
-            }
+            **{k.__name__: set(range(v)) for (k, v) in sizesof(value).items()}
         )
     elif isinstance(value, torch.distributions.Distribution):
         return indices_of(value.sample())

--- a/effectful/internals/base_impl.py
+++ b/effectful/internals/base_impl.py
@@ -16,26 +16,30 @@ V = TypeVar("V")
 
 
 class _BaseOperation(Generic[Q, V], Operation[Q, V]):
-    signature: Callable[Q, V]
+    __signature__: inspect.Signature
+    __name__: str
 
-    def __init__(self, signature: Callable[Q, V], *, name: Optional[str] = None):
-        functools.update_wrapper(self, signature)
-        self.signature = signature
-        self.__name__ = name or signature.__name__
+    _default: Callable[Q, V]
+
+    def __init__(self, default: Callable[Q, V], *, name: Optional[str] = None):
+        functools.update_wrapper(self, default)
+        self._default = default
+        self.__name__ = name or default.__name__
+        self.__signature__ = inspect.signature(default)
 
     def __eq__(self, other):
         if not isinstance(other, Operation):
             return NotImplemented
-        return self.signature == other.signature
+        return self._default == other._default
 
     def __hash__(self):
-        return hash(self.signature)
+        return hash(self._default)
 
     def __default_rule__(self, *args: Q.args, **kwargs: Q.kwargs) -> "Expr[V]":
         from effectful.ops.syntax import defdata
 
         try:
-            return self.signature(*args, **kwargs)
+            return self._default(*args, **kwargs)
         except NotImplementedError:
             return typing.cast(
                 Callable[Concatenate[Operation[Q, V], Q], Expr[V]], defdata
@@ -45,70 +49,36 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
         tuple[collections.abc.Set[Operation], ...],
         dict[str, collections.abc.Set[Operation]],
     ]:
-        from effectful.ops.syntax import Bound, Scoped
+        from effectful.ops.syntax import Scoped
 
-        sig = inspect.signature(self.signature)
+        sig = Scoped.infer_annotations(self.__signature__)
         bound_sig = sig.bind(*args, **kwargs)
         bound_sig.apply_defaults()
 
-        bound_vars: dict[int, set[Operation]] = collections.defaultdict(set)
-        scoped_args: dict[int, set[str]] = collections.defaultdict(set)
-        unscoped_args: set[str] = set()
-        for param_name, param in bound_sig.signature.parameters.items():
+        result_sig = sig.bind(
+            *(frozenset() for _ in bound_sig.args),
+            **{k: frozenset() for k in bound_sig.kwargs},
+        )
+        for name, param in sig.parameters.items():
             if typing.get_origin(param.annotation) is typing.Annotated:
-                for anno in param.annotation.__metadata__:
-                    if isinstance(anno, Bound):
-                        scoped_args[anno.scope].add(param_name)
+                for anno in typing.get_args(param.annotation)[1:]:
+                    if isinstance(anno, Scoped):
+                        param_bound_vars = anno.analyze(bound_sig)
                         if param.kind is inspect.Parameter.VAR_POSITIONAL:
-                            assert isinstance(bound_sig.arguments[param_name], tuple)
-                            for bound_var in bound_sig.arguments[param_name]:
-                                bound_vars[anno.scope].add(bound_var)
+                            result_sig.arguments[name] = tuple(
+                                param_bound_vars for _ in bound_sig.arguments[name]
+                            )
                         elif param.kind is inspect.Parameter.VAR_KEYWORD:
-                            assert isinstance(bound_sig.arguments[param_name], dict)
-                            for bound_var in bound_sig.arguments[param_name].values():
-                                bound_vars[anno.scope].add(bound_var)
+                            result_sig.kwargs[name] = {
+                                k: param_bound_vars for k in bound_sig.arguments[name]
+                            }
                         else:
-                            bound_vars[anno.scope].add(bound_sig.arguments[param_name])
-                    elif isinstance(anno, Scoped):
-                        scoped_args[anno.scope].add(param_name)
-            else:
-                unscoped_args.add(param_name)
+                            result_sig.arguments[name] = param_bound_vars
 
-        if not bound_vars:  # fast path for no bound variables
-            return (
-                tuple(frozenset() for _ in bound_sig.args),
-                {k: frozenset() for k in bound_sig.kwargs},
-            )
-
-        # TODO replace this temporary check with more general scope level propagation
-        min_scope = min(bound_vars.keys(), default=0)
-        scoped_args[min_scope] |= unscoped_args
-        max_scope = max(bound_vars.keys(), default=0)
-        assert all(s in bound_vars or s > max_scope for s in scoped_args.keys())
-
-        # recursively rename bound variables from innermost to outermost scope
-        subs: frozenset[Operation] = frozenset()
-        for scope in sorted(scoped_args.keys()):
-            # create fresh variables for each bound variable in the scope
-            subs = subs | bound_vars[scope]
-
-            # get just the arguments that are in the scope
-            for name in scoped_args[scope]:
-                if sig.parameters[name].kind is inspect.Parameter.VAR_POSITIONAL:
-                    bound_sig.arguments[name] = tuple(
-                        subs for _ in bound_sig.arguments[name]
-                    )
-                elif sig.parameters[name].kind is inspect.Parameter.VAR_KEYWORD:
-                    bound_sig.arguments[name] = {
-                        k: subs for k in bound_sig.arguments[name]
-                    }
-                else:
-                    bound_sig.arguments[name] = subs
-
-        return tuple(bound_sig.args), dict(bound_sig.kwargs)
+        return tuple(result_sig.args), dict(result_sig.kwargs)
 
     def __type_rule__(self, *args: Q.args, **kwargs: Q.kwargs) -> Type[V]:
-        sig = inspect.signature(self.signature)
+        sig = inspect.signature(self._default)
         bound_sig = sig.bind(*args, **kwargs)
         bound_sig.apply_defaults()
 
@@ -145,14 +115,14 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
             ", ".join(f"{k}={str(v)}" for k, v in kwargs.items()) if kwargs else ""
         )
 
-        ret = f"{self.signature.__name__}({args_str}"
+        ret = f"{self._default.__name__}({args_str}"
         if kwargs:
             ret += f"{', ' if args else ''}"
         ret += f"{kwargs_str})"
         return ret
 
     def __repr__(self):
-        return self.signature.__name__
+        return self._default.__name__
 
 
 class _BaseTerm(Generic[T], Term[T]):

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -394,9 +394,9 @@ def deffn(
     :param body: The body of the function.
     :type body: T
     :param args: Operations representing the positional arguments of the function.
-    :type args: Annotated[Operation, Bound()]
+    :type args: Operation
     :param kwargs: Operations representing the keyword arguments of the function.
-    :type kwargs: Annotated[Operation, Bound()]
+    :type kwargs: Operation
     :returns: A callable term.
     :rtype: Callable[..., T]
 

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import collections.abc
+import inspect
 import typing
 from typing import Any, Callable, Generic, Mapping, Sequence, Type, TypeVar, Union
 
@@ -22,6 +23,9 @@ class Operation(abc.ABC, Generic[Q, V]):
        Do not use :class:`Operation` directly. Instead, use :func:`defop` to define operations.
 
     """
+
+    __signature__: inspect.Signature
+    __name__: str
 
     @abc.abstractmethod
     def __eq__(self, other):
@@ -75,19 +79,19 @@ class Term(abc.ABC, Generic[T]):
     @abc.abstractmethod
     def op(self) -> Operation[..., T]:
         """Abstract property for the operation."""
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
     def args(self) -> Sequence["Expr[Any]"]:
         """Abstract property for the arguments."""
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
     def kwargs(self) -> Mapping[str, "Expr[Any]"]:
         """Abstract property for the keyword arguments."""
-        pass
+        raise NotImplementedError
 
     def __repr__(self) -> str:
         from effectful.internals.runtime import interpreter
@@ -104,5 +108,13 @@ Expr = Union[T, Term[T]]
 Interpretation = Mapping[Operation[..., T], Callable[..., V]]
 
 
-class ArgAnnotation:
-    pass
+class ArgAnnotation(Generic[T], abc.ABC):
+
+    @classmethod
+    @abc.abstractmethod
+    def infer_annotations(cls, sig: inspect.Signature) -> inspect.Signature:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def analyze(self, bound_sig: inspect.BoundArguments) -> T:
+        raise NotImplementedError

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Callable, TypeVar
 
 from effectful.ops.semantics import call, evaluate, fvsof
-from effectful.ops.syntax import Bound, defop, defterm
+from effectful.ops.syntax import Scoped, defop, defterm
 from effectful.ops.types import Operation, Term
 
 
@@ -59,9 +59,13 @@ def test_gensym_operation_2():
 def test_gensym_annotations():
     """Test that gensym respects annotations."""
     S, T = TypeVar("S"), TypeVar("T")
+    A = TypeVar("A")
 
     @defop
-    def Lam(var: Annotated[Operation[[], S], Bound()], body: T) -> Callable[[S], T]:
+    def Lam(
+        var: Annotated[Operation[[], S], Scoped[A]],
+        body: Annotated[T, Scoped[A]],
+    ) -> Callable[[S], T]:
         raise NotImplementedError
 
     x = defop(int)


### PR DESCRIPTION
Addresses #171 
Blocked by #180 

This PR replaces the current `Scoped`/`Bound` annotations with a single generalized `Scoped` annotation that uses sets of symbols ordered by subset inclusion instead of integers ordered by value, as sketched in #171.

It also moves much of the logic into `Scoped` itself, simplifying `_BaseOperation` significantly, even beyond the changes already included in #180.