### PR TITLE
Convert `syntactic_eq` to a singledispatch and add tensor support

### DIFF
--- a/effectful/handlers/jax/_handlers.py
+++ b/effectful/handlers/jax/_handlers.py
@@ -20,6 +20,7 @@ from effectful.ops.syntax import (
     deffn,
     defop,
     defterm,
+    syntactic_eq,
 )
 from effectful.ops.types import Expr, NotHandled, Operation, Term
 
@@ -283,3 +284,10 @@ def _indexed_func_wrapper[**P, S, T](
         return indexed_ret
 
     return deindexed, reindex
+
+
+@syntactic_eq.register
+def _(x: jax.typing.ArrayLike, other) -> bool:
+    return isinstance(other, jax.typing.ArrayLike) and bool(  # type: ignore[arg-type]
+        (jnp.asarray(x) == jnp.asarray(other)).all()
+    )

--- a/effectful/handlers/torch.py
+++ b/effectful/handlers/torch.py
@@ -14,7 +14,7 @@ import tree
 from effectful.internals.runtime import interpreter
 from effectful.internals.tensor_utils import _desugar_tensor_index
 from effectful.ops.semantics import apply, evaluate, fvsof, handler, typeof
-from effectful.ops.syntax import Scoped, defdata, defop, defterm
+from effectful.ops.syntax import Scoped, defdata, defop, defterm, syntactic_eq
 from effectful.ops.types import Expr, NotHandled, Operation, Term
 
 # + An element of a tensor index expression.
@@ -717,3 +717,8 @@ def vmap(func, *args, **kwargs):
     # indexed_dim_n, pos_dim_1, ..., pos_dim_m], so we reapply indexes starting
     # at dim 1
     return lambda *a, **k: reindex(vmap_func(*a, *k), starting_dim=1)
+
+
+@syntactic_eq.register
+def _(x: torch.Tensor, other) -> bool:
+    return isinstance(other, torch.Tensor) and bool((x == other).all())

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -1173,7 +1173,6 @@ def _(x: collections.abc.Sequence, other) -> bool:
     )
 
 
-@syntactic_eq.register
 class ObjectInterpretation[T, V](collections.abc.Mapping):
     """A helper superclass for defining an ``Interpretation`` of many
     :class:`~effectful.ops.types.Operation` instances with shared state or behavior.

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -1115,39 +1115,15 @@ iter_ = _IterableTerm.__iter__
 next_ = _IteratorTerm.__next__
 
 
-def syntactic_eq[T](x: Expr[T], other: Expr[T]) -> bool:
+@functools.singledispatch
+def syntactic_eq(x, other) -> bool:
     """Syntactic equality, ignoring the interpretation of the terms.
 
     :param x: A term.
     :param other: Another term.
     :returns: ``True`` if the terms are syntactically equal and ``False`` otherwise.
     """
-    if isinstance(x, Term) and isinstance(other, Term):
-        op, args, kwargs = x.op, x.args, x.kwargs
-        op2, args2, kwargs2 = other.op, other.args, other.kwargs
-        return (
-            op == op2
-            and len(args) == len(args2)
-            and set(kwargs) == set(kwargs2)
-            and all(syntactic_eq(a, b) for a, b in zip(args, args2))
-            and all(syntactic_eq(kwargs[k], kwargs2[k]) for k in kwargs)
-        )
-    elif isinstance(x, Term) or isinstance(other, Term):
-        return False
-    elif isinstance(x, collections.abc.Mapping) and isinstance(
-        other, collections.abc.Mapping
-    ):
-        return all(
-            k in x and k in other and syntactic_eq(x[k], other[k])
-            for k in set(x) | set(other)
-        )
-    elif isinstance(x, collections.abc.Sequence) and isinstance(
-        other, collections.abc.Sequence
-    ):
-        return len(x) == len(other) and all(
-            syntactic_eq(a, b) for a, b in zip(x, other)
-        )
-    elif (
+    if (
         dataclasses.is_dataclass(x)
         and not isinstance(x, type)
         and dataclasses.is_dataclass(other)
@@ -1164,6 +1140,40 @@ def syntactic_eq[T](x: Expr[T], other: Expr[T]) -> bool:
         return x == other
 
 
+@syntactic_eq.register
+def _(x: Term, other) -> bool:
+    if not isinstance(other, Term):
+        return False
+
+    op, args, kwargs = x.op, x.args, x.kwargs
+    op2, args2, kwargs2 = other.op, other.args, other.kwargs
+    return (
+        op == op2
+        and len(args) == len(args2)
+        and set(kwargs) == set(kwargs2)
+        and all(syntactic_eq(a, b) for a, b in zip(args, args2))
+        and all(syntactic_eq(kwargs[k], kwargs2[k]) for k in kwargs)
+    )
+
+
+@syntactic_eq.register
+def _(x: collections.abc.Mapping, other) -> bool:
+    return isinstance(other, collections.abc.Mapping) and all(
+        k in x and k in other and syntactic_eq(x[k], other[k])
+        for k in set(x) | set(other)
+    )
+
+
+@syntactic_eq.register
+def _(x: collections.abc.Sequence, other) -> bool:
+    return (
+        isinstance(other, collections.abc.Sequence)
+        and len(x) == len(other)
+        and all(syntactic_eq(a, b) for a, b in zip(x, other))
+    )
+
+
+@syntactic_eq.register
 class ObjectInterpretation[T, V](collections.abc.Mapping):
     """A helper superclass for defining an ``Interpretation`` of many
     :class:`~effectful.ops.types.Operation` instances with shared state or behavior.

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -1178,9 +1178,6 @@ def _(x: collections.abc.Sequence, other) -> bool:
 @syntactic_eq.register(object)
 @syntactic_eq.register(str | bytes)
 def _(x: object, other) -> bool:
-    # if isinstance(other, Term):
-    #     return False
-    breakpoint()
     return x == other
 
 

--- a/tests/test_handlers_jax.py
+++ b/tests/test_handlers_jax.py
@@ -4,7 +4,7 @@ import pytest
 import effectful.handlers.jax.numpy as jnp
 from effectful.handlers.jax import bind_dims, jax_getitem, jit, sizesof
 from effectful.ops.semantics import evaluate, fvsof, handler
-from effectful.ops.syntax import defdata, defop
+from effectful.ops.syntax import defdata, defop, syntactic_eq
 from effectful.ops.types import Term
 
 
@@ -367,3 +367,9 @@ def test_jax_array():
 
     t2 = jnp.array([jax_getitem(jnp.array([1, 2, 3]), [y()])])
     assert isinstance(t2, Term)
+
+
+def test_array_eq():
+    x = defop(jax.Array)()
+    y = jnp.array([1, 2, 3])
+    assert syntactic_eq(x + y, x + y)

--- a/tests/test_handlers_torch.py
+++ b/tests/test_handlers_torch.py
@@ -16,7 +16,7 @@ from effectful.handlers.torch import (
     vmap,
 )
 from effectful.ops.semantics import evaluate, fvsof, handler
-from effectful.ops.syntax import deffn, defop, trace
+from effectful.ops.syntax import deffn, defop, syntactic_eq, trace
 from effectful.ops.types import Term
 
 logger = logging.getLogger(__name__)
@@ -630,3 +630,9 @@ def test_tensor_iter():
         len(i())
     with pytest.raises(TypeError):
         tuple(i())
+
+
+def test_tensor_eq():
+    x = defop(torch.Tensor)()
+    y = torch.tensor([1, 2, 3])
+    assert syntactic_eq(x + y, x + y)

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -848,3 +848,16 @@ def test_evaluate_2():
     assert isinstance(t, Term)
     with handler({x: lambda: 1, y: lambda: 2}):
         assert evaluate(t) == 3
+
+
+def test_syntactic_eq() -> None:
+    l = defop(list[int])()
+    assert syntactic_eq("test", "test")
+    assert syntactic_eq([1, 2, 3], [1, 2, 3])
+    assert syntactic_eq(set([1, 2, 3]), set([1, 2, 3]))
+    assert syntactic_eq({"a": 1, "b": 2}, {"b": 2, "a": 1})
+    assert syntactic_eq(l, l)
+    assert not syntactic_eq(1, defop(int)())
+    assert not syntactic_eq(defop(int)(), 1)
+    assert not syntactic_eq([], l)
+    assert not syntactic_eq(1, [])


### PR DESCRIPTION
Eliminates the need for a custom jax syntactic_eq in weighted.

Closes #276 