### PR TITLE
Fix bug in `fvsof`

### DIFF
--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -338,7 +338,8 @@ def fvsof[S](term: Expr[S]) -> collections.abc.Set[Operation]:
     def _update_fvs(op, *args, **kwargs):
         _fvs.add(op)
         bindings = op.__fvs_rule__(*args, **kwargs)
-        for bound_var in set().union(*(bindings.args, *bindings.kwargs.values())):
+        for bound_var in set().union(*(*bindings.args, *bindings.kwargs.values())):
+            assert isinstance(bound_var, Operation)
             if bound_var in _fvs:
                 _fvs.remove(bound_var)
 

--- a/tests/test_ops_semantics.py
+++ b/tests/test_ops_semantics.py
@@ -753,3 +753,23 @@ def test_evaluate_deep():
     assert evaluate(evaluate(z(), intp=intp), intp=intp) == 3
 
     assert evaluate(z(), intp=intp) == 3
+
+
+def test_fvsof_binder():
+    x, y, z = defop(int), defop(int), defop(int)
+
+    @defop
+    def add(a: int, b: int) -> int:
+        raise NotHandled
+
+    @defop
+    def Lam2[A, B](
+        body: Annotated[int, Scoped[A | B]],
+        var1: Annotated[Operation[[], int], Scoped[A]],
+        var2: Annotated[Operation[[], int], Scoped[A]],
+    ) -> Annotated[Callable[[int, int], int], Scoped[B]]:
+        raise NotHandled
+
+    term = Lam2(add(x(), add(y(), z())), x, y)
+    assert not {x, y} <= fvsof(term)
+    assert fvsof(term) == {z, Lam2, add}


### PR DESCRIPTION
This PR fixes a small bug in `fvsof` that was inadvertently introduced in #343 and adds a regression test that would have caught it.