### PR TITLE
Support terms that contain jax.array, jax.asarray

### DIFF
--- a/effectful/handlers/jax/numpy.py
+++ b/effectful/handlers/jax/numpy.py
@@ -2,16 +2,23 @@ from typing import TYPE_CHECKING
 
 import jax.numpy
 
-from ._handlers import _register_jax_op
+from effectful.ops.syntax import defop
+
+from ._handlers import _register_jax_op, _register_jax_op_no_partial_eval
 
 _no_overload = ["array", "asarray"]
 
 for name, op in jax.numpy.__dict__.items():
-    if callable(op):
-        globals()[name] = _register_jax_op(op)
+    if not callable(op):
+        continue
 
-for name in _no_overload:
-    globals()[name] = jax.numpy.__dict__[name]
+    jax_op = (
+        _register_jax_op_no_partial_eval(op)
+        if name in _no_overload
+        else _register_jax_op(op)
+    )
+    globals()[name] = jax_op
+
 
 # Tell mypy about our wrapped functions.
 if TYPE_CHECKING:

--- a/effectful/handlers/jax/numpy.py
+++ b/effectful/handlers/jax/numpy.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING
 
 import jax.numpy
 
-from effectful.ops.syntax import defop
-
 from ._handlers import _register_jax_op, _register_jax_op_no_partial_eval
 
 _no_overload = ["array", "asarray"]

--- a/tests/test_handlers_jax.py
+++ b/tests/test_handlers_jax.py
@@ -357,3 +357,13 @@ def test_jax_iter():
     i = defop(jax.Array, name="i")
     with pytest.raises(TypeError):
         tuple(i())
+
+
+def test_jax_array():
+    x, y = defop(jax.Array), defop(jax.Array)
+
+    t1 = jnp.array([x()])
+    assert isinstance(t1, Term)
+
+    t2 = jnp.array([jax_getitem(jnp.array([1, 2, 3]), [y()])])
+    assert isinstance(t2, Term)


### PR DESCRIPTION
The partial evaluation rule doesn't apply to these ops, but they should still be able to be part of terms.