### PR TITLE
Add jnp methods to _ArrayTerm

### DIFF
--- a/effectful/handlers/jax/_terms.py
+++ b/effectful/handlers/jax/_terms.py
@@ -224,11 +224,12 @@ class _ArrayTerm(Term[jax.Array]):
         raise TypeError("A free array is not iterable.")
 
 
-for name in jax.Array.__dict__:
+for name, func in jax.Array.__dict__.items():
     if (
         not name.startswith("_")
         and name in jnp.__dict__
         and name not in _ArrayTerm.__dict__
+        and hasattr(func, "__call__")
     ):
         setattr(_ArrayTerm, name, getattr(jnp, name))
 

--- a/effectful/handlers/jax/_terms.py
+++ b/effectful/handlers/jax/_terms.py
@@ -223,7 +223,7 @@ class _ArrayTerm(Term[jax.Array]):
     def __iter__(self):
         raise TypeError("A free array is not iterable.")
 
-"""
+
 for name in jax.Array.__dict__:
     if (
         not name.startswith("_")
@@ -231,7 +231,6 @@ for name in jax.Array.__dict__:
         and name not in _ArrayTerm.__dict__
     ):
         setattr(_ArrayTerm, name, getattr(jnp, name))
-"""
 
 
 class _EagerArrayTerm(_ArrayTerm):

--- a/effectful/handlers/jax/_terms.py
+++ b/effectful/handlers/jax/_terms.py
@@ -223,15 +223,183 @@ class _ArrayTerm(Term[jax.Array]):
     def __iter__(self):
         raise TypeError("A free array is not iterable.")
 
+    def all(self, axis=None, keepdims=False, *, where=None):
+        return jnp.all(cast(jax.Array, self), axis=axis, keepdims=keepdims, where=where)
 
