### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-VERSION = "0.0.1"
+VERSION = "0.1.0"
 
 try:
     long_description = open("README.rst", encoding="utf-8").read()


### PR DESCRIPTION
Blocked by https://github.com/BasisResearch/effectful/milestone/2

Will do a GitHub release after this lands.