### PR TITLE
Introduce `bind_dims`/`unbind_dims`

### DIFF
--- a/docs/source/named_tensor_notation.ipynb
+++ b/docs/source/named_tensor_notation.ipynb
@@ -33,7 +33,7 @@
     "import torch\n",
     "from torch import tensor\n",
     "\n",
-    "from effectful.handlers.torch import sizesof, bind_dims\n",
+    "from effectful.handlers.torch import bind_dims, sizesof\n",
     "from effectful.ops.semantics import evaluate, fvsof, handler\n",
     "from effectful.ops.syntax import Scoped, defop\n",
     "from effectful.ops.types import Operation\n",

--- a/docs/source/named_tensor_notation.ipynb
+++ b/docs/source/named_tensor_notation.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
     "import torch\n",
     "from torch import tensor\n",
     "\n",
-    "from effectful.handlers.torch import sizesof, to_tensor\n",
+    "from effectful.handlers.torch import sizesof, bind_dims\n",
     "from effectful.ops.semantics import evaluate, fvsof, handler\n",
     "from effectful.ops.syntax import Scoped, defop\n",
     "from effectful.ops.types import Operation\n",
@@ -68,7 +68,7 @@
     "    indexes = [i for i in indexes if i in fvars]\n",
     "\n",
     "    # convert indexed dimensions to positional and flatten all new positional dims\n",
-    "    t = to_tensor(indexed_tensor, *indexes)\n",
+    "    t = bind_dims(indexed_tensor, *indexes)\n",
     "    t_flat = torch.flatten(t, 0, len(indexes) - 1)\n",
     "\n",
     "    # reduce dim 0 into the first index of dim 0, then return reduction\n",
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [
     {
@@ -135,7 +135,7 @@
        "        [2, 6, 5]])[height(), width()]"
       ]
      },
-     "execution_count": 168,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -174,7 +174,7 @@
        "tensor(4)"
       ]
      },
-     "execution_count": 169,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [
     {
@@ -220,7 +220,7 @@
        "tensor([3, 1, 4])[width()]"
       ]
      },
-     "execution_count": 170,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -231,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [
     {
@@ -240,7 +240,7 @@
        "tensor([4, 9, 5])[height()]"
       ]
      },
-     "execution_count": 171,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -287,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [
     {
@@ -298,7 +298,7 @@
        "        [0.8808, 0.9975, 0.9933]])[height(), width()]"
       ]
      },
-     "execution_count": 172,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -336,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
@@ -386,7 +386,7 @@
        "        [ 3,  7,  6]])[height(), width()]"
       ]
      },
-     "execution_count": 174,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [
     {
@@ -408,7 +408,7 @@
        "        [ 3, 10,  6]])[height(), width()]"
       ]
      },
-     "execution_count": 175,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -435,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -446,7 +446,7 @@
        "        [ 2,  6,  5]])[height(), width()]"
       ]
      },
-     "execution_count": 176,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
@@ -484,7 +484,7 @@
        "        [2, 6, 5]])[height(), width()]"
       ]
      },
-     "execution_count": 177,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -521,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [
     {
@@ -530,7 +530,7 @@
        "tensor([ 6, 12, 18])[width()]"
       ]
      },
-     "execution_count": 178,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -553,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [
     {
@@ -562,7 +562,7 @@
        "tensor([ 8, 15, 13])[height()]"
       ]
      },
-     "execution_count": 179,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -590,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -599,7 +599,7 @@
        "tensor(36)"
       ]
      },
-     "execution_count": 180,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -629,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
@@ -638,7 +638,7 @@
        "tensor([  6,  30, 180])[width()]"
       ]
      },
-     "execution_count": 181,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -668,7 +668,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
@@ -677,7 +677,7 @@
        "tensor([3, 6, 9])[width()]"
       ]
      },
-     "execution_count": 182,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -716,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
@@ -725,7 +725,7 @@
        "tensor([11, 30, 31])[height()]"
       ]
      },
-     "execution_count": 183,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -752,7 +752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [
     {
@@ -761,7 +761,7 @@
        "tensor(54)"
       ]
      },
-     "execution_count": 184,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -781,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
@@ -792,7 +792,7 @@
        "        [ 1,  4,  1]])[height(), width()]"
       ]
      },
-     "execution_count": 185,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -812,7 +812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
@@ -821,7 +821,7 @@
        "tensor([11, 30, 31])[height()]"
       ]
      },
-     "execution_count": 186,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -841,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
@@ -850,7 +850,7 @@
        "tensor([15, 43, 76])[width()]"
       ]
      },
-     "execution_count": 187,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -870,7 +870,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
@@ -881,7 +881,7 @@
        "        [ 76,  43,  40]])[height(), width2()]"
       ]
      },
-     "execution_count": 188,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -915,7 +915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
@@ -924,7 +924,7 @@
        "tensor([ 5, 10, 10])[height()]"
       ]
      },
-     "execution_count": 189,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -964,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
@@ -997,7 +997,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
@@ -1034,7 +1034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {
@@ -1099,7 +1099,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [
     {
@@ -1108,7 +1108,7 @@
        "tensor([1, 3, 7])[emb()]"
       ]
      },
-     "execution_count": 193,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1130,7 +1130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [
     {
@@ -1142,7 +1142,7 @@
        "        [2, 1, 5]])[seq(), emb()]"
       ]
      },
-     "execution_count": 194,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1162,7 +1162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [
     {
@@ -1171,7 +1171,7 @@
        "tensor([1, 5, 2, 2])[seq()]"
       ]
      },
-     "execution_count": 195,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1203,7 +1203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [
     {
@@ -1212,7 +1212,7 @@
        "tensor([3, 4, 5])[subseq()]"
       ]
      },
-     "execution_count": 196,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1267,7 +1267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1283,19 +1283,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([49.6214, 49.1620, 46.7234, 48.5531, 49.5717, 49.0428, 49.3330, 50.5993,\n",
-       "        50.1553, 49.8182, 50.9401, 49.1957, 49.4627, 51.3990, 50.4449, 48.4399,\n",
-       "        49.1624, 53.8431, 49.3302, 47.4099, 49.5286, 50.8544, 50.5048, 54.8563,\n",
-       "        48.1085, 51.1001, 49.7631, 52.9175, 48.7131, 50.6819, 49.1625, 50.3209])[output()]"
+       "tensor([48.3593, 49.3429, 49.6938, 49.5739, 49.7935, 47.6643, 48.5268, 48.7058,\n",
+       "        48.5753, 47.1171, 49.0021, 46.8736, 49.2892, 49.6605, 48.2557, 50.7229,\n",
+       "        51.1484, 50.1436, 53.6581, 49.8802, 48.9300, 47.6961, 51.9077, 49.2896,\n",
+       "        52.1283, 49.2487, 52.4998, 49.8213, 47.8229, 53.0242, 53.1161, 50.2577])[output()]"
       ]
      },
-     "execution_count": 198,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1337,7 +1337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1358,21 +1358,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([5.8642e-13, 9.8138e-01, 9.9968e-01, 9.9999e-01, 3.2927e-05, 9.9999e-01,\n",
-       "        6.9062e-04, 5.1937e-02, 1.2397e-05, 9.9914e-01, 7.7800e-03, 1.0000e+00,\n",
-       "        5.7578e-04, 2.0352e-02, 1.5684e-02, 8.6293e-05, 2.7781e-01, 4.2824e-02,\n",
-       "        9.9636e-01, 9.9777e-01, 2.8032e-01, 1.9554e-02, 9.9816e-01, 2.5286e-02,\n",
-       "        1.9089e-04, 2.7259e-09, 9.9995e-01, 9.3336e-01, 6.4968e-07, 3.3902e-05,\n",
-       "        4.0663e-01, 1.2525e-01])[hidden2()]"
+       "tensor([8.6180e-10, 9.9987e-01, 9.9873e-01, 9.9986e-01, 7.8778e-03, 4.5436e-16,\n",
+       "        1.0000e+00, 9.9496e-01, 4.9092e-02, 9.9985e-01, 1.0000e+00, 4.3122e-13,\n",
+       "        6.1678e-02, 9.9988e-01, 9.1688e-01, 6.8095e-01, 6.0129e-04, 2.8505e-01,\n",
+       "        1.1069e-08, 1.7512e-01, 9.9994e-01, 1.0000e+00, 1.0000e+00, 9.9999e-01,\n",
+       "        7.7253e-04, 5.0269e-01, 2.1951e-01, 1.4707e-08, 6.5843e-03, 1.0000e+00,\n",
+       "        3.5189e-01, 9.9996e-01])[hidden2()]"
       ]
      },
-     "execution_count": 200,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1400,7 +1400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1427,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1447,18 +1447,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[0.1311, 0.2201, 0.2817, 0.1219, 0.1279],\n",
-       "        [0.7969, 1.3385, 1.7125, 0.7410, 0.7779],\n",
-       "        [0.0980, 0.1647, 0.2107, 0.0912, 0.0957]])[seq2(), val()]"
+       "tensor([[-0.0563, -0.4442, -0.1326,  0.2052,  0.0198],\n",
+       "        [-0.4215, -3.3251, -0.9924,  1.5363,  0.1484],\n",
+       "        [-0.1722, -1.3586, -0.4055,  0.6277,  0.0606]])[seq2(), val()]"
       ]
      },