-for name, func in jax.Array.__dict__.items():
-    if (
-        not name.startswith("_")
-        and name in jnp.__dict__
-        and name not in _ArrayTerm.__dict__
-        and hasattr(func, "__call__")
+    def any(self, axis=None, keepdims=False, *, where=None):
+        return jnp.any(cast(jax.Array, self), axis=axis, keepdims=keepdims, where=where)
+
+    def argmax(self, axis=None, keepdims=False):
+        return jnp.argmax(cast(jax.Array, self), axis=axis, keepdims=keepdims)
+
+    def argmin(self, axis=None, keepdims=False):
+        return jnp.argmin(cast(jax.Array, self), axis=axis, keepdims=keepdims)
+
+    def argpartition(self, kth, axis=-1):
+        return jnp.argpartition(cast(jax.Array, self), kth, axis=axis)
+
+    def argsort(self, axis=-1, descending=False, stable=True):
+        return jnp.argsort(
+            cast(jax.Array, self), axis=axis, descending=descending, stable=stable
+        )
+
+    def astype(self, dtype):
+        return jnp.astype(cast(jax.Array, self), dtype)
+
+    def choose(self, choices, mode="raise"):
+        return jnp.choose(cast(jax.Array, self), choices, mode=mode)
+
+    def clip(self, min=None, max=None):
+        return jnp.clip(cast(jax.Array, self), min=min, max=max)
+
+    def compress(self, condition, axis=None):
+        return jnp.compress(condition, cast(jax.Array, self), axis=axis)
+
+    def conj(self):
+        return jnp.conj(cast(jax.Array, self))
+
+    def conjugate(self):
+        return jnp.conjugate(cast(jax.Array, self))
+
+    def copy(self):
+        return jnp.copy(cast(jax.Array, self))
+
+    def cumprod(self, axis=None, dtype=None):
+        return jnp.cumprod(cast(jax.Array, self), axis=axis, dtype=dtype)
+
+    def cumsum(self, axis=None, dtype=None):
+        return jnp.cumsum(cast(jax.Array, self), axis=axis, dtype=dtype)
+
+    def diagonal(self, offset=0, axis1=0, axis2=1):
+        return jnp.diagonal(
+            cast(jax.Array, self), offset=offset, axis1=axis1, axis2=axis2
+        )
+
+    def dot(self, b):
+        return jnp.dot(cast(jax.Array, self), b)
+
+    def max(self, axis=None, keepdims=False, initial=None, where=None):
+        return jnp.max(
+            cast(jax.Array, self),
+            axis=axis,
+            keepdims=keepdims,
+            initial=initial,
+            where=where,
+        )
+
+    def mean(self, axis=None, keepdims=False, *, where=None):
+        return jnp.mean(
+            cast(jax.Array, self), axis=axis, keepdims=keepdims, where=where
+        )
+
+    def min(self, axis=None, keepdims=False, initial=None, where=None):
+        return jnp.min(
+            cast(jax.Array, self),
+            axis=axis,
+            keepdims=keepdims,
+            initial=initial,
+            where=where,
+        )
+
+    def nonzero(self, *, size=None, fill_value=None):
+        return jnp.nonzero(cast(jax.Array, self), size=size, fill_value=fill_value)
+
+    def prod(
+        self, axis=None, keepdims=False, initial=None, where=None, promote_integers=True
     ):
-        setattr(_ArrayTerm, name, getattr(jnp, name))
+        return jnp.prod(
+            cast(jax.Array, self),
+            axis=axis,
+            keepdims=keepdims,
+            initial=initial,
+            where=where,
+            promote_integers=promote_integers,
+        )
+
+    def ptp(self, axis=None, keepdims=False):
+        return jnp.ptp(cast(jax.Array, self), axis=axis, keepdims=keepdims)
+
+    def ravel(self, order="C"):
+        return jnp.ravel(cast(jax.Array, self), order=order)
+
+    def repeat(self, repeats, axis=None, *, total_repeat_length=None):
+        return jnp.repeat(
+            cast(jax.Array, self),
+            repeats,
+            axis=axis,
+            total_repeat_length=total_repeat_length,
+        )
+
+    def reshape(self, *shape, order="C"):
+        if len(shape) == 1 and isinstance(shape[0], tuple | list):
+            shape = shape[0]
+        return jnp.reshape(cast(jax.Array, self), shape, order=order)
+
+    def round(self, decimals=0):
+        return jnp.round(cast(jax.Array, self), decimals=decimals)
+
+    def searchsorted(self, v, side="left", sorter=None):
+        return jnp.searchsorted(cast(jax.Array, self), v, side=side, sorter=sorter)
+
+    def sort(self, axis=-1, descending=False, stable=True):
+        return jnp.sort(
+            cast(jax.Array, self), axis=axis, descending=descending, stable=stable
+        )
+
+    def squeeze(self, axis=None):
+        return jnp.squeeze(cast(jax.Array, self), axis=axis)
+
+    def std(self, axis=None, keepdims=False, ddof=0, *, where=None):
+        return jnp.std(
+            cast(jax.Array, self), axis=axis, keepdims=keepdims, ddof=ddof, where=where
+        )
+
+    def sum(
+        self, axis=None, keepdims=False, initial=None, where=None, promote_integers=True
+    ):
+        return jnp.sum(
+            cast(jax.Array, self),
+            axis=axis,
+            keepdims=keepdims,
+            initial=initial,
+            where=where,
+            promote_integers=promote_integers,
+        )
+
+    def swapaxes(self, axis1, axis2):
+        return jnp.swapaxes(cast(jax.Array, self), axis1, axis2)
+
+    def take(
+        self,
+        indices,
+        axis=None,
+        mode=None,
+        unique_indices=False,
+        indices_are_sorted=False,
+        fill_value=None,
+    ):
+        return jnp.take(
+            cast(jax.Array, self),
+            indices,
+            axis=axis,
+            mode=mode,
+            unique_indices=unique_indices,
+            indices_are_sorted=indices_are_sorted,
+            fill_value=fill_value,
+        )
+
+    def trace(self, offset=0, axis1=0, axis2=1, dtype=None):
+        return jnp.trace(
+            cast(jax.Array, self), offset=offset, axis1=axis1, axis2=axis2, dtype=dtype
+        )
+
+    def transpose(self, axes=None):
+        return jnp.transpose(cast(jax.Array, self), axes=axes)
+
+    def var(self, axis=None, keepdims=False, ddof=0, *, where=None):
+        return jnp.var(
+            cast(jax.Array, self), axis=axis, keepdims=keepdims, ddof=ddof, where=where
+        )
 
 
 class _EagerArrayTerm(_ArrayTerm):

--- a/effectful/handlers/jax/_terms.py
+++ b/effectful/handlers/jax/_terms.py
@@ -223,6 +223,16 @@ class _ArrayTerm(Term[jax.Array]):
     def __iter__(self):
         raise TypeError("A free array is not iterable.")
 
+"""
+for name in jax.Array.__dict__:
+    if (
+        not name.startswith("_")
+        and name in jnp.__dict__
+        and name not in _ArrayTerm.__dict__
+    ):
+        setattr(_ArrayTerm, name, getattr(jnp, name))
+"""
+
 
 class _EagerArrayTerm(_ArrayTerm):
     def __init__(self, op, tensor, key):

--- a/tests/test_handlers_jax.py
+++ b/tests/test_handlers_jax.py
@@ -359,6 +359,13 @@ def test_jax_iter():
         tuple(i())
 
 
+def test_arrayterm_methods():
+    i = defop(jax.Array, name="i")
+    i().sum(axis=0)
+    i().trace()
+    i().transpose()
+
+
 def test_jax_array():
     x, y = defop(jax.Array), defop(jax.Array)
 

--- a/tests/test_handlers_jax.py
+++ b/tests/test_handlers_jax.py
@@ -19,7 +19,7 @@ def test_bind_dims():
     t = jax.random.normal(key, (2, 3, 4))
 
     # Test case 1: Converting all named dimensions to positional
-    t_ijk = jax_getitem(t, [i(), j(), k()])
+    t_ijk = jax_getitem(t, (i(), j(), k()))
     assert fvsof(t_ijk) >= {i, j, k}
 
     t1 = bind_dims(t_ijk, i, j, k)
@@ -49,7 +49,7 @@ def test_bind_dims():
     assert t5.shape == tuple()
 
     # Test case 5: Verify permuted tensors maintain correct relationships
-    t_kji = jax_getitem(jnp.permute_dims(t, (2, 1, 0)), [k(), j(), i()])
+    t_kji = jax_getitem(jnp.permute_dims(t, (2, 1, 0)), (k(), j(), i()))
     t6 = bind_dims(t_kji, i, j, k)
     t7 = bind_dims(t_ijk, i, j, k)
     assert jnp.allclose(t6, t7)
@@ -62,7 +62,7 @@ def test_bind_dims():
     assert x1.shape == (2, 3)
 
     # Test case 7: Multiple tensors sharing variables
-    t2_ijk = jax_getitem(jax.random.normal(key, (2, 3, 4)), [i(), j(), k()])
+    t2_ijk = jax_getitem(jax.random.normal(key, (2, 3, 4)), (i(), j(), k()))
     sum_t = t_ijk + t2_ijk
     sum1 = bind_dims(sum_t, i, j)
     assert fvsof(sum1) >= {k}  # k remains free
@@ -71,7 +71,7 @@ def test_bind_dims():
 
     # Test case 8: Tensor term with non-sized free variables
     w = defop(jax.Array, name="w")
-    t_ijk = jax_getitem(t, [i(), j(), k()]) + w()
+    t_ijk = jax_getitem(t, (i(), j(), k())) + w()
     t8 = bind_dims(t_ijk, i, j, k)
     assert fvsof(t8) >= {w}
 
@@ -92,9 +92,9 @@ def test_tpe_1():
 
     expected = xval + y1_val[..., None] + y2_val[None]
 
-    x_ij = jax_getitem(xval, [i(), j()])
-    x_plus_y1_ij = x_ij + jax_getitem(y1_val, [i()])
-    actual = x_plus_y1_ij + jax_getitem(y2_val, [j()])
+    x_ij = jax_getitem(xval, (i(), j()))
+    x_plus_y1_ij = x_ij + jax_getitem(y1_val, (i(),))
+    actual = x_plus_y1_ij + jax_getitem(y2_val, (j(),))
 
     assert actual.op == jax_getitem
     assert fvsof(actual) >= {i, j}
@@ -112,7 +112,7 @@ def test_tpe_2():
     expected = jnp.sum(xval[ival, :], axis=0)
 
     j = defop(jax.Array)
-    x_j = jax_getitem(xval, [ival, j()])
+    x_j = jax_getitem(xval, (ival, j()))
 
     assert x_j.shape == (2,)
     actual = jnp.sum(x_j, axis=0)
@@ -132,7 +132,7 @@ def test_tpe_3():
     expected = jnp.sum(xval, axis=1)
 
     j, k = defop(jax.Array), defop(jax.Array)
-    x_j = jax_getitem(xval, [k(), ival, j()])
+    x_j = jax_getitem(xval, (k(), ival, j()))
     actual = jnp.sum(x_j, axis=0)
 
     assert actual.op == jax_getitem
@@ -148,11 +148,11 @@ def test_tpe_known_index():
     i, j = defop(jax.Array, name="i"), defop(jax.Array, name="j")
 
     cases = [
-        jax_getitem(jnp.ones((2, 3)), [i(), 1]),
-        jax_getitem(jnp.ones((2, 3)), [0, i()]),
-        jax_getitem(jnp.ones((2, 3, 4)), [0, i(), 1]),
-        jax_getitem(jnp.ones((2, 3, 4)), [0, i(), j()]),
-        jax_getitem(jnp.ones((2, 3, 4)), [i(), j(), 3]),
+        jax_getitem(jnp.ones((2, 3)), (i(), 1)),
+        jax_getitem(jnp.ones((2, 3)), (0, i())),
+        jax_getitem(jnp.ones((2, 3, 4)), (0, i(), 1)),
+        jax_getitem(jnp.ones((2, 3, 4)), (0, i(), j())),
+        jax_getitem(jnp.ones((2, 3, 4)), (i(), j(), 3)),
     ]
 
     for case_ in cases:
@@ -167,7 +167,7 @@ def test_tpe_constant_eval():
         defop(jax.Array, name="width"),
     )
     t = jnp.array([[3, 1, 4], [1, 5, 9], [2, 6, 5]])
