### PR TITLE
Prevent XLA preallocation in CI builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Run tests
         env:
           MKL_NUM_THREADS: 1
+          XLA_PYTHON_CLIENT_PREALLOCATE: false
         run: uv run ./scripts/test.sh


### PR DESCRIPTION
I'm seeing some bizarre segfaults in CI builds in #299 that I can't reproduce locally. This is an attempt to remove one possible cause by setting `XLA_PYTHON_CLIENT_PREALLOCATE=false` in the CI workflow, which should be a good idea in general, though I have no idea if it's going to help with #299 .