### PR TITLE
Add a cache for term analysis rules

### DIFF
--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -9,7 +9,7 @@ from typing import Any, TypeVar
 from typing_extensions import ParamSpec
 
 from effectful.ops.syntax import defdata, defop, syntactic_eq
-from effectful.ops.types import Expr, Operation, Term
+from effectful.ops.types import Expr, Operation, Term, _TermRuleCache
 
 P = ParamSpec("P")
 Q = ParamSpec("Q")
@@ -23,12 +23,16 @@ T_Number = TypeVar("T_Number", bound=numbers.Number)
 @defdata.register(numbers.Number)
 @numbers.Number.register
 class _NumberTerm(Term[numbers.Number]):
+    _rule_cache: _TermRuleCache
+
     def __init__(
         self, op: Operation[..., numbers.Number], *args: Expr, **kwargs: Expr
     ) -> None:
+        super().__init__()
         self._op = op
         self._args = args
         self._kwargs = kwargs
+        self._rule_cache = _TermRuleCache()
 
     @property
     def op(self) -> Operation[..., numbers.Number]:
@@ -41,6 +45,9 @@ class _NumberTerm(Term[numbers.Number]):
     @property
     def kwargs(self) -> dict:
         return self._kwargs
+
+    def apply_rule(self, rule):
+        return self._rule_cache.apply_rule(self, rule)
 
     def __hash__(self):
         return hash((self.op, tuple(self.args), tuple(self.kwargs.items())))

--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -4,6 +4,7 @@ This module provides a term representation for numbers and operations on them.
 
 import numbers
 import operator
+from collections.abc import Callable
 from typing import Any, TypeVar
 
 from typing_extensions import ParamSpec
@@ -46,7 +47,7 @@ class _NumberTerm(Term[numbers.Number]):
     def kwargs(self) -> dict:
         return self._kwargs
 
-    def apply_rule(self, rule):
+    def apply_rule(self, rule: Callable[..., S]) -> S:
         return self._rule_cache.apply_rule(self, rule)
 
     def __hash__(self):

--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -29,7 +29,6 @@ class _NumberTerm(Term[numbers.Number]):
     def __init__(
         self, op: Operation[..., numbers.Number], *args: Expr, **kwargs: Expr
     ) -> None:
-        super().__init__()
         self._op = op
         self._args = args
         self._kwargs = kwargs

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -28,7 +28,7 @@ from typing_extensions import ParamSpec
 from effectful.handlers.torch import sizesof, to_tensor
 from effectful.ops.semantics import call
 from effectful.ops.syntax import Scoped, defop, defterm
-from effectful.ops.types import Operation, Term
+from effectful.ops.types import Operation, Term, _TermRuleCache
 
 P = ParamSpec("P")
 A = TypeVar("A")
@@ -373,6 +373,10 @@ class _DistributionTerm(Term[TorchDistribution], TorchDistribution):
     def __init__(self, dist_constr: type[TorchDistribution], *args, **kwargs):
         self._args = (dist_constr,) + tuple(defterm(a) for a in args)
         self._kwargs = kwargs
+        self._rule_cache = _TermRuleCache()
+
+    def apply_rule(self, rule):
+        return self._rule_cache.apply_rule(self, rule)
 
     @property
     def op(self):

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -1,11 +1,7 @@
 import typing
 import warnings
-from collections.abc import Collection, Mapping
-from typing import (
-    Annotated,
-    Any,
-    TypeVar,
-)
+from collections.abc import Callable, Collection, Mapping
+from typing import Annotated, Any, TypeVar
 
 try:
     import pyro
@@ -375,7 +371,7 @@ class _DistributionTerm(Term[TorchDistribution], TorchDistribution):
         self._kwargs = kwargs
         self._rule_cache = _TermRuleCache()
 
-    def apply_rule(self, rule):
+    def apply_rule(self, rule: Callable[..., A]) -> A:
         return self._rule_cache.apply_rule(self, rule)
 
     @property

--- a/effectful/handlers/torch.py
+++ b/effectful/handlers/torch.py
@@ -14,8 +14,7 @@ import tree
 from typing_extensions import ParamSpec
 
 import effectful.handlers.numbers  # noqa: F401
