### PR TITLE
Remove non-uniform behavior for numeric equality

### DIFF
--- a/docs/source/lambda_.py
+++ b/docs/source/lambda_.py
@@ -3,7 +3,7 @@ from typing import Annotated, Callable
 
 from effectful.handlers.numbers import add
 from effectful.ops.semantics import coproduct, evaluate, fvsof, fwd, handler
-from effectful.ops.syntax import Scoped, defop
+from effectful.ops.syntax import Scoped, defop, syntactic_eq
 from effectful.ops.types import Expr, Interpretation, Operation, Term
 
 
@@ -84,13 +84,12 @@ def assoc_add(x: Expr[int], y: Expr[int]) -> Expr[int]:
 
 
 def unit_add(x: Expr[int], y: Expr[int]) -> Expr[int]:
-    match x, y:
-        case _, 0:
-            return x
-        case 0, _:
-            return y
-        case _:
-            return fwd()
+    if syntactic_eq(y, 0):
+        return x
+    elif syntactic_eq(x, 0):
+        return y
+    else:
+        return fwd()
 
 
 def sort_add(x: Expr[int], y: Expr[int]) -> Expr[int]:

--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -37,14 +37,6 @@ class _NumberTerm(Term[numbers.Number]):
 
 
 # Complex specific methods
-@defop
-def eq[T_Number: numbers.Number](x: T_Number, y: T_Number) -> bool:
-    if not any(isinstance(a, Term) for a in (x, y)):
-        return operator.eq(x, y)
-    else:
-        return syntactic_eq(x, y)
-
-
 def _wrap_cmp(op):
     def _wrapped_op[T_Number: numbers.Number](x: T_Number, y: T_Number) -> bool:
         if not any(isinstance(a, Term) for a in (x, y)):
@@ -86,6 +78,7 @@ mul = defop(_wrap_binop(operator.mul))
 truediv = defop(_wrap_binop(operator.truediv))
 pow = defop(_wrap_binop(operator.pow))
 abs = defop(_wrap_unop(operator.abs))
+eq = defop(_wrap_cmp(operator.eq))
 
 
 @defdata.register(numbers.Complex)

--- a/effectful/handlers/numbers.py
+++ b/effectful/handlers/numbers.py
@@ -6,7 +6,7 @@ import numbers
 import operator
 from typing import Any
 
-from effectful.ops.syntax import defdata, defop, syntactic_eq
+from effectful.ops.syntax import defdata, defop
 from effectful.ops.types import Expr, Operation, Term
 
 

--- a/tests/test_handlers_numbers.py
+++ b/tests/test_handlers_numbers.py
@@ -6,7 +6,7 @@ import pytest
 
 from docs.source.lambda_ import App, Lam, Let, eager_mixed
 from effectful.ops.semantics import evaluate, fvsof, handler, typeof
-from effectful.ops.syntax import defop, trace
+from effectful.ops.syntax import defop, syntactic_eq, trace
 from effectful.ops.types import Term
 
 logger = logging.getLogger(__name__)
@@ -19,9 +19,9 @@ def test_lambda_calculus_1():
         e1 = x() + 1
         f1 = Lam(x, e1)
 
-        assert App(f1, 1) == 2
-        assert Lam(y, f1) == f1
-        assert Lam(x, f1.args[1]) == f1.args[1]
+        assert syntactic_eq(App(f1, 1), 2)
+        assert syntactic_eq(Lam(y, f1), f1)
+        assert syntactic_eq(Lam(x, f1.args[1]), f1.args[1])
 
         assert fvsof(e1) == fvsof(x() + 1)
         assert fvsof(Lam(x, e1).args[1]) != fvsof(Lam(x, e1).args[1])
@@ -35,8 +35,8 @@ def test_lambda_calculus_2():
 
     with handler(eager_mixed):
         f2 = Lam(x, Lam(y, (x() + y())))