-     "execution_count": 203,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1497,7 +1497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1509,7 +1509,7 @@
     "    kernel: Operation[[], torch.Tensor],\n",
     "    seq2: Operation[[], torch.Tensor],\n",
     ") -> torch.Tensor:\n",
-    "    return to_tensor(x, seq).unfold(0, k, 1)[seq2(), kernel()]"
+    "    return bind_dims(x, seq).unfold(0, k, 1)[seq2(), kernel()]"
    ]
   },
   {
@@ -1534,7 +1534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 205,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1555,16 +1555,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 206,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([ 1.3124,  0.1102, -6.1440, -1.6563, -5.7074,  3.8315, -2.5586, -3.6780])[seq2()]"
+       "tensor([ 3.7172, -3.7238, -2.8743, -1.5637, -2.1118, -0.7070,  0.0755, -0.8824])[seq2()]"
       ]
      },
-     "execution_count": 206,
+     "execution_count": 135,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1609,7 +1609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 207,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1634,20 +1634,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 208,
+   "execution_count": 137,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[ 3.1259, -2.5779, -8.5917, -5.2500,  0.9331, -1.0349, -2.5460, -7.8026],\n",
-       "        [-2.4204,  2.6947, -4.3422, -4.1924, -1.6958, -4.8411,  6.3812,  3.1479],\n",
-       "        [ 8.0389, -3.5227,  8.6371, -7.9508,  3.3021, -4.4417,  4.8447, -7.3063],\n",
-       "        [ 7.1624, -0.9561,  6.7281, -1.8662,  1.8822,  0.0897,  1.0368, -4.5366],\n",
-       "        [ 3.3856,  0.3371, -4.8247, -2.9813, 10.4098, -1.9862, -4.5428, -2.5016]])[width2(), height2()]"
+       "tensor([[ -0.7712,  -0.4630,  -2.1199,   2.0400,  -5.2443,   0.7167,  11.3082,\n",
+       "          -7.4289],\n",
+       "        [ -1.2358,   2.4401, -10.5980,  -3.6137, -14.8803, -12.0193,  -0.3878,\n",
+       "          -4.7996],\n",
+       "        [ -0.3710,   8.4944,  -4.7507,  10.5713,   0.5455,  -3.3798,   0.5670,\n",
+       "          15.1692],\n",
+       "        [ 10.9288, -12.4020,   7.1001, -10.2582,   1.6296,   4.3733,  -0.6362,\n",
+       "           8.1692],\n",
+       "        [-13.7094,  -2.2593,   0.0851,  -7.8723,   0.5353,   9.0647, -15.1656,\n",
+       "           2.3979]])[width2(), height2()]"
       ]
      },
-     "execution_count": 208,
+     "execution_count": 137,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1692,7 +1697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1704,26 +1709,26 @@
     "    kernel: Operation[[], torch.Tensor],\n",
     "    seq2: Operation[[], torch.Tensor],\n",
     ") -> torch.Tensor:\n",
-    "    xp = to_tensor(x, seq)\n",
+    "    xp = bind_dims(x, seq)\n",
     "    return xp.reshape((xp.shape[0] // k, k) + xp.shape[1:])[seq2(), kernel()]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 210,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[ 0.1942,  2.0733],\n",
-       "        [ 0.1388,  0.7844],\n",
-       "        [-0.8563, -0.3301],\n",
-       "        [ 1.0066, -0.4537],\n",
-       "        [ 1.3682, -0.9057]])[seq2(), kernel()]"
+       "tensor([[ 2.6660, -1.6172],\n",
+       "        [ 0.6933,  0.9224],\n",
+       "        [ 1.5376, -1.1706],\n",
+       "        [ 0.7437,  1.6497],\n",
+       "        [ 0.8990,  0.8265]])[seq2(), kernel()]"
       ]
      },
-     "execution_count": 210,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1756,7 +1761,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 211,
+   "execution_count": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1773,20 +1778,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 212,
+   "execution_count": 141,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[ 0.3129],\n",
-       "        [ 1.0415],\n",
-       "        [-0.5359],\n",
-       "        [ 1.1539],\n",
-       "        [ 0.1567]])[seq2(), slice(None, None, None)]"
+       "tensor([[ 0.8047],\n",
+       "        [ 1.0641],\n",
+       "        [ 0.2888],\n",
+       "        [-0.9893],\n",
+       "        [-0.0883]])[seq2(), slice(None, None, None)]"
       ]
      },
-     "execution_count": 212,
+     "execution_count": 141,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1802,7 +1807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 213,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1824,22 +1829,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 214,
+   "execution_count": 143,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[[2.2239],\n",
-       "         [1.4813],\n",
-       "         [1.2894]],\n",
+       "tensor([[[1.7747],\n",
+       "         [1.9943],\n",
+       "         [0.8689]],\n",
        "\n",
-       "        [[1.7128],\n",
-       "         [1.7628],\n",
-       "         [1.4359]]])[height2(), width2(), slice(None, None, None)]"
+       "        [[0.3376],\n",
+       "         [1.3729],\n",
+       "         [1.4328]]])[height2(), width2(), slice(None, None, None)]"
       ]
      },
-     "execution_count": 214,
+     "execution_count": 143,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1877,7 +1882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1955,7 +1960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 216,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1999,30 +2004,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 217,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[[ 0.2670, -0.1588, -1.2522, -0.7949, -0.4869],\n",
-       "         [ 0.3384, -0.1322, -0.8064,  0.9302,  0.0463],\n",
-       "         [ 2.1462,  2.1542,  1.9729,  2.6483,  2.8954]],\n",
+       "tensor([[[-0.0980,  1.1506, -0.6597,  3.1979,  1.3816],\n",
+       "         [-1.8462, -0.7802, -2.2415, -2.8337, -2.4419],\n",
+       "         [-0.1820, -0.1727,  1.8149, -1.1343,  0.8576]],\n",
        "\n",
-       "        [[ 0.4752, -0.9735, -0.6327, -2.0224, -1.0046],\n",
-       "         [-0.9306, -0.2433, -0.2080,  0.3491, -0.0462],\n",
-       "         [ 2.0179,  3.4996,  2.2253,  2.7595,  1.7771]],\n",
+       "        [[-1.3853,  0.4412, -0.0613,  0.0438, -1.2001],\n",
+       "         [-1.1071, -2.8085, -0.2433, -2.1072, -2.8466],\n",
+       "         [ 0.9574,  1.7885, -1.6812, -0.7833,  1.7904]],\n",
        "\n",
-       "        [[-2.1675,  0.3962, -0.9786,  1.1038,  0.6551],\n",
-       "         [-0.3270, -0.1066, -0.1575,  0.0266,  0.5415],\n",
-       "         [ 1.9313,  3.4777,  2.7468,  2.4394,  3.2106]],\n",
+       "        [[ 1.8424,  0.5241,  2.8473,  0.0444,  1.8414],\n",
+       "         [-2.8606, -0.8699, -3.0584, -2.4499, -2.6714],\n",
+       "         [ 0.4484, -1.7353,  1.5164,  2.0637,  1.2156]],\n",
        "\n",
-       "        [[ 2.2192, -0.8806, -1.7958, -0.9050, -1.3091],\n",
-       "         [-0.3796, -0.4029, -0.8666, -0.0087,  0.6328],\n",
-       "         [ 2.8615,  2.2634,  2.4476,  2.4643,  2.6424]]])[batch2(), chans(), layer2()]"
+       "        [[ 1.4954,  0.2327,  1.4578,  2.0248,  1.2005],\n",
+       "         [-3.4012, -2.1421, -3.6344, -2.3489, -1.5841],\n",
+       "         [-0.2463,  0.1265, -2.5361, -1.2339,  0.4741]]])[batch2(), chans(), layer2()]"
       ]
      },
