### PR TITLE
Support ordering `Operations`

### DIFF
--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -536,6 +536,11 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
             return NotImplemented
         return self is other
 
+    def __lt__(self, other):
+        if not isinstance(other, Operation):
+            return NotImplemented
+        return id(self) < id(other)
+
     def __hash__(self):
         return hash(self._default)
 

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import collections.abc
+import functools
 import inspect
 import typing
 from collections.abc import Callable, Mapping, Sequence
@@ -16,6 +17,7 @@ T = TypeVar("T")
 V = TypeVar("V")
 
 
+@functools.total_ordering
 class Operation(abc.ABC, Generic[Q, V]):
     """An abstract class representing an effect that can be implemented by an effect handler.
 
@@ -34,6 +36,10 @@ class Operation(abc.ABC, Generic[Q, V]):
 
     @abc.abstractmethod
     def __hash__(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def __lt__(self):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -39,7 +39,7 @@ class Operation(abc.ABC, Generic[Q, V]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __lt__(self):
+    def __lt__(self, other):
         raise NotImplementedError
 
     @abc.abstractmethod


### PR DESCRIPTION
dm-tree behaves badly on objects that are hashable but not orderable, so add ordering to `Operations`.

```
import tree


class A:
    def __init__(self, x):
        self.x = x

    def __hash__(self):
        return hash(self.x)

    def __eq__(self, other):
        return isinstance(other, A) and self.x == other.x


tree.flatten({A(0): 0, A(1): 1})
```
```
Traceback (most recent call last):
  File "/Users/feser/work/basis/effectful/test.py", line 15, in <module>
    tree.flatten({A(0): 0, A(1): 1})
  File "/Users/feser/work/basis/effectful/.venv/lib/python3.10/site-packages/tree/__init__.py", line 224, in flatten
    return _tree.flatten(structure)
TypeError: '<' not supported between instances of 'A' and 'A'
```