### PR TITLE
Add parallel CI builds for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["<3.13", ">=3.13"]
+        python-version: ["'<3.13'", "'>=3.13'"]
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
This PR modifies the CI workflow to run the tests for Python 3.12 and Python 3.13 in parallel via a [build matrix](https://github.com/orgs/community/discussions/132605). This is useful for the type inference machinery in `internals.unification` and the bytecode transformation in #288.