-        assert App(App(f2, 1), 2) == 3
-        assert Lam(y, f2) == f2
+        assert syntactic_eq(App(App(f2, 1), 2), 3)
+        assert syntactic_eq(Lam(y, f2), f2)
 
 
 def test_lambda_calculus_3():
@@ -45,7 +45,7 @@ def test_lambda_calculus_3():
     with handler(eager_mixed):
         f2 = Lam(x, Lam(y, (x() + y())))
         app2 = Lam(f, Lam(x, Lam(y, App(App(f(), x()), y()))))
-        assert App(App(App(app2, f2), 1), 2) == 3
+        assert syntactic_eq(App(App(App(app2, f2), 1), 2), 3)
 
 
 def test_lambda_calculus_4():
@@ -59,7 +59,7 @@ def test_lambda_calculus_4():
         add1 = Lam(x, (x() + 1))
         compose = Lam(f, Lam(g, Lam(x, App(f(), App(g(), x())))))
         f1_twice = App(App(compose, add1), add1)
-        assert App(f1_twice, 1) == 3
+        assert syntactic_eq(App(f1_twice, 1), 3)
 
 
 def test_lambda_calculus_5():
@@ -75,8 +75,8 @@ def test_lambda_calculus_5():
         assert x not in fvsof(f_add1)
         assert f_add1.args[0] != f_add1.args[1].args[0]
 
-        assert App(f_add1, 1) == 2
-        assert Let(x, 1, e_add1) == 2
+        assert syntactic_eq(App(f_add1, 1), 2)
+        assert syntactic_eq(Let(x, 1, e_add1), 2)
 
 
 def test_arithmetic_1():
@@ -84,9 +84,9 @@ def test_arithmetic_1():
     x, y = x_(), y_()
 
     with handler(eager_mixed):
-        assert (1 + 2) + x == x + 3
-        assert not (x + 1 == y + 1)
-        assert x + 0 == 0 + x == x
+        assert syntactic_eq((1 + 2) + x, x + 3)
+        assert not syntactic_eq(x + 1, y + 1)
+        assert syntactic_eq(x + 0, 0 + x) and syntactic_eq(0 + x, x)
 
 
 def test_arithmetic_2():
@@ -94,10 +94,10 @@ def test_arithmetic_2():
     x, y = x_(), y_()
 
     with handler(eager_mixed):
-        assert x + y == y + x
-        assert 3 + x == x + 3
-        assert 1 + (x + 2) == x + 3
-        assert (x + 1) + 2 == x + 3
+        assert syntactic_eq(x + y, y + x)
+        assert syntactic_eq(3 + x, x + 3)
+        assert syntactic_eq(1 + (x + 2), x + 3)
+        assert syntactic_eq((x + 1) + 2, x + 3)
 
 
 def test_arithmetic_3():
@@ -105,9 +105,9 @@ def test_arithmetic_3():
     x, y = x_(), y_()
 
     with handler(eager_mixed):
-        assert (1 + (y + 1)) + (1 + (x + 1)) == (y + x) + 4
-        assert 1 + ((x + y) + 2) == (x + y) + 3
-        assert 1 + ((x + (y + 1)) + 1) == (x + y) + 3
+        assert syntactic_eq((1 + (y + 1)) + (1 + (x + 1)), (y + x) + 4)
+        assert syntactic_eq(1 + ((x + y) + 2), (x + y) + 3)
+        assert syntactic_eq(1 + ((x + (y + 1)) + 1), (x + y) + 3)
 
 
 def test_arithmetic_4():
@@ -115,23 +115,25 @@ def test_arithmetic_4():
     x, y = x_(), y_()
 
     with handler(eager_mixed):
-        assert (
-            ((x + x) + (x + x)) + ((x + x) + (x + x))
-            == x + (x + (x + (x + (x + (x + (x + x))))))
-            == ((((((x + x) + x) + x) + x) + x) + x) + x
-        )
+        expr1 = ((x + x) + (x + x)) + ((x + x) + (x + x))
+        expr2 = x + (x + (x + (x + (x + (x + (x + x))))))
+        expr3 = ((((((x + x) + x) + x) + x) + x) + x) + x
+        assert syntactic_eq(expr1, expr2) and syntactic_eq(expr2, expr3)
 