-     "execution_count": 217,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2244,7 +2249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 218,
+   "execution_count": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2255,30 +2260,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 219,
+   "execution_count": 148,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[[0.0000, 0.0000, 0.7641, 0.3760, 0.1145],\n",
-       "         [0.4051, 0.0000, 0.0000, 1.4258, 0.0000],\n",
-       "         [1.1718, 1.1479, 1.6898, 0.0000, 0.0000]],\n",
+       "tensor([[[0.0000, 0.3641, 0.0000, 1.7635, 0.5220],\n",
+       "         [0.0757, 1.2179, 0.0000, 0.0000, 0.0000],\n",
+       "         [0.0000, 0.0000, 1.1420, 0.0000, 0.3911]],\n",
        "\n",
-       "        [[0.0000, 0.5275, 0.2382, 1.4178, 0.5540],\n",
-       "         [0.0000, 0.0000, 0.0000, 0.4236, 0.0000],\n",
-       "         [1.5552, 0.0000, 0.9354, 0.0000, 2.2747]],\n",
+       "        [[0.0000, 0.0000, 0.0000, 0.0000, 0.0000],\n",
+       "         [0.8676, 0.0000, 1.7932, 0.0000, 0.0000],\n",
+       "         [0.4694, 1.1212, 0.0000, 0.0000, 1.1227]],\n",
        "\n",
-       "        [[1.5410, 0.0000, 0.5318, 0.0000, 0.0000],\n",
-       "         [0.0000, 0.0000, 0.0000, 0.0000, 0.7555],\n",
-       "         [1.8139, 0.0000, 0.0000, 0.2960, 0.0000]],\n",
+       "        [[0.8370, 0.0000, 1.5239, 0.0000, 0.8363],\n",
+       "         [0.0000, 1.1218, 0.0000, 0.0000, 0.0000],\n",
+       "         [0.0702, 0.0000, 0.9078, 1.3371, 0.6719]],\n",
        "\n",
-       "        [[0.0000, 0.4487, 1.2255, 0.4694, 0.8124],\n",
-       "         [0.0000, 0.0000, 0.0000, 0.0000, 0.9130],\n",
-       "         [0.0000, 0.8218, 0.2714, 0.2214, 0.0000]]])[batch(), chans(), layer()]"
+       "        [[0.5998, 0.0000, 0.5741, 0.9617, 0.3982],\n",
+       "         [0.0000, 0.0000, 0.0000, 0.0000, 0.3565],\n",
+       "         [0.0000, 0.0000, 0.0000, 0.0000, 0.0904]]])[batch(), chans(), layer()]"
       ]
      },
-     "execution_count": 219,
+     "execution_count": 148,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2289,7 +2294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [
     {
@@ -2300,20 +2305,20 @@
        "         [0.0000e+00],\n",
        "         [0.0000e+00]],\n",
        "\n",
-       "        [[0.0000e+00],\n",
-       "         [0.0000e+00],\n",
-       "         [0.0000e+00],\n",
-       "         [0.0000e+00]],\n",
-       "\n",
-       "        [[1.5932e-07],\n",
-       "         [1.0565e-36],\n",
-       "         [8.7251e-37],\n",
-       "         [0.0000e+00]],\n",
-       "\n",
        "        [[1.0000e+00],\n",
        "         [1.0000e+00],\n",
        "         [1.0000e+00],\n",
        "         [1.0000e+00]],\n",
+       "\n",
+       "        [[1.6579e-15],\n",
+       "         [0.0000e+00],\n",
+       "         [0.0000e+00],\n",
+       "         [0.0000e+00]],\n",
+       "\n",
+       "        [[0.0000e+00],\n",
+       "         [0.0000e+00],\n",
+       "         [0.0000e+00],\n",
+       "         [0.0000e+00]],\n",
        "\n",
        "        [[0.0000e+00],\n",
        "         [0.0000e+00],\n",
@@ -2321,7 +2326,7 @@
        "         [0.0000e+00]]])[classes2(), batch(), slice(None, None, None)]"
       ]
      },
-     "execution_count": 220,
+     "execution_count": 149,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2411,7 +2416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.9"
   },
   "toc": {
    "base_numbering": 1,

--- a/effectful/handlers/indexed.py
+++ b/effectful/handlers/indexed.py
@@ -264,13 +264,13 @@ def cond(fst: torch.Tensor, snd: torch.Tensor, case_: torch.Tensor) -> torch.Ten
     and both branches are evaluated, as with :func:`torch.where` ::
 
         >>> from effectful.ops.syntax import defop
-        >>> from effectful.handlers.torch import to_tensor
+        >>> from effectful.handlers.torch import bind_dims
 
         >>> b = defop(torch.Tensor, name="b")
         >>> fst, snd = torch.randn(2, 3)[b()], torch.randn(2, 3)[b()]
         >>> case = (fst < snd).all(-1)
         >>> x = cond(fst, snd, case)
-        >>> assert (to_tensor(x, b) == to_tensor(torch.where(case[..., None], snd, fst), b)).all()
+        >>> assert (bind_dims(x, b) == bind_dims(torch.where(case[..., None], snd, fst), b)).all()
 
     .. note::
 

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -564,18 +564,16 @@ def _embed_independent(d: dist.Independent) -> Term[TorchDistribution]:
     with interpreter({}):
         base_dist = d.base_dist
         reinterpreted_batch_ndims = d.reinterpreted_batch_ndims
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(base_dist, reinterpreted_batch_ndims)
+    return _register_distribution_op(type(d))(base_dist, reinterpreted_batch_ndims)
 
 
 @defterm.register
 def _embed_folded(d: dist.FoldedDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         base_dist = d.base_dist
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(base_dist)  # type: ignore
+    return _register_distribution_op(type(d))(base_dist)  # type: ignore
 
 
 @defterm.register
@@ -583,9 +581,8 @@ def _embed_masked(d: dist.MaskedDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         base_dist = d.base_dist
         mask = d._mask
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(base_dist, mask)
+    return _register_distribution_op(type(d))(base_dist, mask)
 
 
 @defterm.register(dist.Cauchy)
@@ -600,9 +597,8 @@ def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         loc = d.loc
         scale = d.scale
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(loc, scale)
+    return _register_distribution_op(type(d))(loc, scale)
 
 
 @defterm.register(dist.Bernoulli)
@@ -614,9 +610,8 @@ def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
 def _embed_probs(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         probs = d.probs
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(probs)
+    return _register_distribution_op(type(d))(probs)
 
 
 @defterm.register(dist.Beta)
@@ -625,9 +620,8 @@ def _embed_beta(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         concentration1 = d.concentration1
         concentration0 = d.concentration0
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(concentration1, concentration0)
+    return _register_distribution_op(type(d))(concentration1, concentration0)
 
 
 @defterm.register
@@ -686,9 +680,8 @@ def _embed_gamma(d: dist.Gamma) -> Term[TorchDistribution]:
 def _embed_half_cauchy(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         scale = d.scale
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(scale)
+    return _register_distribution_op(type(d))(scale)
 
 
 @defterm.register
@@ -754,9 +747,8 @@ def _embed_relaxed(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         temperature = d.temperature
         probs = d.probs
-        dist_type = type(d)
     
-    return _register_distribution_op(dist_type)(temperature, probs)
+    return _register_distribution_op(type(d))(temperature, probs)
 
 
 @defterm.register

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -30,6 +30,7 @@ from effectful.handlers.torch import (
     sizesof,
     unbind_dims,
 )
+from effectful.internals.runtime import interpreter
 from effectful.ops.semantics import apply, runner, typeof
 from effectful.ops.syntax import defdata, defop, defterm
 from effectful.ops.types import Operation, Term
@@ -587,18 +588,21 @@ def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
 @defterm.register(dist.OneHotCategorical)
 @defterm.register(dist.OneHotCategoricalStraightThrough)
 def _embed_probs(d: TorchDistribution) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.probs)
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.probs)
 
 
 @defterm.register(dist.Beta)
 @defterm.register(dist.Kumaraswamy)
 def _embed_beta(d: TorchDistribution) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.concentration1, d.concentration0)
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.concentration1, d.concentration0)
 
 
 @defterm.register
 def _embed_binomial(d: dist.Binomial) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Binomial)(d.total_count, d.probs)
+    with interpreter({}):
+        return _register_distribution_op(dist.Binomial)(d.total_count, d.probs)
 
 
 @defterm.register

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -550,27 +550,42 @@ def _embed_distribution(dist: TorchDistribution) -> Term[TorchDistribution]:
 @defterm.register
 def _embed_expanded(d: dist.ExpandedDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        if d._batch_shape == d.base_dist.batch_shape:
-            return d.base_dist
-        raise ValueError("Nontrivial ExpandedDistribution not implemented.")
+        batch_shape = d._batch_shape
+        base_dist = d.base_dist
+        base_batch_shape = base_dist.batch_shape
+        if batch_shape == base_batch_shape:
+            return base_dist
+    
+    raise ValueError("Nontrivial ExpandedDistribution not implemented.")
 
 
 @defterm.register
 def _embed_independent(d: dist.Independent) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.base_dist, d.reinterpreted_batch_ndims)
+        base_dist = d.base_dist
+        reinterpreted_batch_ndims = d.reinterpreted_batch_ndims
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(base_dist, reinterpreted_batch_ndims)
 
 
 @defterm.register
 def _embed_folded(d: dist.FoldedDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.base_dist)  # type: ignore
+        base_dist = d.base_dist
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(base_dist)  # type: ignore
 
 
 @defterm.register
 def _embed_masked(d: dist.MaskedDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.base_dist, d._mask)
+        base_dist = d.base_dist
+        mask = d._mask
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(base_dist, mask)
 
 
 @defterm.register(dist.Cauchy)
@@ -583,7 +598,11 @@ def _embed_masked(d: dist.MaskedDistribution) -> Term[TorchDistribution]:
 @defterm.register(dist.StudentT)
 def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.loc, d.scale)
+        loc = d.loc
+        scale = d.scale
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(loc, scale)
 
 
 @defterm.register(dist.Bernoulli)
@@ -594,136 +613,198 @@ def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
 @defterm.register(dist.OneHotCategoricalStraightThrough)
 def _embed_probs(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.probs)
+        probs = d.probs
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(probs)
 
 
 @defterm.register(dist.Beta)
 @defterm.register(dist.Kumaraswamy)
 def _embed_beta(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.concentration1, d.concentration0)
+        concentration1 = d.concentration1
+        concentration0 = d.concentration0
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(concentration1, concentration0)
 
 
 @defterm.register
 def _embed_binomial(d: dist.Binomial) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Binomial)(d.total_count, d.probs)
