### PR TITLE
Add term conversion for iterables

### DIFF
--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -8,7 +8,7 @@ from typing import Any, TypeVar
 
 from typing_extensions import ParamSpec
 
-from effectful.ops.syntax import defdata, defop, syntactic_eq
+from effectful.ops.syntax import bool_, defdata, defop, syntactic_eq
 from effectful.ops.types import Expr, Operation, Term
 
 P = ParamSpec("P")
@@ -102,7 +102,7 @@ abs = defop(_wrap_unop(operator.abs))
 @numbers.Complex.register
 class _ComplexTerm(_NumberTerm, Term[numbers.Complex]):
     def __bool__(self) -> bool:
-        raise ValueError("Cannot convert term to bool")
+        return bool_(self)
 
     def __add__(self, other: Any) -> numbers.Real:
         return add(self, other)

--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -193,6 +193,12 @@ class _RealTerm(_ComplexTerm, Term[numbers.Real]):
     def __le__(self, other):
         return le(self, other)
 
+    def __gt__(self, other):
+        return gt(self, other)
+
+    def __ge__(self, other):
+        return ge(self, other)
+
 
 @defdata.register(numbers.Rational)
 @numbers.Rational.register

--- a/effectful/handlers/torch.py
+++ b/effectful/handlers/torch.py
@@ -337,6 +337,11 @@ def _embed_tensor(op, *args, **kwargs):
         return _TensorTerm(op, *args, **kwargs)
 
 
