### PR TITLE
Disable code coverage

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-pytest effectful/ tests/ -s -n auto --cov=effectful/ --cov-report=term-missing ${@-} --cov-report html
+pytest effectful/ tests/ -n auto


### PR DESCRIPTION
Coverage imposes a ~1.8x slowdown on tests, and the console output is not that useful.