+        total_count = d.total_count
+        probs = d.probs
+    
+    return _register_distribution_op(dist.Binomial)(total_count, probs)
 
 
 @defterm.register
 def _embed_chi2(d: dist.Chi2) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Chi2)(d.df)
+        df = d.df
+    
+    return _register_distribution_op(dist.Chi2)(df)
 
 
 @defterm.register
 def _embed_dirichlet(d: dist.Dirichlet) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Dirichlet)(d.concentration)
+        concentration = d.concentration
+    
+    return _register_distribution_op(dist.Dirichlet)(concentration)
 
 
 @defterm.register
 def _embed_exponential(d: dist.Exponential) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Exponential)(d.rate)
+        rate = d.rate
+    
+    return _register_distribution_op(dist.Exponential)(rate)
 
 
 @defterm.register
 def _embed_fisher_snedecor(d: dist.FisherSnedecor) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.FisherSnedecor)(d.df1, d.df2)
+        df1 = d.df1
+        df2 = d.df2
+    
+    return _register_distribution_op(dist.FisherSnedecor)(df1, df2)
 
 
 @defterm.register
 def _embed_gamma(d: dist.Gamma) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Gamma)(d.concentration, d.rate)
+        concentration = d.concentration
+        rate = d.rate
+    
+    return _register_distribution_op(dist.Gamma)(concentration, rate)
 
 
 @defterm.register(dist.HalfCauchy)
 @defterm.register(dist.HalfNormal)
 def _embed_half_cauchy(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.scale)
+        scale = d.scale
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(scale)
 
 
 @defterm.register
 def _embed_lkj_cholesky(d: dist.LKJCholesky) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.LKJCholesky)(
-            d.dim, concentration=d.concentration
-        )
+        dim = d.dim
+        concentration = d.concentration
+    
+    return _register_distribution_op(dist.LKJCholesky)(
+        dim, concentration=concentration
+    )
 
 
 @defterm.register
 def _embed_multinomial(d: dist.Multinomial) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Multinomial)(d.total_count, d.probs)
+        total_count = d.total_count
+        probs = d.probs
+    
+    return _register_distribution_op(dist.Multinomial)(total_count, probs)
 
 
 @defterm.register
 def _embed_multivariate_normal(d: dist.MultivariateNormal) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.MultivariateNormal)(
-            d.loc, scale_tril=d.scale_tril
-        )
+        loc = d.loc
+        scale_tril = d.scale_tril
+    
+    return _register_distribution_op(dist.MultivariateNormal)(
+        loc, scale_tril=scale_tril
+    )
 
 
 @defterm.register
 def _embed_negative_binomial(d: dist.NegativeBinomial) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.NegativeBinomial)(d.total_count, d.probs)
+        total_count = d.total_count
+        probs = d.probs
+    
+    return _register_distribution_op(dist.NegativeBinomial)(total_count, probs)
 
 
 @defterm.register
 def _embed_pareto(d: dist.Pareto) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Pareto)(d.scale, d.alpha)
+        scale = d.scale
+        alpha = d.alpha
+    
+    return _register_distribution_op(dist.Pareto)(scale, alpha)
 
 
 @defterm.register
 def _embed_poisson(d: dist.Poisson) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Poisson)(d.rate)
+        rate = d.rate
+    
+    return _register_distribution_op(dist.Poisson)(rate)
 
 
 @defterm.register(dist.RelaxedBernoulli)
 @defterm.register(dist.RelaxedOneHotCategorical)
 def _embed_relaxed(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(type(d))(d.temperature, d.probs)
+        temperature = d.temperature
+        probs = d.probs
+        dist_type = type(d)
+    
+    return _register_distribution_op(dist_type)(temperature, probs)
 
 
 @defterm.register
 def _embed_uniform(d: dist.Uniform) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Uniform)(d.low, d.high)
+        low = d.low
+        high = d.high
+    
+    return _register_distribution_op(dist.Uniform)(low, high)
 
 
 @defterm.register
 def _embed_von_mises(d: dist.VonMises) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.VonMises)(d.loc, d.concentration)
+        loc = d.loc
+        concentration = d.concentration
+    
+    return _register_distribution_op(dist.VonMises)(loc, concentration)
 
 
 @defterm.register
 def _embed_weibull(d: dist.Weibull) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Weibull)(d.scale, d.concentration)
+        scale = d.scale
+        concentration = d.concentration
+    
+    return _register_distribution_op(dist.Weibull)(scale, concentration)
 
 
 @defterm.register
 def _embed_wishart(d: dist.Wishart) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Wishart)(d.df, d.scale_tril)
+        df = d.df
+        scale_tril = d.scale_tril
+    
+    return _register_distribution_op(dist.Wishart)(df, scale_tril)
 
 
 @defterm.register
 def _embed_delta(d: dist.Delta) -> Term[TorchDistribution]:
     with interpreter({}):