-        assert (x + y) + (y + x) == (y + (x + x)) + y == y + (x + (y + x))
+        expr4 = (x + y) + (y + x)
+        expr5 = (y + (x + x)) + y
+        expr6 = y + (x + (y + x))
+        assert syntactic_eq(expr4, expr5) and syntactic_eq(expr5, expr6)
 
 
 def test_arithmetic_5():
     x, y = defop(int), defop(int)
 
     with handler(eager_mixed):
-        assert Let(x, x() + 3, x() + 1) == x() + 4
-        assert Let(x, x() + 3, x() + y() + 1) == y() + x() + 4
+        assert syntactic_eq(Let(x, x() + 3, x() + 1), x() + 4)
+        assert syntactic_eq(Let(x, x() + 3, x() + y() + 1), y() + x() + 4)
 
-        assert Let(x, x() + 3, Let(x, x() + 4, x() + y())) == x() + y() + 7
+        assert syntactic_eq(Let(x, x() + 3, Let(x, x() + 4, x() + y())), x() + y() + 7)
 
 
 def test_defun_1():
@@ -147,8 +149,8 @@ def test_defun_1():
         assert y in fvsof(f1)
         assert x not in fvsof(f1)
 
-        assert f1(1) == y() + 2
-        assert f1(x()) == x() + y() + 1
+        assert syntactic_eq(f1(1), y() + 2)
+        assert syntactic_eq(f1(x()), x() + y() + 1)
 
 
 def test_defun_2():
@@ -166,7 +168,7 @@ def test_defun_2():
 
             return f2_inner(y)
 
-        assert f1(1, 2) == f2(1, 2) == 3
+        assert syntactic_eq(f1(1, 2), 3) and syntactic_eq(f2(1, 2), 3)
 
 
 def test_defun_3():
@@ -180,7 +182,7 @@ def test_defun_3():
         def app2(f: collections.abc.Callable, x: int, y: int) -> int:
             return f(x, y)
 
-        assert app2(f2, 1, 2) == 3
+        assert syntactic_eq(app2(f2, 1, 2), 3)
 
 
 @pytest.mark.xfail(condition=os.getenv("CI") == "true", reason="Fails on CI")
@@ -196,6 +198,7 @@ def test_defun_4():
         ) -> collections.abc.Callable[[int], int]:
             @trace
             def fg(x: int) -> int:
+                breakpoint()
                 assert callable(f), f"f is not callable: {f}"
                 assert callable(g), f"g is not callable: {g}"
                 return f(g(x))
@@ -216,8 +219,12 @@ def test_defun_4():
 
         assert callable(add1_twice), f"add1_twice is not callable: {add1_twice}"
 
-        assert add1_twice(1) == compose(add1, add1)(1) == 3
-        assert add1_twice(x()) == compose(add1, add1)(x()) == x() + 2
+        assert syntactic_eq(add1_twice(1), 3) and syntactic_eq(
+            compose(add1, add1)(1), 3
+        )
+        assert syntactic_eq(add1_twice(x()), x() + 2) and syntactic_eq(
+            compose(add1, add1)(x()), x() + 2
+        )
 
 
 def test_defun_5():

--- a/tests/test_handlers_numbers.py
+++ b/tests/test_handlers_numbers.py
@@ -198,7 +198,6 @@ def test_defun_4():
         ) -> collections.abc.Callable[[int], int]:
             @trace
             def fg(x: int) -> int:
-                breakpoint()
                 assert callable(f), f"f is not callable: {f}"
                 assert callable(g), f"g is not callable: {g}"
                 return f(g(x))


### PR DESCRIPTION
`defop(float)() == 1.` should result in a term, not `False`.