### PR TITLE
Rework numpyro distribution handling to enable symbolic distributions and handling of distribution methods

### DIFF
--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -153,6 +153,9 @@ class _DistributionOperation[T: dist.Distribution](_BaseOperation[Any, T]):
     """
 
     def __init__(self, default: dist.Distribution, **kwargs):
+        # FIXME: This ensures that calling a distribution operation always
+        # results in a term, while still being able to access the original
+        # distribution constructor.
         self._constr = default
 
         @functools.wraps(default)

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -632,7 +632,7 @@ class _BaseOperation[**Q, V](Operation[Q, V]):
         return drop_params(anno)
 
     def __repr__(self):
-        return f"_BaseOperation({self._default}, name={self.__name__}, freshening={self._freshening})"
+        return f"{type(self).__name__}({self._default}, name={self.__name__}, freshening={self._freshening})"
 
     def __str__(self):
         return self.__name__

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -11,6 +11,7 @@ import pytest
 import effectful.handlers.jax.numpy as jnp
 import effectful.handlers.numpyro as dist
 from effectful.handlers.jax import bind_dims, jax_getitem, sizesof, unbind_dims
+from effectful.ops.semantics import typeof
 from effectful.ops.syntax import defop
 from effectful.ops.types import Operation, Term
 
@@ -852,4 +853,19 @@ def test_distribution_terms():
     d3 = dist.Normal(jnp.array(0.0), jnp.array(1.0))
     assert not isinstance(d3, Term) and isinstance(
         d3, numpyro.distributions.Distribution
+    )
+
+
+def test_distribution_typeof():
+    """Check that typeof() behaves correctly on distribution-valued terms."""
+    assert (
+        typeof(dist.Normal(defop(jax.Array)()))
+        is numpyro.distributions.continuous.Normal
+    )
+
+    assert typeof(dist.Normal()) is numpyro.distributions.continuous.Normal
+
+    assert (
+        typeof(dist.Normal(jax_getitem(jnp.array([0, 1, 2]), [defop(jax.Array)()])))
+        is numpyro.distributions.continuous.Normal
     )

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -68,7 +68,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
 
     # Binomial
     add_case(
-        "dist.BinomialProbs(total_count=case.total_count, probs=case.probs)",
+        "dist.BinomialProbs(case.probs, case.total_count)",
         (
             ("total_count", "5"),
             ("probs", f"rand({batch_shape})"),
@@ -79,7 +79,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     # CategoricalLogits
     for size in [2, 4]:
         add_case(
-            "dist.CategoricalLogits(logits=case.logits)",
+            "dist.CategoricalLogits(case.logits)",
             (("logits", f"rand({batch_shape + (size,)})"),),
             batch_shape,
         )
@@ -87,25 +87,25 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     # CategoricalProbs
     for size in [2, 4]:
         add_case(
-            "dist.CategoricalProbs(probs=case.probs)",
+            "dist.CategoricalProbs(case.probs)",
             (("probs", f"rand({batch_shape + (size,)})"),),
             batch_shape,
         )
 
     # Cauchy
     add_case(
-        "dist.Cauchy(loc=case.loc, scale=case.scale)",
+        "dist.Cauchy(case.loc, case.scale)",
         (("loc", f"rand({batch_shape})"), ("scale", f"rand({batch_shape})")),
         batch_shape,
     )
 
     # Chi2
-    add_case("dist.Chi2(df=case.df)", (("df", f"rand({batch_shape})"),), batch_shape)
+    add_case("dist.Chi2(case.df)", (("df", f"rand({batch_shape})"),), batch_shape)
 
     # Delta
     for event_shape in [(), (4,), (3, 2)]:
         add_case(
-            f"dist.Delta(v=case.v, log_density=case.log_density, event_dim={len(event_shape)})",
+            f"dist.Delta(case.v, case.log_density, {len(event_shape)})",
             (
                 ("v", f"rand({batch_shape + event_shape})"),
                 ("log_density", f"rand({batch_shape})"),
@@ -134,9 +134,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
 
     # Exponential
     add_case(
-        "dist.Exponential(rate=case.rate)",
-        (("rate", f"rand({batch_shape})"),),
-        batch_shape,
+        "dist.Exponential(case.rate)", (("rate", f"rand({batch_shape})"),), batch_shape
     )
 
     # Gamma
@@ -148,47 +146,43 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
 
     # Geometric
     add_case(
-        "dist.GeometricProbs(probs=case.probs)",
+        "dist.GeometricProbs(case.probs)",
         (("probs", f"rand({batch_shape})"),),
         batch_shape,
     )
     add_case(
-        "dist.GeometricLogits(logits=case.logits)",
+        "dist.GeometricLogits(case.logits)",
         (("logits", f"rand({batch_shape})"),),
         batch_shape,
     )
 
     # Gumbel
     add_case(
-        "dist.Gumbel(loc=case.loc, scale=case.scale)",
+        "dist.Gumbel(case.loc, case.scale)",
         (("loc", f"rand({batch_shape})"), ("scale", f"rand({batch_shape})")),
         batch_shape,
     )
 
     # HalfCauchy
     add_case(
-        "dist.HalfCauchy(scale=case.scale)",
-        (("scale", f"rand({batch_shape})"),),
-        batch_shape,
+        "dist.HalfCauchy(case.scale)", (("scale", f"rand({batch_shape})"),), batch_shape
     )
 
     # HalfNormal
     add_case(
-        "dist.HalfNormal(scale=case.scale)",
-        (("scale", f"rand({batch_shape})"),),
-        batch_shape,
+        "dist.HalfNormal(case.scale)", (("scale", f"rand({batch_shape})"),), batch_shape
     )
 
     # Laplace
     add_case(
-        "dist.Laplace(loc=case.loc, scale=case.scale)",
+        "dist.Laplace(case.loc, case.scale)",
         (("loc", f"rand({batch_shape})"), ("scale", f"rand({batch_shape})")),
         batch_shape,
     )
 
     # Logistic
     add_case(
-        "dist.Logistic(loc=case.loc, scale=case.scale)",
+        "dist.Logistic(case.loc, case.scale)",
         (("loc", f"rand({batch_shape})"), ("scale", f"rand({batch_shape})")),
         batch_shape,
     )
@@ -196,7 +190,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     # # LowRankMultivariateNormal
     for event_shape in [(3,), (4,)]:
         add_case(
-            "dist.LowRankMultivariateNormal(loc=case.loc, cov_factor=case.cov_factor, cov_diag=case.cov_diag)",
+            "dist.LowRankMultivariateNormal(case.loc, case.cov_factor, case.cov_diag)",
             (
                 ("loc", f"rand({batch_shape + event_shape})"),
                 ("cov_factor", f"rand({batch_shape + event_shape + (2,)})"),
@@ -228,7 +222,9 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     for n_event in [1, 3]:
         event_shape = (n_event,)
         add_case(
-            "dist.MultivariateNormal(loc=case.loc, scale_tril=case.scale_tril)",
+            # FIXME: See https://github.com/BasisResearch/effectful/issues/310
+            # The better call would be dist.MultivariateNormal(case.loc, scale_tril=case.scale_tril)
+            "dist.MultivariateNormal(case.loc, None, None, case.scale_tril)",
             (
                 ("loc", f"rand({batch_shape + event_shape})"),
                 ("scale_tril", f"random_scale_tril({batch_shape}, {n_event})"),
@@ -238,7 +234,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
 
     # NegativeBinomial
     add_case(
-        "dist.NegativeBinomialProbs(total_count=case.total_count, probs=case.probs)",
+        "dist.NegativeBinomialProbs(case.total_count, case.probs)",
         (
             ("total_count", "5"),
             ("probs", f"rand({batch_shape})"),
@@ -247,7 +243,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     )
 
     add_case(
-        "dist.NegativeBinomialLogits(total_count=case.total_count, logits=case.logits)",
+        "dist.NegativeBinomialLogits(case.total_count, case.logits)",
         (
             ("total_count", "5"),
             ("logits", f"rand({batch_shape})"),
@@ -264,28 +260,26 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
 
     # Pareto
     add_case(
-        "dist.Pareto(scale=case.scale, alpha=case.alpha)",
+        "dist.Pareto(case.scale, case.alpha)",
         (("scale", f"rand({batch_shape})"), ("alpha", f"rand({batch_shape})")),
         batch_shape,
     )
 
     # Poisson
     add_case(
-        "dist.Poisson(rate=case.rate)",
-        (("rate", f"rand({batch_shape})"),),
-        batch_shape,
+        "dist.Poisson(case.rate)", (("rate", f"rand({batch_shape})"),), batch_shape
     )
 
     # RelaxedBernoulli
     add_case(
-        "dist.RelaxedBernoulliLogits(temperature=case.temperature, logits=case.logits)",
+        "dist.RelaxedBernoulliLogits(case.temperature, case.logits)",
         (("temperature", f"rand({batch_shape})"), ("logits", f"rand({batch_shape})")),
         batch_shape,
     )
 
     # StudentT
     add_case(
-        "dist.StudentT(df=case.df, loc=case.loc, scale=case.scale)",
+        "dist.StudentT(case.df, case.loc, case.scale)",
         (
             ("df", f"rand({batch_shape})"),
             ("loc", f"rand({batch_shape})"),
@@ -296,7 +290,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
 
     # Uniform
     add_case(
-        "dist.Uniform(low=case.low, high=case.high)",
+        "dist.Uniform(case.low, case.high)",
         (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
         batch_shape,
     )
@@ -310,7 +304,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
 
     # Weibull
     add_case(
-        "dist.Weibull(scale=case.scale, concentration=case.concentration)",
+        "dist.Weibull(case.scale, case.concentration)",
         (
             ("scale", f"exp(rand({batch_shape}))"),
             ("concentration", f"exp(rand({batch_shape}))"),
@@ -323,7 +317,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Uniform(low=case.low, high=case.high),
+            dist.Uniform(case.low, case.high),
             [dist.transforms.ExpTransform()])
         """,
         (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
@@ -335,7 +329,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Uniform(low=case.low, high=case.high),
+            dist.Uniform(case.low, case.high),
             [dist.transforms.ExpTransform().inv])
         """,
         (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
@@ -347,7 +341,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Uniform(low=case.low, high=case.high),
+            dist.Uniform(case.low, case.high),
             [dist.transforms.TanhTransform(),])
         """,
         (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
@@ -359,7 +353,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Uniform(low=case.low, high=case.high),
+            dist.Uniform(case.low, case.high),
             [dist.transforms.TanhTransform().inv])
         """,
         (
@@ -374,7 +368,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Uniform(low=case.low, high=case.high),
+            dist.Uniform(case.low, case.high),
             [dist.transforms.TanhTransform(),
              dist.transforms.ExpTransform()])
         """,