-        return _register_distribution_op(dist.Delta)(
-            d.v, log_density=d.log_density, event_dim=d.event_dim
-        )
+        v = d.v
+        log_density = d.log_density
+        event_dim = d.event_dim
+    
+    return _register_distribution_op(dist.Delta)(
+        v, log_density=log_density, event_dim=event_dim
+    )
 
 
 def pyro_module_shim(

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -555,7 +555,7 @@ def _embed_expanded(d: dist.ExpandedDistribution) -> Term[TorchDistribution]:
         base_batch_shape = base_dist.batch_shape
         if batch_shape == base_batch_shape:
             return base_dist
-    
+
     raise ValueError("Nontrivial ExpandedDistribution not implemented.")
 
 
@@ -564,7 +564,7 @@ def _embed_independent(d: dist.Independent) -> Term[TorchDistribution]:
     with interpreter({}):
         base_dist = d.base_dist
         reinterpreted_batch_ndims = d.reinterpreted_batch_ndims
-    
+
     return _register_distribution_op(type(d))(base_dist, reinterpreted_batch_ndims)
 
 
@@ -572,7 +572,7 @@ def _embed_independent(d: dist.Independent) -> Term[TorchDistribution]:
 def _embed_folded(d: dist.FoldedDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         base_dist = d.base_dist
-    
+
     return _register_distribution_op(type(d))(base_dist)  # type: ignore
 
 
@@ -581,7 +581,7 @@ def _embed_masked(d: dist.MaskedDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         base_dist = d.base_dist
         mask = d._mask
-    
+
     return _register_distribution_op(type(d))(base_dist, mask)
 
 
@@ -597,7 +597,7 @@ def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         loc = d.loc
         scale = d.scale
-    
+
     return _register_distribution_op(type(d))(loc, scale)
 
 
@@ -610,7 +610,7 @@ def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
 def _embed_probs(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         probs = d.probs
-    
+
     return _register_distribution_op(type(d))(probs)
 
 
@@ -620,7 +620,7 @@ def _embed_beta(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         concentration1 = d.concentration1
         concentration0 = d.concentration0
-    
+
     return _register_distribution_op(type(d))(concentration1, concentration0)
 
 
@@ -629,7 +629,7 @@ def _embed_binomial(d: dist.Binomial) -> Term[TorchDistribution]:
     with interpreter({}):
         total_count = d.total_count
         probs = d.probs
-    
+
     return _register_distribution_op(dist.Binomial)(total_count, probs)
 
 
@@ -637,7 +637,7 @@ def _embed_binomial(d: dist.Binomial) -> Term[TorchDistribution]:
 def _embed_chi2(d: dist.Chi2) -> Term[TorchDistribution]:
     with interpreter({}):
         df = d.df
-    
+
     return _register_distribution_op(dist.Chi2)(df)
 
 
@@ -645,7 +645,7 @@ def _embed_chi2(d: dist.Chi2) -> Term[TorchDistribution]:
 def _embed_dirichlet(d: dist.Dirichlet) -> Term[TorchDistribution]:
     with interpreter({}):
         concentration = d.concentration
-    
+
     return _register_distribution_op(dist.Dirichlet)(concentration)
 
 
@@ -653,7 +653,7 @@ def _embed_dirichlet(d: dist.Dirichlet) -> Term[TorchDistribution]:
 def _embed_exponential(d: dist.Exponential) -> Term[TorchDistribution]:
     with interpreter({}):
         rate = d.rate
-    
+
     return _register_distribution_op(dist.Exponential)(rate)
 
 
@@ -662,7 +662,7 @@ def _embed_fisher_snedecor(d: dist.FisherSnedecor) -> Term[TorchDistribution]:
     with interpreter({}):
         df1 = d.df1
         df2 = d.df2
-    
+
     return _register_distribution_op(dist.FisherSnedecor)(df1, df2)
 
 
@@ -671,7 +671,7 @@ def _embed_gamma(d: dist.Gamma) -> Term[TorchDistribution]:
     with interpreter({}):
         concentration = d.concentration
         rate = d.rate
-    
+
     return _register_distribution_op(dist.Gamma)(concentration, rate)
 
 
@@ -680,7 +680,7 @@ def _embed_gamma(d: dist.Gamma) -> Term[TorchDistribution]:
 def _embed_half_cauchy(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         scale = d.scale
-    
+
     return _register_distribution_op(type(d))(scale)
 
 
@@ -689,10 +689,8 @@ def _embed_lkj_cholesky(d: dist.LKJCholesky) -> Term[TorchDistribution]:
     with interpreter({}):
         dim = d.dim
         concentration = d.concentration
-    
-    return _register_distribution_op(dist.LKJCholesky)(
-        dim, concentration=concentration
-    )
+
+    return _register_distribution_op(dist.LKJCholesky)(dim, concentration=concentration)
 
 
 @defterm.register
@@ -700,7 +698,7 @@ def _embed_multinomial(d: dist.Multinomial) -> Term[TorchDistribution]:
     with interpreter({}):
         total_count = d.total_count
         probs = d.probs
-    
+
     return _register_distribution_op(dist.Multinomial)(total_count, probs)
 
 
@@ -709,7 +707,7 @@ def _embed_multivariate_normal(d: dist.MultivariateNormal) -> Term[TorchDistribu
     with interpreter({}):
         loc = d.loc
         scale_tril = d.scale_tril
-    
+
     return _register_distribution_op(dist.MultivariateNormal)(
         loc, scale_tril=scale_tril
     )
@@ -720,7 +718,7 @@ def _embed_negative_binomial(d: dist.NegativeBinomial) -> Term[TorchDistribution
     with interpreter({}):
         total_count = d.total_count
         probs = d.probs
-    
+
     return _register_distribution_op(dist.NegativeBinomial)(total_count, probs)
 
 
@@ -729,7 +727,7 @@ def _embed_pareto(d: dist.Pareto) -> Term[TorchDistribution]:
     with interpreter({}):
         scale = d.scale
         alpha = d.alpha
-    
+
     return _register_distribution_op(dist.Pareto)(scale, alpha)
 
 
@@ -737,7 +735,7 @@ def _embed_pareto(d: dist.Pareto) -> Term[TorchDistribution]:
 def _embed_poisson(d: dist.Poisson) -> Term[TorchDistribution]:
     with interpreter({}):
         rate = d.rate
-    
+
     return _register_distribution_op(dist.Poisson)(rate)
 
 
@@ -747,7 +745,7 @@ def _embed_relaxed(d: TorchDistribution) -> Term[TorchDistribution]:
     with interpreter({}):
         temperature = d.temperature
         probs = d.probs
-    
+
     return _register_distribution_op(type(d))(temperature, probs)
 
 
@@ -756,7 +754,7 @@ def _embed_uniform(d: dist.Uniform) -> Term[TorchDistribution]:
     with interpreter({}):
         low = d.low
         high = d.high
-    
+
     return _register_distribution_op(dist.Uniform)(low, high)
 
 
@@ -765,7 +763,7 @@ def _embed_von_mises(d: dist.VonMises) -> Term[TorchDistribution]:
     with interpreter({}):
         loc = d.loc
         concentration = d.concentration
-    
+
     return _register_distribution_op(dist.VonMises)(loc, concentration)
 
 
@@ -774,7 +772,7 @@ def _embed_weibull(d: dist.Weibull) -> Term[TorchDistribution]:
     with interpreter({}):
         scale = d.scale
         concentration = d.concentration
-    
+
     return _register_distribution_op(dist.Weibull)(scale, concentration)
 
 
@@ -783,7 +781,7 @@ def _embed_wishart(d: dist.Wishart) -> Term[TorchDistribution]:
     with interpreter({}):
         df = d.df
         scale_tril = d.scale_tril
-    
+
     return _register_distribution_op(dist.Wishart)(df, scale_tril)
 
 
@@ -793,7 +791,7 @@ def _embed_delta(d: dist.Delta) -> Term[TorchDistribution]:
         v = d.v
         log_density = d.log_density
         event_dim = d.event_dim
-    
+
     return _register_distribution_op(dist.Delta)(
         v, log_density=log_density, event_dim=event_dim
     )

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -549,24 +549,28 @@ def _embed_distribution(dist: TorchDistribution) -> Term[TorchDistribution]:
 
 @defterm.register
 def _embed_expanded(d: dist.ExpandedDistribution) -> Term[TorchDistribution]:
-    if d._batch_shape == d.base_dist.batch_shape:
-        return d.base_dist
-    raise ValueError("Nontrivial ExpandedDistribution not implemented.")
+    with interpreter({}):
+        if d._batch_shape == d.base_dist.batch_shape:
+            return d.base_dist
+        raise ValueError("Nontrivial ExpandedDistribution not implemented.")
 
 
 @defterm.register
 def _embed_independent(d: dist.Independent) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.base_dist, d.reinterpreted_batch_ndims)
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.base_dist, d.reinterpreted_batch_ndims)
 
 
 @defterm.register
 def _embed_folded(d: dist.FoldedDistribution) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.base_dist)  # type: ignore
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.base_dist)  # type: ignore
 
 
 @defterm.register
 def _embed_masked(d: dist.MaskedDistribution) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.base_dist, d._mask)
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.base_dist, d._mask)
 
 
 @defterm.register(dist.Cauchy)
@@ -578,7 +582,8 @@ def _embed_masked(d: dist.MaskedDistribution) -> Term[TorchDistribution]:
 @defterm.register(dist.Normal)
 @defterm.register(dist.StudentT)
 def _embed_loc_scale(d: TorchDistribution) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.loc, d.scale)
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.loc, d.scale)
 
 
 @defterm.register(dist.Bernoulli)
@@ -607,100 +612,118 @@ def _embed_binomial(d: dist.Binomial) -> Term[TorchDistribution]:
 
 @defterm.register
 def _embed_chi2(d: dist.Chi2) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Chi2)(d.df)
+    with interpreter({}):
+        return _register_distribution_op(dist.Chi2)(d.df)
 
 
 @defterm.register
 def _embed_dirichlet(d: dist.Dirichlet) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Dirichlet)(d.concentration)
+    with interpreter({}):
+        return _register_distribution_op(dist.Dirichlet)(d.concentration)
 
 
 @defterm.register
 def _embed_exponential(d: dist.Exponential) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Exponential)(d.rate)
+    with interpreter({}):
+        return _register_distribution_op(dist.Exponential)(d.rate)
 
 
 @defterm.register
 def _embed_fisher_snedecor(d: dist.FisherSnedecor) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.FisherSnedecor)(d.df1, d.df2)
+    with interpreter({}):
+        return _register_distribution_op(dist.FisherSnedecor)(d.df1, d.df2)
 
 
 @defterm.register
 def _embed_gamma(d: dist.Gamma) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Gamma)(d.concentration, d.rate)
+    with interpreter({}):
+        return _register_distribution_op(dist.Gamma)(d.concentration, d.rate)
 
 
 @defterm.register(dist.HalfCauchy)
 @defterm.register(dist.HalfNormal)
 def _embed_half_cauchy(d: TorchDistribution) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.scale)
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.scale)
 
 
 @defterm.register
 def _embed_lkj_cholesky(d: dist.LKJCholesky) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.LKJCholesky)(
-        d.dim, concentration=d.concentration
-    )
+    with interpreter({}):
+        return _register_distribution_op(dist.LKJCholesky)(
+            d.dim, concentration=d.concentration
+        )
 
 
 @defterm.register
 def _embed_multinomial(d: dist.Multinomial) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Multinomial)(d.total_count, d.probs)
