### PR TITLE
Move docs requirements into pyproject toml

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,8 +1,0 @@
-sphinx
-sphinxcontrib-bibtex
-sphinx_rtd_theme
-myst_parser
-nbsphinx
-pyro-ppl
-torch
-dm-tree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,19 @@ jax = ["jax", "dm-tree"]
 numpyro = ["numpyro>=0.19", "dm-tree"]
 
 [dependency-groups]
-dev = [
+docs = [
     "sphinx",
     "sphinxcontrib-bibtex",
     "sphinx_rtd_theme",
     "myst-parser",
     "nbsphinx",
+    "sphinx_autodoc_typehints",
+    {include-group = "torch"},
+    {include-group = "pyro"},
+    {include-group = "jax"},
+    {include-group = "numpyro"},
+]
+dev = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
@@ -56,7 +63,7 @@ dev = [
     "ruff",
     "nbval",
     "nbqa",
-    "sphinx_autodoc_typehints",
+    {include-group = "docs"},
 ]
 
 [tool.ruff]


### PR DESCRIPTION
After #338 doc deployments are failing with [this error](https://github.com/BasisResearch/effectful/actions/runs/17277714474/job/49038619899):
```
  Extension error:
  Could not import extension sphinx_autodoc_typehints (exception: No module named 'sphinx_autodoc_typehints')
```
This should fix it by adding `sphinx_autodoc_typehints` to the docs dependencies and moving those to `pyproject.toml`.