-from effectful.internals.runtime import interpreter
-from effectful.ops.semantics import apply, evaluate, fvsof, typeof
+from effectful.ops.semantics import fvsof, typeof
 from effectful.ops.syntax import defdata, defop, defterm
 from effectful.ops.types import Expr, Operation, Term, _TermRuleCache
 
@@ -354,7 +353,7 @@ class _TensorTerm(Term[torch.Tensor]):
     def kwargs(self) -> dict:
         return self._kwargs
 
-    def apply_rule(self, rule):
+    def apply_rule(self, rule: Callable[..., S]) -> S:
         return self._rule_cache.apply_rule(self, rule)
 
     def __getitem__(
@@ -499,8 +498,8 @@ class _EagerTensorTerm(torch.Tensor):
         ret._rule_cache = _TermRuleCache()
         return ret
 
-    def apply_rule(self, rule):
-        return self._rule_cache.apply_rule(self, rule)
+    def apply_rule(self, rule: Callable[..., S]) -> S:
+        return self._rule_cache.apply_rule(typing.cast(Term, self), rule)
 
     def __str__(self):
         tensor_str = str(self.args[0])

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -265,8 +265,8 @@ def evaluate(expr: Expr[T], *, intp: Interpretation | None = None) -> Expr[T]:
         return expr
 
 
-def _type_rule(op, *args, **kwargs):
-    return op.__type_rule__(*args, **kwargs)
+def _type_rule(term, *args, **kwargs):
+    return term.op.__type_rule__(*args, **kwargs)
 
 
 def typeof(term: Expr[T]) -> type[T]:
@@ -300,11 +300,15 @@ def typeof(term: Expr[T]) -> type[T]:
     return type(term)
 
 
-def _free_var_rule(op, *args, **kwargs):
-    free = {op} | set().union(
+def _fvs_rule(term, *args, **kwargs):
+    return term.op.__fvs_rule__(*args, **kwargs)
+
+
+def _free_var_rule(term, *args, **kwargs):
+    free = {term.op} | set().union(
         *[x for x in tree.flatten((args, kwargs.values())) if isinstance(x, set)]
     )
-    arg_ctxs, kwarg_ctxs = op.__fvs_rule__(*args, **kwargs)
+    arg_ctxs, kwarg_ctxs = term.apply_rule(_fvs_rule)
     bound_vars = set().union(*(a for a in arg_ctxs), *(k for k in kwarg_ctxs.values()))
     free -= bound_vars
     return free

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -265,6 +265,10 @@ def evaluate(expr: Expr[T], *, intp: Interpretation | None = None) -> Expr[T]:
         return expr
 
 
+def _type_rule(op, *args, **kwargs):
+    return op.__type_rule__(*args, **kwargs)
+
+
 def typeof(term: Expr[T]) -> type[T]:
     """Return the type of an expression.
 
@@ -291,8 +295,9 @@ def typeof(term: Expr[T]) -> type[T]:
     """
     from effectful.internals.runtime import interpreter
 
-    with interpreter({apply: lambda _, op, *a, **k: op.__type_rule__(*a, **k)}):
-        return evaluate(term) if isinstance(term, Term) else type(term)  # type: ignore
+    if isinstance(term, Term):
+        return term.apply_rule(_type_rule)
+    return type(term)
 
 
 def fvsof(term: Expr[S]) -> set[Operation]:

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -294,7 +294,6 @@ def typeof(term: Expr[T]) -> type[T]:
     <class 'int'>
 
     """
-    from effectful.internals.runtime import interpreter
 
     if isinstance(term, Term):
         return term.apply_rule(_type_rule)

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -608,6 +608,12 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
             origin = typing.get_origin(typ)
             return typ if origin is None else origin
 
+        def any_to_object(typ):
+            return object if typ is typing.Any else typ
+
+        def cleanup(typ):
+            return any_to_object(drop_params(typ))
+
         anno = unwrap_annotation(anno)
 
         if anno is inspect.Signature.empty:
@@ -626,11 +632,11 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
                 ):
                     arg = bound_sig.arguments[name]
                     tp: type[V] = type(arg) if not isinstance(arg, type) else arg
-                    return drop_params(tp)
+                    return cleanup(tp)
 
             return typing.cast(type[V], object)
 
-        return drop_params(anno)
+        return cleanup(anno)
 
     def __repr__(self):
         return f"_BaseOperation({self._default}, name={self.__name__}, freshening={self._freshening})"

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -884,7 +884,7 @@ def _(value: T) -> T:
 
 
 @defdata.register(object)
-class _BaseTerm(Generic[T], Term[T], _TermRuleCache):
+class _BaseTerm(Generic[T], Term[T]):
     _op: Operation[..., T]
     _args: collections.abc.Sequence[Expr]
     _kwargs: collections.abc.Mapping[str, Expr]
@@ -918,7 +918,7 @@ class _BaseTerm(Generic[T], Term[T], _TermRuleCache):
     def kwargs(self):
         return self._kwargs
 
-    def apply_rule(self, rule: Callable[..., T]) -> T:
+    def apply_rule(self, rule: Callable[..., S]) -> S:
         return self._rule_cache.apply_rule(self, rule)
 
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -11,7 +11,14 @@ from typing import Annotated, Concatenate, Generic, TypeVar
 import tree
 from typing_extensions import ParamSpec
 
-from effectful.ops.types import Annotation, Expr, Interpretation, Operation, Term
+from effectful.ops.types import (
+    Annotation,
+    Expr,
+    Interpretation,
+    Operation,
+    Term,
+    _TermRuleCache,
+)
 
 P = ParamSpec("P")
 Q = ParamSpec("Q")
@@ -877,10 +884,11 @@ def _(value: T) -> T:
 
 
 @defdata.register(object)
-class _BaseTerm(Generic[T], Term[T]):
+class _BaseTerm(Generic[T], Term[T], _TermRuleCache):
     _op: Operation[..., T]
     _args: collections.abc.Sequence[Expr]
     _kwargs: collections.abc.Mapping[str, Expr]
+    _rule_cache: _TermRuleCache
 
     def __init__(
         self,
@@ -891,6 +899,7 @@ class _BaseTerm(Generic[T], Term[T]):
         self._op = op
         self._args = args
         self._kwargs = kwargs
+        self._rule_cache = _TermRuleCache()
 
     def __eq__(self, other) -> bool:
         from effectful.ops.syntax import syntactic_eq
@@ -908,6 +917,9 @@ class _BaseTerm(Generic[T], Term[T]):
     @property
     def kwargs(self):
         return self._kwargs
+
+    def apply_rule(self, rule: Callable[..., T]) -> T:
+        return self._rule_cache.apply_rule(self, rule)
 
 
 @defdata.register(collections.abc.Callable)

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -6,6 +6,7 @@ import functools
 import inspect
 import typing
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Generic, TypeAlias, TypeVar
 
 import tree
@@ -89,6 +90,14 @@ class _TermRuleCache:
         self._rule_cache = {}
 
     def apply_rule(self, term: Term, rule: Callable[..., V]) -> V:
+        """Apply an analysis rule to a term, returning the result.
+
+        The rule is passed the term and the results of applying the rule
+        recursively to the term arguments. If the term arguments are nested, the
+        rule is applied recursively to the nested terms as well. The rule is
+        never applied to ordinary values.
+
+        """
         if rule in self._rule_cache:
             return self._rule_cache[rule]
 

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -6,7 +6,6 @@ import functools
 import inspect
 import typing
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
 from typing import Any, Generic, TypeAlias, TypeVar
 
 import tree
@@ -89,7 +88,7 @@ class _TermRuleCache:
     def __init__(self):
         self._rule_cache = {}
 
-    def apply_rule(self, term: Term, rule: Callable[..., V]) -> V:
+    def apply_rule(self, term: Term[T], rule: Callable[..., V]) -> V:
         """Apply an analysis rule to a term, returning the result.
 
         The rule is passed the term and the results of applying the rule

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -96,7 +96,7 @@ class _TermRuleCache:
             lambda x: x.apply_rule(rule) if isinstance(x, Term) else x,
             (term.args, term.kwargs),
         )
-        value = rule(term.op, *args, **kwargs)
+        value = rule(term, *args, **kwargs)
         self._rule_cache[rule] = value
         return value
 


### PR DESCRIPTION
All terms now must implement the `apply_rule` method. `t.apply_rule(r)` is equivalent to
```
with handler({apply: lambda _, op, *args, **kwargs: r(t, *args, **kwargs)}):
    return evaluate(t)
```
but the results returned by `r` may be cached on the term and reused. `_TermRuleCache` implements such a cache.

In some of the rule implementations, a wrapper type is introduced to make it possible to distinguish between analysis results and ordinary values present in the term tree.