+    with interpreter({}):
+        return _register_distribution_op(dist.Multinomial)(d.total_count, d.probs)
 
 
 @defterm.register
 def _embed_multivariate_normal(d: dist.MultivariateNormal) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.MultivariateNormal)(
-        d.loc, scale_tril=d.scale_tril
-    )
+    with interpreter({}):
+        return _register_distribution_op(dist.MultivariateNormal)(
+            d.loc, scale_tril=d.scale_tril
+        )
 
 
 @defterm.register
 def _embed_negative_binomial(d: dist.NegativeBinomial) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.NegativeBinomial)(d.total_count, d.probs)
+    with interpreter({}):
+        return _register_distribution_op(dist.NegativeBinomial)(d.total_count, d.probs)
 
 
 @defterm.register
 def _embed_pareto(d: dist.Pareto) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Pareto)(d.scale, d.alpha)
+    with interpreter({}):
+        return _register_distribution_op(dist.Pareto)(d.scale, d.alpha)
 
 
 @defterm.register
 def _embed_poisson(d: dist.Poisson) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Poisson)(d.rate)
+    with interpreter({}):
+        return _register_distribution_op(dist.Poisson)(d.rate)
 
 
 @defterm.register(dist.RelaxedBernoulli)
 @defterm.register(dist.RelaxedOneHotCategorical)
 def _embed_relaxed(d: TorchDistribution) -> Term[TorchDistribution]:
-    return _register_distribution_op(type(d))(d.temperature, d.probs)
+    with interpreter({}):
+        return _register_distribution_op(type(d))(d.temperature, d.probs)
 
 
 @defterm.register
 def _embed_uniform(d: dist.Uniform) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Uniform)(d.low, d.high)
+    with interpreter({}):
+        return _register_distribution_op(dist.Uniform)(d.low, d.high)
 
 
 @defterm.register
 def _embed_von_mises(d: dist.VonMises) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.VonMises)(d.loc, d.concentration)
+    with interpreter({}):
+        return _register_distribution_op(dist.VonMises)(d.loc, d.concentration)
 
 
 @defterm.register
 def _embed_weibull(d: dist.Weibull) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Weibull)(d.scale, d.concentration)
+    with interpreter({}):
+        return _register_distribution_op(dist.Weibull)(d.scale, d.concentration)
 
 
 @defterm.register
 def _embed_wishart(d: dist.Wishart) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Wishart)(d.df, d.scale_tril)
+    with interpreter({}):
+        return _register_distribution_op(dist.Wishart)(d.df, d.scale_tril)
 
 
 @defterm.register
 def _embed_delta(d: dist.Delta) -> Term[TorchDistribution]:
-    return _register_distribution_op(dist.Delta)(
-        d.v, log_density=d.log_density, event_dim=d.event_dim
-    )
+    with interpreter({}):
+        return _register_distribution_op(dist.Delta)(
+            d.v, log_density=d.log_density, event_dim=d.event_dim
+        )
 
 
 def pyro_module_shim(

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -343,10 +343,12 @@ PyroDistribution = (
 )
 
 
-@_unbind_dims.register
+@_unbind_dims.register(pyro.distributions.torch_distribution.TorchDistribution)
+@_unbind_dims.register(pyro.distributions.torch_distribution.TorchDistributionMixin)
 def _unbind_dims_distribution(
-    value: PyroDistribution, *names: Operation[[], torch.Tensor]
-) -> PyroDistribution:
+    value: pyro.distributions.torch_distribution.TorchDistribution,
+    *names: Operation[[], torch.Tensor],
+) -> pyro.distributions.torch_distribution.TorchDistribution:
     d = value
     batch_shape = None
 
@@ -388,10 +390,12 @@ def _unbind_dims_distribution(
     return new_d
 
 
-@_bind_dims.register
+@_bind_dims.register(pyro.distributions.torch_distribution.TorchDistribution)
+@_bind_dims.register(pyro.distributions.torch_distribution.TorchDistributionMixin)
 def _bind_dims_distribution(
-    value: PyroDistribution, *names: Operation[[], torch.Tensor]
-) -> PyroDistribution:
+    value: pyro.distributions.torch_distribution.TorchDistribution,
+    *names: Operation[[], torch.Tensor],
+) -> pyro.distributions.torch_distribution.TorchDistribution:
     d = value
 
     def _to_positional(a, indices):

--- a/effectful/handlers/torch.py
+++ b/effectful/handlers/torch.py
@@ -277,7 +277,7 @@ def _unbind_dims_tensor(
     value: torch.Tensor,
     *names: Annotated[Operation[[], torch.Tensor], Scoped[B]],
 ) -> Annotated[torch.Tensor, Scoped[A | B]]:
-    return value[*[n() for n in names]]
+    return value[tuple(n() for n in names)]
 
 
 @defop

--- a/tests/test_handlers_indexed.py
+++ b/tests/test_handlers_indexed.py
@@ -16,7 +16,7 @@ from effectful.handlers.indexed import (
     name_to_sym,
     stack,
 )
-from effectful.handlers.torch import sizesof, to_tensor
+from effectful.handlers.torch import bind_dims, sizesof
 from effectful.ops.semantics import evaluate, handler
 from effectful.ops.syntax import deffn
 
@@ -239,5 +239,5 @@ def test_cond_tensor_associate(enum_shape, batch_shape, plate_shape, event_shape
     )
 
     vars = list(map(name_to_sym, name_to_dim.keys()))
-    assert (to_tensor(actual_full, *vars) == to_tensor(actual_left, *vars)).all()
-    assert (to_tensor(actual_left, *vars) == to_tensor(actual_right, *vars)).all()
+    assert (bind_dims(actual_full, *vars) == bind_dims(actual_left, *vars)).all()
+    assert (bind_dims(actual_left, *vars) == bind_dims(actual_right, *vars)).all()

--- a/tests/test_handlers_pyro.py
+++ b/tests/test_handlers_pyro.py
@@ -7,13 +7,8 @@ import pyro.distributions as dist
 import pytest
 import torch
 
-from effectful.handlers.pyro import (
-    PyroShim,
-    named_distribution,
-    positional_distribution,
-    pyro_sample,
-)
-from effectful.handlers.torch import sizesof, torch_getitem
+from effectful.handlers.pyro import Naming, PyroShim, pyro_sample
+from effectful.handlers.torch import bind_dims, sizesof, torch_getitem, unbind_dims
 from effectful.ops.semantics import fvsof, fwd, handler
 from effectful.ops.syntax import defop
 
@@ -181,7 +176,7 @@ def test_indexed_sample():
 
 def test_named_dist():
     x, y = defop(torch.Tensor, name="x"), defop(torch.Tensor, name="y")
-    d = named_distribution(dist.Normal(0.0, 1.0).expand((2, 3)), x, y)
+    d = unbind_dims(dist.Normal(0.0, 1.0).expand((2, 3)), x, y)
 
     expected_indices = {x: 2, y: 3}
 
@@ -205,32 +200,38 @@ def test_positional_dist():
 
     expected_indices = {x: 2, y: 3}
 
-    d, naming = positional_distribution(dist.Normal(loc, scale))
+    i_dist = dist.Normal(loc, scale)
+    sizes = sizesof(i_dist)
+    naming = Naming.from_shape(sizes.keys(), len(i_dist.shape()))
+    p_dist = bind_dims(i_dist, *sizes.keys())
 
-    assert d.shape() == torch.Size([2, 3])
+    assert p_dist.shape() == torch.Size([2, 3])
 
-    s1 = d.sample()
+    s1 = p_dist.sample()
     assert sizesof(s1) == {}
     assert s1.shape == torch.Size([2, 3])
     assert all(n in sizesof(naming.apply(s1)) for n in [x, y])
 
-    d_exp = d.expand((4, 5) + d.batch_shape)
+    d_exp = p_dist.expand((4, 5) + p_dist.batch_shape)
     s2 = d_exp.sample()
     assert sizesof(s2) == {}
     assert s2.shape == torch.Size([4, 5, 2, 3])
 
-    s3 = d.sample((4, 5))
+    s3 = p_dist.sample((4, 5))
     assert sizesof(s3) == {}
     assert s3.shape == torch.Size([4, 5, 2, 3])
     assert all(n in sizesof(naming.apply(s3)) for n in [x, y])
 
     loc = (torch.tensor(0.0).expand((2, 3, 4, 5)))[x(), y()]
     scale = (torch.tensor(1.0).expand((2, 3, 4, 5)))[x(), y()]
-    d, naming = positional_distribution(dist.Normal(loc, scale))
+    i_dist = dist.Normal(loc, scale)
+    sizes = sizesof(i_dist)
+    naming = Naming.from_shape(sizes.keys(), len(i_dist.shape()))
+    p_dist = bind_dims(i_dist, *sizes.keys())
 