+@defterm.register(torch.Tensor)
+def _(x: torch.Tensor) -> Expr[torch.Tensor]:
+    return x
+
+
 class _TensorTerm(Term[torch.Tensor]):
     def __init__(
         self, op: Operation[..., torch.Tensor], *args: Expr, **kwargs: Expr

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -78,7 +78,7 @@ def call(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
 
 
 @defop
-def next_(i: Iterable[T]) -> Operation[[], T]:
+def next_(i: Iterable[T]) -> T:
     raise NotImplementedError
 
 

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -1,6 +1,6 @@
 import contextlib
 import functools
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterator
 from typing import Any, TypeVar
 
 import tree
@@ -78,7 +78,7 @@ def call(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
 
 
 @defop
-def next_(i: Iterable[T]) -> T:
+def next_(i: Iterator[T]) -> T:
     if isinstance(i, Term):
         raise NotImplementedError
     return next(i)

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -79,7 +79,9 @@ def call(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
 
 @defop
 def next_(i: Iterable[T]) -> T:
-    raise NotImplementedError
+    if isinstance(i, Term):
+        raise NotImplementedError
+    return next(i)
 
 
 @defop

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -1,6 +1,6 @@
 import contextlib
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any, TypeVar
 
 import tree
@@ -75,6 +75,11 @@ def call(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         return fn(*args, **kwargs)
     else:
         raise NotImplementedError
+
+
+@defop
+def next_(i: Iterable[T]) -> Operation[[], T]:
+    raise NotImplementedError
 
 
 @defop

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -614,11 +614,11 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
                 ):
                     arg = bound_sig.arguments[name]
                     tp: type[V] = type(arg) if not isinstance(arg, type) else arg
-                    return drop_params(tp)
+                    return tp
 
             return typing.cast(type[V], object)
 
-        return drop_params(anno)
+        return anno
 
     def __repr__(self):
         return f"_BaseOperation({self._default}, name={self.__name__}, freshening={self._freshening})"
@@ -724,7 +724,12 @@ class _CustomSingleDispatchCallable(Generic[P, Q, S, T]):
 
     @property
     def dispatch(self):
-        return self._registry.dispatch
+        def dispatch_origin_type(typ):
+            origin = typing.get_origin(typ)
+            typ = typ if origin is None else origin
+            return self._registry.dispatch(typ)
+
+        return dispatch_origin_type
 
     @property
     def register(self):

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -872,6 +872,9 @@ def defdata(
 @defterm.register(Term)
 @defterm.register(type)
 @defterm.register(types.BuiltinFunctionType)
+@defterm.register(str)
+@defterm.register(list)
+@defterm.register(tuple)
 def _(value: T) -> T:
     return value
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -872,9 +872,6 @@ def defdata(
 @defterm.register(Term)
 @defterm.register(type)
 @defterm.register(types.BuiltinFunctionType)
-@defterm.register(str)
-@defterm.register(list)
-@defterm.register(tuple)
 def _(value: T) -> T:
     return value
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -980,12 +980,14 @@ def _get_iterable_type_param(type_hint: Any) -> type | None:
         The type parameter if the input is an Iterable type annotation,
 
     Examples:
-        >>> get_iterable_type_param(list[str])
+        >>> _get_iterable_type_param(list[str])
         <class 'str'>
-        >>> get_iterable_type_param(set[int])
+        >>> _get_iterable_type_param(set[int])
         <class 'int'>
-        >>> get_iterable_type_param(bool)
-        TypeError
+        >>> _get_iterable_type_param(bool)
+        Traceback (most recent call last):
+        ...
+        TypeError: Expected an Iterable type, but got <class 'bool'>.
     """
     # Get the base type (like list, set etc)
     origin = get_origin(type_hint)

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -1019,7 +1019,7 @@ def _guard(value: bool) -> bool:
     return value
 
 
-class _IterableWrapper:
+class _IterableWrapper(Generic[T], collections.abc.Iterable[T]):
     def __init__(self, value):
         self.value = value
 
@@ -1027,8 +1027,8 @@ class _IterableWrapper:
         return _IteratorWrapper(iter(self.value), self.value)
 
 
-class _IteratorWrapper:
-    get_iterable = defop(Iterable)
+class _IteratorWrapper(Generic[T], collections.abc.Iterator[T]):
+    get_iterable: Operation[[], Iterable[T]] = defop(Iterable)
 
     def __init__(self, iterator, iterable):
         self.iterator = iterator
@@ -1042,18 +1042,18 @@ class _IteratorWrapper:
 
 
 @defop
-def iter_(value: Iterable[T]) -> Iterable[T]:
+def iter_(value: Iterable[T]) -> Iterator[T]:
     if isinstance(value, Term):
-        return value
+        return typing.cast(Iterator[T], value)
     return iter(value)
 
 
-def _gen(value: Generator[T]) -> Generator[T]:
+def _gen(value: Iterable[T]) -> Iterable[T]:
     return _IterableWrapper(value)
 
 
 @defterm.register(Generator)
-def _(value: Generator[T]) -> Generator[T]:
+def _(value: Generator[T, None, None]) -> Iterable[T]:
     from .semantics import handler, next_, typeof
 
     # capture calls to next to identify the underlying iterators

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -876,6 +876,13 @@ def _(value: T) -> T:
     return value
 
 
+@defop  # type: ignore
+def bool_(term: Term[T] | T) -> bool:
+    if not isinstance(term, Term):
+        return bool(term)
+    raise ValueError("Cannot convert term to bool")
+
+
 @defdata.register(object)
 class _BaseTerm(Generic[T], Term[T]):
     _op: Operation[..., T]
@@ -908,6 +915,9 @@ class _BaseTerm(Generic[T], Term[T]):
     @property
     def kwargs(self):
         return self._kwargs
+
+    def __bool__(self):
+        return bool_(self)
 
 
 @defdata.register(collections.abc.Callable)

--- a/tests/test_handlers_numbers.py
+++ b/tests/test_handlers_numbers.py
@@ -1,5 +1,6 @@
 import collections
 import logging
+import typing
 
 import pytest
 
@@ -26,7 +27,7 @@ def test_lambda_calculus_1():
         assert fvsof(Lam(x, e1).args[1]) != fvsof(Lam(x, e1).args[1])
 
         assert typeof(e1) is int
-        assert typeof(f1) is collections.abc.Callable
+        assert typing.get_origin(typeof(f1)) is collections.abc.Callable
 
 
 def test_lambda_calculus_2():
@@ -142,7 +143,7 @@ def test_defun_1():
         def f1(x: int) -> int:
             return x + y() + 1
 
-        assert typeof(f1) is collections.abc.Callable
+        assert typing.get_origin(typeof(f1)) is collections.abc.Callable
         assert y in fvsof(f1)
         assert x not in fvsof(f1)
 


### PR DESCRIPTION
Adds `defdata`, `defterm` implementations for iterables. These are aimed at supporting comprehension expressions rather than arbitrary iterables.

```
>>> x = defop(list[int], name='x')
>>> gen = ((i, j) for i in x() for j in x() if i > 0)
>>> print(str(defterm(gen)))
filter_map(('int()', 'int!1()'), gt(int(), 0), (_BaseOperation(<function _.<locals>.func at 0x11e5bc5e0>, name=int, freshening=[1164120249]), _BaseOperation(<function _.<locals>.func at 0x11e5bc700>, name=int, freshening=[1685202287])), ('x()', 'x()'))
```