-    A = jax_getitem(t, [height(), width()])
+    A = jax_getitem(t, (height(), width()))
 
     layer = defop(jax.Array, name="layer")
     with handler(
@@ -191,8 +191,8 @@ def test_tpe_stack():
 
     i = defop(jax.Array)
     j = defop(jax.Array)
-    x_ij = jax_getitem(xval, [i(), j()])
-    y_ij = jax_getitem(yval, [i(), j()])
+    x_ij = jax_getitem(xval, (i(), j()))
+    y_ij = jax_getitem(yval, (i(), j()))
     actual = jnp.stack((x_ij, y_ij))
     assert actual.shape == (2,)
     assert (
@@ -203,7 +203,7 @@ def test_tpe_stack():
 def test_jax_jit_1():
     @jit
     def f(x, y):
-        bound = bind_dims(jax_getitem(x, [i(), j()]) + jax_getitem(y, [j()]), i, j)
+        bound = bind_dims(jax_getitem(x, (i(), j())) + jax_getitem(y, (j(),)), i, j)
         return bound
 
     i, j = defop(jax.Array, name="i"), defop(jax.Array, name="j")
@@ -216,7 +216,7 @@ def test_jax_jit_1():
 def test_jax_jit_2():
     @jit
     def f(x, y):
-        return jax_getitem(x, [i(), j()]) + jax_getitem(y, [j()])
+        return jax_getitem(x, (i(), j())) + jax_getitem(y, (j(),))
 
     i, j = defop(jax.Array, name="i"), defop(jax.Array, name="j")
     x, y = jnp.ones((5, 4)), jnp.ones((4,))
@@ -227,7 +227,7 @@ def test_jax_jit_2():
 def test_jax_jit_3():
     @jit
     def f(x, y):
-        return jax_getitem(x, [i(), j()]) + jax_getitem(y, [j()])
+        return jax_getitem(x, (i(), j())) + jax_getitem(y, (j(),))
 
     i, j = defop(jax.Array, name="i"), defop(jax.Array, name="j")
     x, y = jnp.ones((5, 4)), jnp.ones((4,))
@@ -237,19 +237,19 @@ def test_jax_jit_3():
 
 def test_jax_broadcast_to():
     i = defop(jax.Array, name="i")
-    t = jnp.broadcast_to(jax_getitem(jnp.ones((2, 3)), [i(), slice(None)]), (3,))
+    t = jnp.broadcast_to(jax_getitem(jnp.ones((2, 3)), (i(), slice(None))), (3,))
     assert not isinstance(t.shape, Term) and t.shape == (3,)
 
 
 def test_jax_nested_getitem():
     t = jnp.ones((2, 3))
     i, j = defop(jax.Array), defop(jax.Array)
-    t_i = jax_getitem(t, [i()])
+    t_i = jax_getitem(t, (i(),))
 
-    t_ij = defdata(jax_getitem, t_i, [j()])
+    t_ij = defdata(jax_getitem, t_i, (j(),))
     assert sizesof(t_ij) == {i: 2, j: 3}
 
-    t_ij = jax_getitem(t_i, [j()])
+    t_ij = jax_getitem(t_i, (j(),))
     assert sizesof(t_ij) == {i: 2, j: 3}
 
 
@@ -258,9 +258,9 @@ def test_jax_at_updates():
     i, j, k = defop(jax.Array), defop(jax.Array), defop(jax.Array)
 
     # Test the exact case from the original issue
-    a = jax_getitem(jnp.ones((5, 4, 3)), [i(), j()])
+    a = jax_getitem(jnp.ones((5, 4, 3)), (i(), j()))
     a = a.at[1].set(0)
-    b = jax_getitem(jnp.array([0, 1]), [k()])
+    b = jax_getitem(jnp.array([0, 1]), (k(),))
     a = a.at[b].set(0)
 
     # Verify the result has the expected properties
@@ -269,23 +269,23 @@ def test_jax_at_updates():
 
     # Test with 1D remaining dimension
     arr_2d = jnp.ones((3, 5))
-    indexed_2d = jax_getitem(arr_2d, [i()])  # Shape (5,)
+    indexed_2d = jax_getitem(arr_2d, (i(),))  # Shape (5,)
     updated_2d = indexed_2d.at[2].set(99.0)
     assert isinstance(updated_2d, Term)
     assert updated_2d.shape == (5,)
 
     # Test with 2D remaining dimensions
     arr_3d = jnp.ones((2, 3, 4))
-    indexed_3d = jax_getitem(arr_3d, [i()])  # Shape (3, 4)
+    indexed_3d = jax_getitem(arr_3d, (i(),))  # Shape (3, 4)
     updated_3d = indexed_3d.at[1, 2].set(99.0)
     assert isinstance(updated_3d, Term)
     assert updated_3d.shape == (3, 4)
 
     # Test using term as index
     arr = jnp.ones((5, 3))
-    a = jax_getitem(arr, [i()])  # Shape (3,)
+    a = jax_getitem(arr, (i(),))  # Shape (3,)
     k = defop(jax.Array)
-    b = jax_getitem(jnp.array([0, 1, 2]), [k()])  # Shape ()
+    b = jax_getitem(jnp.array([0, 1, 2]), (k(),))  # Shape ()
     updated = a.at[b].set(99.0)
     assert isinstance(updated, Term)
     assert updated.shape == (3,)
@@ -297,7 +297,7 @@ def test_jax_len():
         len(i())
 
     t = jnp.ones((2, 3, 4))
-    t_i = jax_getitem(t, [i()])
+    t_i = jax_getitem(t, (i(),))
     assert len(t_i) == 3
 
     for row in t_i:
@@ -359,18 +359,577 @@ def test_jax_iter():
         tuple(i())
 
 
-def test_arrayterm_methods():
-    i = defop(jax.Array, name="i")
-    i().sum(axis=0)
-    i().trace()
-    i().transpose()
-
-
 def test_jax_array():
     x, y = defop(jax.Array), defop(jax.Array)
 
-    t1 = jnp.array([x()])
+    t1 = jnp.array((x(),))
     assert isinstance(t1, Term)
 
-    t2 = jnp.array([jax_getitem(jnp.array([1, 2, 3]), [y()])])
+    t2 = jnp.array((jax_getitem(jnp.array([1, 2, 3]), (y(),)),))
     assert isinstance(t2, Term)
+
+
+def test_arrayterm_all():
+    """Test .all() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[True, False, True], [True, True, True]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.all()
+    jnp_result = jnp.all(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_any():
+    """Test .any() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[False, False, True], [False, False, False]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.any()
+    jnp_result = jnp.any(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_argmax():
+    """Test .argmax() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 5, 3], [4, 2, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.argmax()
+    jnp_result = jnp.argmax(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_argmin():
+    """Test .argmin() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[5, 1, 3], [4, 6, 2]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.argmin()
+    jnp_result = jnp.argmin(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_argpartition():
+    """Test .argpartition() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[5, 1, 3, 2], [4, 6, 2, 8]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.argpartition(2)
+    jnp_result = jnp.argpartition(array_term, 2)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        # argpartition results can vary, so just check they have the same shape
+        assert eval_result.shape == eval_jnp_result.shape
+
+
+def test_arrayterm_argsort():
+    """Test .argsort() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[5, 1, 3], [4, 6, 2]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.argsort()
+    jnp_result = jnp.argsort(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_astype():
+    """Test .astype() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]], dtype=jnp.int32)
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.astype(jnp.float32)
+    jnp_result = jnp.astype(array_term, jnp.float32)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert eval_result.dtype == jnp.float32
+        assert eval_jnp_result.dtype == jnp.float32
+
+
+def test_arrayterm_choose():
+    """Test .choose() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[0, 1, 2], [1, 0, 2]])
+    array_term = jax_getitem(base_array, (i(),))
+    choices = [
+        jnp.array([10, 20, 30]),
+        jnp.array([40, 50, 60]),
+        jnp.array([70, 80, 90]),
+    ]
+
+    result = array_term.choose(choices, mode="wrap")
+    jnp_result = jnp.choose(array_term, choices, mode="wrap")
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_clip():
+    """Test .clip() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 5, 3], [4, 2, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.clip(min=2, max=5)
+    jnp_result = jnp.clip(array_term, min=2, max=5)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_compress():
+    """Test .compress() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+    condition = jnp.array([True, False, True])
+
+    result = array_term.compress(condition)
+    jnp_result = jnp.compress(condition, array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_conj():
+    """Test .conj() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.conj()
+    jnp_result = jnp.conj(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_conjugate():
+    """Test .conjugate() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.conjugate()
+    jnp_result = jnp.conjugate(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_copy():
+    """Test .copy() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.copy()
+    jnp_result = jnp.copy(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_cumprod():
+    """Test .cumprod() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [2, 3, 4]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.cumprod()
+    jnp_result = jnp.cumprod(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_cumsum():
+    """Test .cumsum() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.cumsum()
+    jnp_result = jnp.cumsum(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_diagonal():
+    """Test .diagonal() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.diagonal()
+    jnp_result = jnp.diagonal(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_dot():
+    """Test .dot() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+    other = jnp.array([1, 1, 1])
+
+    result = array_term.dot(other)
+    jnp_result = jnp.dot(array_term, other)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_max():
+    """Test .max() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 5, 3], [4, 2, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.max()
+    jnp_result = jnp.max(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_mean():
+    """Test .mean() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.mean()
+    jnp_result = jnp.mean(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_min():
+    """Test .min() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 5, 3], [4, 2, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.min()
+    jnp_result = jnp.min(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_nonzero():
+    """Test .nonzero() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[0, 1, 0], [2, 0, 3]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.nonzero(size=4)
+    jnp_result = jnp.nonzero(array_term, size=4)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        for r, j in zip(eval_result, eval_jnp_result):
+            assert jnp.allclose(r, j)
+
+
+def test_arrayterm_prod():
+    """Test .prod() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [2, 3, 4]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.prod()
+    jnp_result = jnp.prod(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_ptp():
+    """Test .ptp() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 5, 3], [4, 2, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.ptp()
+    jnp_result = jnp.ptp(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_ravel():
+    """Test .ravel() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.ravel()
+    jnp_result = jnp.ravel(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_repeat():
+    """Test .repeat() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.repeat(2)
+    jnp_result = jnp.repeat(array_term, 2)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_reshape():
+    """Test .reshape() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.reshape((3,))
+    jnp_result = jnp.reshape(array_term, (3,))
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_round():
+    """Test .round() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1.234, 2.567], [3.891, 4.123]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.round(decimals=1)
+    jnp_result = jnp.round(array_term, decimals=1)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_searchsorted():
+    """Test .searchsorted() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 3, 5], [2, 4, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.searchsorted(4)
+    jnp_result = jnp.searchsorted(array_term, 4)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_sort():
+    """Test .sort() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[3, 1, 5], [6, 2, 4]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.sort()
+    jnp_result = jnp.sort(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_squeeze():
+    """Test .squeeze() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[[1], [2]], [[3], [4]]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.squeeze()
+    jnp_result = jnp.squeeze(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_std():
+    """Test .std() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.std()
+    jnp_result = jnp.std(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_sum():
+    """Test .sum() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.sum()
+    jnp_result = jnp.sum(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_swapaxes():
+    """Test .swapaxes() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.swapaxes(0, 1)
+    jnp_result = jnp.swapaxes(array_term, 0, 1)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_take():
+    """Test .take() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[10, 20, 30], [40, 50, 60]])
+    array_term = jax_getitem(base_array, (i(),))
+    indices = jnp.array([0, 2])
+
+    result = array_term.take(indices)
+    jnp_result = jnp.take(array_term, indices)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_trace():
+    """Test .trace() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.trace()
+    jnp_result = jnp.trace(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_transpose():
+    """Test .transpose() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.transpose()
+    jnp_result = jnp.transpose(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)
+
+
+def test_arrayterm_var():
+    """Test .var() method on _ArrayTerm."""
+    i = defop(jax.Array, name="i")
+    base_array = jnp.array([[1, 2, 3], [4, 5, 6]])
+    array_term = jax_getitem(base_array, (i(),))
+
+    result = array_term.var()
+    jnp_result = jnp.var(array_term)
+
+    with handler({i: lambda: jnp.array([0, 1])}):
+        eval_result = evaluate(result)
+        eval_jnp_result = evaluate(jnp_result)
+        assert jnp.allclose(eval_result, eval_jnp_result)


### PR DESCRIPTION
Adds the following methods to `_ArrayTerm`:

```
['all', 'any', 'argmax', 'argmin', 'argpartition', 'argsort', 'astype', 'choose', 'clip', 'compress', 'conj', 'conjugate', 'copy', 'cumprod', 'cumsum', 'diagonal', 'dot', 'max', 'mean', 'min', 'nonzero', 'prod', 'ptp', 'ravel', 'repeat', 'reshape', 'round', 'searchsorted', 'sort', 'squeeze', 'std', 'sum', 'swapaxes', 'take', 'trace', 'transpose', 'var']
```
So now we can do things on the Array terms such as

```Python3
i = defop(jax.Array)
jnp.sum(i(), axis=0) # works
i().sum(axis=0) # doesn't work currently
```


(If the monkey patch is not desirable, I can also manually add the above methods, but I figured this would be a lot of boilerplate.) 