-    assert sizesof(naming.apply(d.sample((6, 7)))) == expected_indices
-    assert d.sample().shape == torch.Size([2, 3, 4, 5])
-    assert d.sample((6, 7)).shape == torch.Size([6, 7, 2, 3, 4, 5])
+    assert sizesof(naming.apply(p_dist.sample((6, 7)))) == expected_indices
+    assert p_dist.sample().shape == torch.Size([2, 3, 4, 5])
+    assert p_dist.sample((6, 7)).shape == torch.Size([6, 7, 2, 3, 4, 5])
 
 
 def test_simple_distribution():
@@ -242,17 +243,16 @@ def test_simple_distribution():
     dist.Bernoulli(t, validate_args=False)
 
 
-def test_sizesof_named_distribution():
+def test_sizesof_unbind_dims():
     # Create base distribution with known batch shape
     base_dist = dist.Normal(torch.zeros(3, 4, 5), torch.ones(3, 4, 5))
 
     # Create names for the first two dimensions
     dim0 = defop(torch.Tensor, name="dim0")
     dim1 = defop(torch.Tensor, name="dim1")
-    names = [dim0, dim1]
 
     # Create named distribution
-    named_dist = named_distribution(base_dist, *names)
+    named_dist = unbind_dims(base_dist, dim0, dim1)
 
     # Get sizes
     sizes = sizesof(named_dist)
@@ -263,7 +263,7 @@ def test_sizesof_named_distribution():
     assert len(sizes) == 2  # Only named dimensions should be included
 
 
-def test_sizesof_positional_distribution():
+def test_sizesof_bind_dims():
     dim0 = defop(torch.Tensor, name="dim0")
     dim1 = defop(torch.Tensor, name="dim1")
 
@@ -271,6 +271,6 @@ def test_sizesof_positional_distribution():
     var = (torch.ones(3, 4, 5))[dim0(), dim1()]
     base_dist = dist.Normal(mean, var)
 
-    pos_dist = positional_distribution(base_dist)
+    pos_dist = bind_dims(base_dist, dim0, dim1)
 
     assert sizesof(pos_dist) == {}

--- a/tests/test_handlers_pyro_dist.py
+++ b/tests/test_handlers_pyro_dist.py
@@ -789,12 +789,3 @@ def test_dist_stats(case_, statistic):
         assert_close(
             bind_dims(expected_stat_i, *indexes), bind_dims(actual_stat_i, *indexes)
         )
-
-
-def test_dist_sizesof():
-    i = defop(torch.Tensor)
-    d = dist.Bernoulli(logits=rand(3)[i()])
-    s1 = str(d)
-    sizesof(d)
-    s2 = str(d)
-    assert s1 == s2

--- a/tests/test_handlers_pyro_dist.py
+++ b/tests/test_handlers_pyro_dist.py
@@ -13,6 +13,7 @@ from torch import exp, rand, randint  # noqa: F401
 #################################################
 from torch.testing import assert_close
 
+import effectful.handlers.pyro
 from effectful.handlers.indexed import name_to_sym
 from effectful.handlers.torch import bind_dims, sizesof, unbind_dims
 from effectful.ops.syntax import defop

--- a/tests/test_handlers_pyro_dist.py
+++ b/tests/test_handlers_pyro_dist.py
@@ -789,3 +789,12 @@ def test_dist_stats(case_, statistic):
         assert_close(
             bind_dims(expected_stat_i, *indexes), bind_dims(actual_stat_i, *indexes)
         )
+
+
+def test_dist_sizesof():
+    i = defop(torch.Tensor)
+    d = dist.Bernoulli(logits=rand(3)[i()])
+    s1 = str(d)
+    sizesof(d)
+    s2 = str(d)
+    assert s1 == s2

--- a/tests/test_handlers_pyro_dist.py
+++ b/tests/test_handlers_pyro_dist.py
@@ -14,8 +14,7 @@ from torch import exp, rand, randint  # noqa: F401
 from torch.testing import assert_close
 
 from effectful.handlers.indexed import name_to_sym
-from effectful.handlers.pyro import named_distribution, positional_distribution
-from effectful.handlers.torch import sizesof, to_tensor
+from effectful.handlers.torch import bind_dims, sizesof, unbind_dims
 from effectful.ops.syntax import defop
 
 ##################################################
@@ -47,7 +46,7 @@ def from_indexed(tensor, batch_dims):
     tensor_sizes = sizesof(tensor)
     indices = [name_to_sym(str(i)) for i in range(batch_dims)]
     indices = [i for i in indices if i in tensor_sizes]
-    return to_tensor(tensor, *indices)
+    return bind_dims(tensor, *indices)
 
 
 class DistTestCase:
@@ -622,7 +621,8 @@ def test_dist_to_positional(case_):
     _, indexed_dist = case_.get_dist()
 
     try:
-        pos_dist, naming = positional_distribution(indexed_dist)
+        sizes = sizesof(indexed_dist)
+        pos_dist = bind_dims(indexed_dist, *sizes.keys())
         pos_sample = pos_dist.sample()
         assert sizesof(pos_sample) == {}
         indexed_sample = indexed_dist.sample()
@@ -645,7 +645,7 @@ def test_dist_to_named(case_):
     try:
         dist, _ = case_.get_dist()
         indexes = [name_to_sym(str(i)) for i in range(len(case_.batch_shape))]
-        indexed_dist = named_distribution(dist, *indexes)
+        indexed_dist = unbind_dims(dist, *indexes)
 
         indexed_sample = indexed_dist.sample()
         assert set(sizesof(indexed_sample)) == set(indexes)
@@ -778,7 +778,7 @@ def test_dist_stats(case_, statistic):
         pytest.xfail(f"{statistic} not implemented")
 
     if expected_stat.isnan().all():
-        assert to_tensor(actual_stat).isnan().all()
+        assert bind_dims(actual_stat).isnan().all()
     else:
         # Stats may not be indexed in all batch dimensions, but they should be
         # extensionally equal to the indexed expected stat
@@ -788,5 +788,5 @@ def test_dist_stats(case_, statistic):
             expected_stat_i, actual_stat
         )
         assert_close(
-            to_tensor(expected_stat_i, *indexes), to_tensor(actual_stat_i, *indexes)
+            bind_dims(expected_stat_i, *indexes), bind_dims(actual_stat_i, *indexes)
         )

--- a/tests/test_handlers_pyro_dist.py
+++ b/tests/test_handlers_pyro_dist.py
@@ -13,7 +13,7 @@ from torch import exp, rand, randint  # noqa: F401
 #################################################
 from torch.testing import assert_close
 
-import effectful.handlers.pyro
+import effectful.handlers.pyro  # noqa: F401
 from effectful.handlers.indexed import name_to_sym
 from effectful.handlers.torch import bind_dims, sizesof, unbind_dims
 from effectful.ops.syntax import defop