@@ -387,7 +381,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Uniform(low=case.low, high=case.high),
+            dist.Uniform(case.low, case.high),
             dist.transforms.ComposeTransform([
                 dist.transforms.TanhTransform(),
                 dist.transforms.ExpTransform()]))
@@ -401,7 +395,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Exponential(rate=case.rate),
+            dist.Exponential(case.rate),
             dist.transforms.PowerTransform(0.5))
         """,
         (("rate", f"rand({batch_shape})"),),
@@ -413,7 +407,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
     add_case(
         """
         dist.TransformedDistribution(
-            dist.Normal(loc=case.loc, scale=1.).to_event(1),
+            dist.Normal(case.loc, 1.).to_event(1),
             dist.transforms.HaarTransform(dim=-1))
         """,
         (("loc", f"rand({batch_shape} + (3,))"),),
@@ -453,7 +447,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
             f"""
             dist.Independent(
                 dist.TransformedDistribution(
-                    dist.Uniform(low=case.low, high=case.high),
+                    dist.Uniform(case.low, case.high),
                     dist.transforms.ComposeTransform([
                         dist.transforms.TanhTransform(),
                         dist.transforms.ExpTransform()])),

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -911,9 +911,7 @@ def test_symbolic_dist(dist_factory):
     indexed_sample_logprob = distribution.log_prob(
         jax_getitem(jnp.array([0.0, 1.0]), [index()])
     )
-    assert isinstance(indexed_sample_logprob, Term) and not isinstance(
-        bind_dims(indexed_sample_logprob, index), jax.Array
-    )
+    assert isinstance(indexed_sample_logprob, Term)
 
 
 def test_distribution_typeof():

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -44,7 +44,7 @@ def add_case(raw_dist, raw_params, batch_shape, xfail=None):
 for batch_shape in [(5,), (2, 3, 4), ()]:
     # BernoulliProbs
     add_case(
-        "dist.BernoulliProbs(probs=case.probs)",
+        "dist.BernoulliProbs(case.probs)",
         (("probs", f"rand({batch_shape})"),),
         batch_shape,
     )
@@ -718,9 +718,9 @@ def test_dist_expand(case_, sample_shape, indexed_sample_shape, extra_batch_shap
     sample = expanded.sample(key, sample_shape_full)
 
     # Index into the sample
-    indexed_sample = sample[
-        tuple(defop(jax.Array)() for _ in range(len(indexed_sample_shape)))
-    ]
+    indexed_sample = jax_getitem(
+        sample, tuple(defop(jax.Array)() for _ in range(len(indexed_sample_shape)))
+    )
 
     # Check shapes
     expected_shape = (
@@ -841,9 +841,7 @@ def test_distribution_terms():
     y = defop(jax.Array, name="y")
 
     d1 = dist.Normal(x(), y())
-    assert isinstance(d1, Term) and not isinstance(
-        d1, numpyro.distributions.Distribution
-    )
+    assert isinstance(d1, Term) and isinstance(d1, numpyro.distributions.Distribution)
 
     a = jax_getitem(jnp.array([0.0]), [x()])
     b = jax_getitem(jnp.array([1.0]), [y()])
@@ -851,9 +849,7 @@ def test_distribution_terms():
     assert isinstance(d2, Term) and isinstance(d2, numpyro.distributions.Distribution)
 
     d3 = dist.Normal(jnp.array(0.0), jnp.array(1.0))
-    assert not isinstance(d3, Term) and isinstance(
-        d3, numpyro.distributions.Distribution
-    )
+    assert isinstance(d3, Term) and isinstance(d3, numpyro.distributions.Distribution)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This makes a significant change to the representation of numpyro distributions. In the current version, when a distribution constructor is called with non-term arguments, it evaluates to a numpyro distribution object. However, this means that passing terms to the methods of this distribution fails. In the new version, distribution constructors always produce terms, and the `_DistributionTerm` class fully implements the `numpyro.distribution.Distribution` interface.

Closes #308 