### PR TITLE
Make `defdata` and `__fvs_rule__` rely on `inspect.BoundArguments`

### DIFF
--- a/effectful/handlers/jax/_terms.py
+++ b/effectful/handlers/jax/_terms.py
@@ -227,7 +227,7 @@ class _ArrayTerm(Term[jax.Array]):
 class _EagerArrayTerm(_ArrayTerm):
     def __init__(self, op, tensor, key):
         new_shape, new_key = _desugar_tensor_index(tensor.shape, key)
-        super().__init__(op, jnp.reshape(tensor, new_shape), new_key)
+        super().__init__(op, jax.numpy.reshape(tensor, new_shape), new_key)
 
     def __iter__(self):
         for i in range(len(self)):

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -319,7 +319,7 @@ def typeof[T](term: Expr[T]) -> type[T]:
             return type(term)
 
 
-def fvsof[S](term: Expr[S]) -> set[Operation]:
+def fvsof[S](term: Expr[S]) -> collections.abc.Set[Operation]:
     """Return the free variables of an expression.
 
     **Example usage**:
@@ -337,12 +337,8 @@ def fvsof[S](term: Expr[S]) -> set[Operation]:
 
     def _update_fvs(op, *args, **kwargs):
         _fvs.add(op)
-        arg_ctxs, kwarg_ctxs = op.__fvs_rule__(*args, **kwargs)
-        bound_vars = set().union(
-            *(a for a in arg_ctxs),
-            *(k for k in kwarg_ctxs.values()),
-        )
-        for bound_var in bound_vars:
+        bindings = op.__fvs_rule__(*args, **kwargs)
+        for bound_var in set().union(*(bindings.args, *bindings.kwargs.values())):
             if bound_var in _fvs:
                 _fvs.remove(bound_var)
 

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -54,12 +54,7 @@ class Operation[**Q, V](abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __fvs_rule__(
-        self, *args: Q.args, **kwargs: Q.kwargs
-    ) -> tuple[
-        tuple[collections.abc.Set[Operation], ...],
-        dict[str, collections.abc.Set[Operation]],
-    ]:
+    def __fvs_rule__(self, *args: Q.args, **kwargs: Q.kwargs) -> inspect.BoundArguments:
         """
         Returns the sets of variables that appear free in each argument and keyword argument
         but not in the result of the operation, i.e. the variables bound by the operation.

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -848,3 +848,13 @@ def test_evaluate_2():
     assert isinstance(t, Term)
     with handler({x: lambda: 1, y: lambda: 2}):
         assert evaluate(t) == 3
+
+
+def test_arg_positioning():
+    @defop
+    def f(x):
+        raise NotHandled
+
+    assert isinstance(f(0), Term) and isinstance(f(x=0), Term)
+    assert f(0).args == f(x=0).args == (0,)
+    assert f(0).kwargs == f(x=0).kwargs == {}


### PR DESCRIPTION
Resolves #310 

This PR fixes the bug reported in #310 by using `inspect.Signature` and `inspect.BoundArguments` to correctly associate argument values with argument names. It also changes `__fvs_rule__` to return `inspect.BoundArguments`.

The PR includes a test with the case from #310 that fails on `master` and passes with the fix here.