--- a/tests/test_handlers_torch.py
+++ b/tests/test_handlers_torch.py
@@ -6,13 +6,13 @@ import torch
 from typing_extensions import ParamSpec
 
 from effectful.handlers.torch import (
+    bind_dims,
     grad,
     hessian,
     jacfwd,
     jacrev,
     jvp,
     sizesof,
-    to_tensor,
     torch_getitem,
     vjp,
     vmap,
@@ -288,14 +288,14 @@ def test_grad_1():
 
     cos_x_expected = x.cos()
 
-    assert torch.allclose(to_tensor(cos_x_actual, i), to_tensor(cos_x_expected, i))
+    assert torch.allclose(bind_dims(cos_x_actual, i), bind_dims(cos_x_expected, i))
 
     # Second-order gradients
     neg_sin_x_actual = grad(grad(lambda x: torch.sin(x)))(x)
     neg_sin_x_expected = -x.sin()
 
     assert torch.allclose(
-        to_tensor(neg_sin_x_actual, i), to_tensor(neg_sin_x_expected, i)
+        bind_dims(neg_sin_x_actual, i), bind_dims(neg_sin_x_expected, i)
     )
 
 
@@ -305,7 +305,7 @@ def test_jacfwd_1():
     jacobian = jacfwd(torch.sin)(x)
     expected = torch.diag(torch.cos(x))
 
-    assert torch.allclose(to_tensor(jacobian, i), to_tensor(expected, i))
+    assert torch.allclose(bind_dims(jacobian, i), bind_dims(expected, i))
 
 
 def test_jacfwd_nested_1():
@@ -320,7 +320,7 @@ def test_jacfwd_nested_1():
     jacobian = jacfwd(sin)(x)
     expected = torch.diag(torch.cos(x) + 0 * y)
 
-    assert torch.allclose(to_tensor(jacobian, i, a), to_tensor(expected, i, a))
+    assert torch.allclose(bind_dims(jacobian, i, a), bind_dims(expected, i, a))
 
 
 def test_jacfwd_nested_2():
@@ -335,7 +335,7 @@ def test_jacfwd_nested_2():
     jacobian = jacfwd(sin)(x)[0]
     expected = torch.diag(torch.cos(x))
 
-    assert torch.allclose(to_tensor(jacobian, i), to_tensor(expected, i))
+    assert torch.allclose(bind_dims(jacobian, i), bind_dims(expected, i))
 
 
 def test_jacrev_1():
@@ -344,7 +344,7 @@ def test_jacrev_1():
     jacobian = jacrev(torch.sin)(x)
     expected = torch.diag(torch.cos(x))
 
-    assert torch.allclose(to_tensor(jacobian, i), to_tensor(expected, i))
+    assert torch.allclose(bind_dims(jacobian, i), bind_dims(expected, i))
 
 
 def test_hessian_1():
@@ -354,7 +354,7 @@ def test_hessian_1():
     i = defop(torch.Tensor, name="i")
     x = torch.randn(11, 5)[i()]
     hess = hessian(f)(x)  # equivalent to jacfwd(jacrev(f))(x)
-    assert torch.allclose(to_tensor(hess, i), to_tensor(torch.diag(-x.sin()), i))
+    assert torch.allclose(bind_dims(hess, i), bind_dims(torch.diag(-x.sin()), i))
 
 
 def test_jvp_1():
@@ -366,8 +366,8 @@ def test_jvp_1():
 
     value, grad = jvp(f, (x,), (torch.tensor(1.0),))
 
-    assert torch.allclose(to_tensor(value, i), to_tensor(f(x), i))
-    assert torch.allclose(to_tensor(grad, i), torch.tensor([1.0, 2, 3]))
+    assert torch.allclose(bind_dims(value, i), bind_dims(f(x), i))
+    assert torch.allclose(bind_dims(grad, i), torch.tensor([1.0, 2, 3]))
 
 
 def test_jvp_nested():
@@ -381,8 +381,8 @@ def test_jvp_nested():
 
     value, grad = jvp(f, (x,), (torch.tensor(1.0),))
 
-    assert torch.allclose(to_tensor(value, i, j), to_tensor(f(x), i, j))
-    assert torch.allclose(to_tensor(grad, i, j), torch.tensor([1.0, 2, 3]))
+    assert torch.allclose(bind_dims(value, i, j), bind_dims(f(x), i, j))
+    assert torch.allclose(bind_dims(grad, i, j), torch.tensor([1.0, 2, 3]))
 
 
 def test_vjp_1():
@@ -396,7 +396,7 @@ def test_vjp_1():
 
     (_, vjpfunc) = vjp(f, x)
     vjps = vjpfunc((y, z))
-    assert torch.allclose(to_tensor(vjps[0], i), to_tensor(x.cos() + -x.sin(), i))
+    assert torch.allclose(bind_dims(vjps[0], i), bind_dims(x.cos() + -x.sin(), i))
 
 
 def test_vjp_nested():
@@ -411,7 +411,7 @@ def test_vjp_nested():
 
     (result, vjpfunc) = vjp(f, x)
     vjps = vjpfunc(y)
-    assert torch.allclose(to_tensor(vjps[0], i), torch.tensor(7.0))
+    assert torch.allclose(bind_dims(vjps[0], i), torch.tensor(7.0))
 
 
 def test_vmap_1():
@@ -424,7 +424,7 @@ def test_vmap_1():
 
     actual = vmap(f)(x_i)
     expected = x + 1
-    assert torch.allclose(to_tensor(actual, i), expected)
+    assert torch.allclose(bind_dims(actual, i), expected)
 
 
 def test_vmap_nested():
@@ -439,7 +439,7 @@ def test_vmap_nested():
         return y_j + x
 
     actual = vmap(f)(x_i)
-    actual_t = to_tensor(actual, i, j)
+    actual_t = bind_dims(actual, i, j)
 
     for ii in range(10):
         for jj in range(7):
@@ -457,8 +457,8 @@ def test_vmap_and_grad():
     actual = vmap(grad_sin)(x)
     assert actual.shape == torch.Size([7])
 
-    actual_t = to_tensor(actual, i)
-    x_t = to_tensor(x, i)
+    actual_t = bind_dims(actual, i)
+    x_t = bind_dims(x, i)
     for ii in range(10):
         for jj in range(7):
             assert torch.allclose(actual_t[ii, jj], x_t[ii, jj].cos())
@@ -472,8 +472,8 @@ def test_index_incompatible():
     torch.randn(2, 2)[i(), i()]
 
 
-def test_to_tensor():
-    """Test to_tensor's handling of free variables and tensor shapes"""
+def test_bind_dims():
+    """Test bind_dims's handling of free variables and tensor shapes"""
     i, j, k = (
         defop(torch.Tensor, name="i"),
         defop(torch.Tensor, name="j"),
@@ -485,41 +485,41 @@ def test_to_tensor():
     t_ijk = t[i(), j(), k()]
     assert fvsof(t_ijk) >= {i, j, k}
 
-    t1 = to_tensor(t_ijk, i, j, k)
+    t1 = bind_dims(t_ijk, i, j, k)
     assert not (fvsof(t1) & {i, j, k})
     assert t1.shape == torch.Size([2, 3, 4])
 
     # Test case 2: Different ordering of dimensions
-    t2 = to_tensor(t_ijk, k, j, i)
+    t2 = bind_dims(t_ijk, k, j, i)
     assert not (fvsof(t1) & {i, j, k})
     assert t2.shape == torch.Size([4, 3, 2])
 
     # Test case 3: Keeping some dimensions as free variables
-    t3 = to_tensor(t_ijk, i)  # Convert only i to positional
+    t3 = bind_dims(t_ijk, i)  # Convert only i to positional
     assert fvsof(t3) >= {j, k}  # j and k remain free
     assert isinstance(t3, Term)
     assert t3.shape == torch.Size([2])
 
-    t4 = to_tensor(t_ijk, i, j)  # Convert i and j to positional
+    t4 = bind_dims(t_ijk, i, j)  # Convert i and j to positional
     assert fvsof(t4) >= {k} and not (fvsof(t4) & {i, j})  # only k remains free
     assert isinstance(t4, Term)
     assert t4.shape == torch.Size([2, 3])
 
     # Test case 4: Empty order list keeps all variables free
-    t5 = to_tensor(t_ijk)
+    t5 = bind_dims(t_ijk)
     assert fvsof(t5) >= {i, j, k}  # All variables remain free
     assert isinstance(t5, Term)
     assert t5.shape == torch.Size([])
 
     # Test case 5: Verify permuted tensors maintain correct relationships
     t_kji = t.permute(2, 1, 0)[k(), j(), i()]
-    t6 = to_tensor(t_kji, i, j, k)
-    t7 = to_tensor(t_ijk, i, j, k)
+    t6 = bind_dims(t_kji, i, j, k)
+    t7 = bind_dims(t_ijk, i, j, k)
     assert torch.allclose(t6, t7)
 
     # Test case 6: Mixed operations with free variables
     x = torch.sin(t_ijk)  # Apply operation to indexed tensor
-    x1 = to_tensor(x, i, j)  # Convert some dimensions
+    x1 = bind_dims(x, i, j)  # Convert some dimensions
     assert fvsof(x1) >= {k}  # k remains free
     assert isinstance(x1, Term)
     assert x1.shape == torch.Size([2, 3])
@@ -527,7 +527,7 @@ def test_to_tensor():
     # Test case 7: Multiple tensors sharing variables
     t2_ijk = torch.randn([2, 3, 4])[i(), j(), k()]
     sum_t = t_ijk + t2_ijk
-    sum1 = to_tensor(sum_t, i, j)
+    sum1 = bind_dims(sum_t, i, j)
     assert fvsof(sum1) >= {k}  # k remains free
     assert isinstance(sum1, Term)
     assert sum1.shape == torch.Size([2, 3])
@@ -535,7 +535,7 @@ def test_to_tensor():
     # Test case 8: Tensor term with non-sized free variables
     w = defop(torch.Tensor, name="w")
     t_ijk = t[i(), j(), k()] + w()
-    t8 = to_tensor(t_ijk, i, j, k)
+    t8 = bind_dims(t_ijk, i, j, k)
     assert fvsof(t8) >= {w}
 
     # Test case 9: Eliminate remaining free variables in result
@@ -613,7 +613,7 @@ def test_indexed_tensor_as_index():
 
     t3 = t1[t2]
     assert sizesof(t3) == sizesof(t2)
-    assert (to_tensor(t3, i) == t1).all()
+    assert (bind_dims(t3, i) == t1).all()
 
 
 def test_longtensor_index_variables():


### PR DESCRIPTION
As discussed here https://github.com/BasisResearch/effectful/issues/203#issuecomment-2627794884, introduce `bind_dims`, `unbind_dims` as a unification of `to_tensor`, `positional_distribution` and `torch_getitem`, `named_distribution`.

Closes #203 