### PR TITLE
Absorb `call` into `CallableTerm`

### DIFF
--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -6,7 +6,13 @@ import typing
 from typing import Any
 
 from effectful.ops.syntax import defop
-from effectful.ops.types import Expr, Interpretation, Operation, Term
+from effectful.ops.types import (
+    Expr,
+    Interpretation,
+    NotHandled,  # noqa: F401
+    Operation,
+    Term,
+)
 
 
 @defop  # type: ignore

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -932,7 +932,7 @@ def defdata[T](
 
           @defop
           def __call__(self: collections.abc.Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
-              raise NotHandled
+              ...
 
     When an Operation whose return type is `Callable` is passed to :func:`defdata`,
     it is reconstructed as a :class:`_CallableTerm`, which implements the :func:`__call__` method.

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -1,3 +1,4 @@
+import collections.abc
 import dataclasses
 import functools
 import inspect
@@ -7,10 +8,11 @@ from typing import Annotated, ClassVar
 import pytest
 
 import effectful.handlers.numbers  # noqa: F401
-from effectful.ops.semantics import call, evaluate, fvsof, handler, typeof
+from effectful.ops.semantics import evaluate, fvsof, handler, typeof
 from effectful.ops.syntax import (
     Scoped,
     _CustomSingleDispatchCallable,
+    defdata,
     deffn,
     defop,
     defstream,
@@ -19,6 +21,8 @@ from effectful.ops.syntax import (
     next_,
 )
 from effectful.ops.types import NotHandled, Operation, Term
+
+call = defdata.dispatch(collections.abc.Callable).__call__
 
 
 def test_always_fresh():


### PR DESCRIPTION
Resolves #330 

This PR converts `ops.semantics.call` into the `__call__` method of `_CallableTerm` and removes the original `call` operation from `ops.semantics`.