### PR TITLE
Fix vestigial calls to apply.__default_rule__

### DIFF
--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -89,7 +89,7 @@ def _unbind_distribution(
         typ = op.__type_rule__(*args, **kwargs)
         if issubclass(typ, dist.Distribution):
             return defdata(op, *args, **kwargs)
-        return apply.__default_rule__({}, op, *args, **kwargs)
+        return op.__default_rule__(*args, **kwargs)
 
     with runner({apply: _apply}):
         d = defterm(d)
@@ -137,7 +137,7 @@ def _bind_dims_distribution(
         typ = op.__type_rule__(*args, **kwargs)
         if issubclass(typ, dist.Distribution):
             return defdata(op, *args, **kwargs)
-        return apply.__default_rule__({}, op, *args, **kwargs)
+        return op.__default_rule__(*args, **kwargs)
 
     with runner({apply: _apply}):
         d = defterm(d)

--- a/effectful/handlers/pyro.py
+++ b/effectful/handlers/pyro.py
@@ -377,7 +377,7 @@ def _unbind_dims_distribution(
             typ, pyro.distributions.torch_distribution.TorchDistributionMixin
         ):
             return defdata(op, *args, **kwargs)
-        return apply.__default_rule__({}, op, *args, **kwargs)
+        return op.__default_rule__(*args, **kwargs)
 
     with runner({apply: _apply}):
         d = defterm(d)
@@ -425,7 +425,7 @@ def _bind_dims_distribution(
             typ, pyro.distributions.torch_distribution.TorchDistributionMixin
         ):
             return defdata(op, *args, **kwargs)
-        return apply.__default_rule__({}, op, *args, **kwargs)
+        return op.__default_rule__(*args, **kwargs)
 
     with runner({apply: _apply}):
         d = defterm(d)


### PR DESCRIPTION
This PR fixes oversights from #333: a few calls to `apply.__default_rule__` still used an `intp` argument. These weren't caught in the tests and seem to be on a mostly dead code path, but I think that should be addressed as part of #328. Here I've just fixed the calls so that they aren't manifestly incorrect.