### PR TITLE
Support polymorphic function and collection types in `defdata`

### DIFF
--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import typing
 from collections.abc import Callable
 from typing import Any, TypeVar
 
@@ -294,7 +295,12 @@ def typeof(term: Expr[T]) -> type[T]:
     from effectful.internals.runtime import interpreter
 
     with interpreter({apply: lambda _, op, *a, **k: op.__type_rule__(*a, **k)}):
-        return evaluate(term) if isinstance(term, Term) else type(term)  # type: ignore
+        if isinstance(term, Term):
+            # If term is a Term, we evaluate it to get its type
+            tp = evaluate(term)
+            return typing.get_origin(tp) or tp  # type: ignore
+        else:
+            return type(term)
 
 
 def fvsof(term: Expr[S]) -> set[Operation]:

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -598,48 +598,13 @@ class _BaseOperation(Generic[Q, V], Operation[Q, V]):
         return tuple(result_sig.args), dict(result_sig.kwargs)
 
     def __type_rule__(self, *args: Q.args, **kwargs: Q.kwargs) -> type[V]:
-        def unwrap_annotation(typ):
-            """Unwrap Annotated types."""
-            return (
-                typing.get_args(typ)[0] if typing.get_origin(typ) is Annotated else typ
-            )
+        from effectful.internals.unification import infer_return_type
 
-        def drop_params(typ):
-            """Strip parameters from polymorphic types."""
-            origin = typing.get_origin(typ)
-            return typ if origin is None else origin
-
-        sig = self.__signature__
-        bound_sig = sig.bind(*args, **kwargs)
-        bound_sig.apply_defaults()
-
-        anno = sig.return_annotation
-        anno = unwrap_annotation(anno)
-
-        if anno is None:
-            return typing.cast(type[V], type(None))
-
-        if anno is inspect.Signature.empty:
+        if self.__signature__.return_annotation is inspect.Parameter.empty:
             return typing.cast(type[V], object)
 
-        if isinstance(anno, typing.TypeVar):
-            # rudimentary but sound special-case type inference sufficient for syntax ops:
-            # if the return type annotation is a TypeVar,
-            # look for a parameter with the same annotation and return its type,
-            # otherwise give up and return Any/object
-            for name, param in bound_sig.signature.parameters.items():
-                param_typ = unwrap_annotation(param.annotation)
-                if param_typ is anno and param.kind not in (
-                    inspect.Parameter.VAR_POSITIONAL,
-                    inspect.Parameter.VAR_KEYWORD,
-                ):
-                    arg = bound_sig.arguments[name]
-                    tp: type[V] = type(arg) if not isinstance(arg, type) else arg
-                    return drop_params(tp)
-
-            return typing.cast(type[V], object)
-
-        return drop_params(anno)
+        bound_sig = self.__signature__.bind(*args, **kwargs)
+        return infer_return_type(bound_sig)
 
     def __repr__(self):
         return f"_BaseOperation({self._default}, name={self.__name__}, freshening={self._freshening})"
@@ -670,6 +635,9 @@ def _(t: Operation[P, T], *, name: str | None = None) -> Operation[P, T]:
 
 
 @defop.register(type)
+@defop.register(types.GenericAlias)
+@defop.register(typing._GenericAlias)  # type: ignore
+@defop.register(types.UnionType)  # type: ignore
 def _(t: type[T], *, name: str | None = None) -> Operation[[], T]:
     def func() -> t:  # type: ignore
         raise NotImplementedError
@@ -1006,9 +974,7 @@ def defdata(
 
     base_term = __dispatch(typing.cast(type[T], object))(op, *args_, **kwargs_)
     tp = typeof(base_term)
-    if tp is typing.Union:
-        raise ValueError("Terms that return Union types are not supported.")
-    assert isinstance(tp, type)
+    tp = typing.get_origin(tp) or tp
 
     typed_term = __dispatch(tp)(op, *args_, **kwargs_)
     return typed_term

--- a/tests/test_handlers_numbers.py
+++ b/tests/test_handlers_numbers.py
@@ -1,6 +1,8 @@
 import collections
+import collections.abc
 import logging
 import os
+import typing
 
 import pytest
 
@@ -10,6 +12,9 @@ from effectful.ops.syntax import defop, trace
 from effectful.ops.types import Term
 
 logger = logging.getLogger(__name__)
+
+T = typing.TypeVar("T")
+S = typing.TypeVar("S")
 
 
 def test_lambda_calculus_1():
@@ -40,7 +45,7 @@ def test_lambda_calculus_2():
 
 
 def test_lambda_calculus_3():
-    x, y, f = defop(int), defop(int), defop(collections.abc.Callable)
+    x, y, f = defop(int), defop(int), defop(collections.abc.Callable[[int], collections.abc.Callable[[int], int]])
 
     with handler(eager_mixed):
         f2 = Lam(x, Lam(y, (x() + y())))
@@ -51,8 +56,8 @@ def test_lambda_calculus_3():
 def test_lambda_calculus_4():
     x, f, g = (
         defop(int),
-        defop(collections.abc.Callable),
-        defop(collections.abc.Callable),
+        defop(collections.abc.Callable[[T], T]),
+        defop(collections.abc.Callable[[T], T]),
     )
 
     with handler(eager_mixed):
@@ -177,7 +182,7 @@ def test_defun_3():
             return x + y
 
         @trace
-        def app2(f: collections.abc.Callable, x: int, y: int) -> int:
+        def app2(f: collections.abc.Callable[[int, int], int], x: int, y: int) -> int:
             return f(x, y)
 
         assert app2(f2, 1, 2) == 3


### PR DESCRIPTION
Blocked by #299 

This PR uses the type inference module added in #299 to enable the semantic embedding of `Term`s whose semantic type is a polymorphic function or collection that can be unified with an abstract type from `collections.abc`.

It replaces the existing implementation of `Operation.__type_rule__` with a simpler and more general version in terms of the `infer_return_type` function added in #299.