### PR TITLE
Term Unification

### DIFF
--- a/effectful/internals/mgu.py
+++ b/effectful/internals/mgu.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+from effectful.ops.syntax import deffn, syntactic_eq
+from effectful.ops.types import Term
+
+
+def mgu(*pairs, intp=None) -> dict | None:
+    if intp is None:
+        intp = {}
+    for t1, t2 in pairs:
+        intp = _mgu(t1, t2, intp)
+    return intp
+
+
+def _mgu(term1: Any, term2: Any, intp: dict) -> dict | None:
+    """
+    Unifier of term1 with term2.
+    (Unlike usual mgu, this does not unify bi-directionally.)
+    """
+    # Case 1: terms are identical -> pass
+    if syntactic_eq(term1, term2):
+        return intp
+
+    # Case 2: term1 is ground -> fail
+    if not isinstance(term1, Term):
+        return None
+
+    # Case 3: term1 is an open var -> assign term2 to it
+    if len(term1.args) == 0:
+        if term1.op in intp:
+            if syntactic_eq(term2, intp[term1.op]()):
+                return intp
+            else:
+                return None
+        else:
+            intp[term1.op] = deffn(term2)
+            return intp
+
+    # Case 4: term1 is structured term -> check inductively
+    if (
+        isinstance(term2, Term)
+        and term1.op == term2.op
+        and len(term1.args) == len(term2.args)
+    ):
+        for t1, t2 in zip(term1.args, term2.args, strict=False):
+            intp = _mgu(t1, t2, intp)  # type: ignore
+            if intp is None:
+                return None
+        return intp
+    return None

--- a/tests/test_mgu.py
+++ b/tests/test_mgu.py
@@ -1,0 +1,31 @@
+from effectful.internals.mgu import mgu
+from effectful.ops.syntax import defop, syntactic_eq
+
+
+
+def test_mgu():
+    x = defop(int, name="x")
+    y = defop(int, name="y")
+    z = defop(int, name="z")
+
+    match = mgu((x(), 2))
+    assert syntactic_eq(match[x](), 2)
+
+    match = mgu((x(), y()))
+    assert syntactic_eq(match[x](), y())
+
+    match = mgu((2, 2))
+    assert match == {}
+
+    match = mgu((2, 3))
+    assert match is None
+
+    match = mgu((x() + y(), z()))
+    assert match is None
+
+    match = mgu((x(), y() + 2))
+    assert syntactic_eq(match[x](), y() + 2)
+
+    match = mgu(((x() + y()) / 2, (z() + 3) / 2))
+    assert syntactic_eq(match[x](), z())
+    assert syntactic_eq(match[y](), 3)


### PR DESCRIPTION
Currently, writing transforms in Weighted involves quite some boilerplate for pattern matching/parsing. So solve this, I implemented a unification method on terms, making it considerably less painful to match on elaborate patterns. The unification method is rather straightforward, as we can use the infrastructure of Effectful to make patterns as open terms.

@jfeser We previously discussed the pros/cons of adding higher-level ops vs doing lower-level pattern matching. I believe this has the advantages of both approaches. For example, to support KL-divergence, we can method to help construct it:

def kl_divergence(x, p, q):
    log_p = log_prob(p, x)
    log_q = log_prob(q, x)
    return Sum({x.op: reals()}, jnp.exp(log_p) * (log_p - log_q))

This can be used by a user to avoid manually defining the divergence each time. But it can also by used to parse the divergence in a program transform. For example, if we are doing a transform of the divergence between two gaussians, we can write the following.

x, loc1, loc2, scale1, scale2 = (defop(Any) for _ in range(5))
with interpretation({}):  # to make sure pattern is not evaluated
    pattern = kl_divergence(x(), Normal(loc1(), scale1()), Normal(loc1(), scale2()))
match = mgu((pattern, term))
# do some program transform...

Note that this program transform works, even when the user manually defines a KL-divergence instead of using our kl_divergence method. Currently, the unification is still somewhat brittle as it e.g. cannot detect commutativity of addition/multiplication. Handling this would detect the patterns even better and would be an obvious next step.
