### PR TITLE
Add `namedtuple` case in `evaluate`

### DIFF
--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -250,6 +250,12 @@ def evaluate[T](expr: Expr[T], *, intp: Interpretation | None = None) -> Expr[T]
     elif isinstance(expr, collections.abc.Sequence):
         if isinstance(expr, str | bytes):
             return typing.cast(T, expr)  # mypy doesnt like ignore here, so we use cast
+        elif (
+            isinstance(expr, tuple)
+            and hasattr(expr, "_fields")
+            and all(hasattr(expr, field) for field in getattr(expr, "_fields"))
+        ):  # namedtuple
+            return type(expr)._make(evaluate(item) for item in expr)  # type: ignore
         else:
             return type(expr)(evaluate(item) for item in expr)  # type: ignore
     elif isinstance(expr, collections.abc.Set):

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -255,7 +255,9 @@ def evaluate[T](expr: Expr[T], *, intp: Interpretation | None = None) -> Expr[T]
             and hasattr(expr, "_fields")
             and all(hasattr(expr, field) for field in getattr(expr, "_fields"))
         ):  # namedtuple
-            return type(expr)._make(evaluate(item) for item in expr)  # type: ignore
+            return type(expr)(
+                **{field: evaluate(getattr(expr, field)) for field in expr._fields}
+            )
         else:
             return type(expr)(evaluate(item) for item in expr)  # type: ignore
     elif isinstance(expr, collections.abc.Set):

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -1161,11 +1161,23 @@ def _(x: collections.abc.Mapping, other) -> bool:
 
 @syntactic_eq.register
 def _(x: collections.abc.Sequence, other) -> bool:
-    return (
-        isinstance(other, collections.abc.Sequence)
-        and len(x) == len(other)
-        and all(syntactic_eq(a, b) for a, b in zip(x, other))
-    )
+    if (
+        isinstance(x, tuple)
+        and hasattr(x, "_fields")
+        and all(hasattr(x, f) for f in x._fields)
+    ):
+        return (
+            isinstance(other, tuple)
+            and hasattr(other, "_fields")
+            and x._fields == other._fields
+            and all(syntactic_eq(getattr(x, f), getattr(other, f)) for f in x._fields)
+        )
+    else:
+        return (
+            isinstance(other, collections.abc.Sequence)
+            and len(x) == len(other)
+            and all(syntactic_eq(a, b) for a, b in zip(x, other))
+        )
 
 
 @syntactic_eq.register(object)

--- a/tests/test_handlers_jax.py
+++ b/tests/test_handlers_jax.py
@@ -375,6 +375,14 @@ def test_array_eq():
     assert syntactic_eq(x + y, x + y)
 
 
+def test_jax_rotation():
+    import jax.scipy.spatial.transform
+
+    x = jax.scipy.spatial.transform.Rotation.from_rotvec(jnp.array([1, 2, 3]))
+    y = evaluate(x)
+    assert syntactic_eq(x, y)
+
+
 def test_arrayterm_all():
     """Test .all() method on _ArrayTerm."""
     i = defop(jax.Array, name="i")

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -594,6 +594,31 @@ def test_eval_dataclass() -> None:
     )
 
 
+def test_eval_namedtuple() -> None:
+    Point = collections.namedtuple("Point", ["x", "y"])
+    Line = collections.namedtuple("Line", ["start", "end"])
+    Lines = collections.namedtuple("Lines", ["origin", "lines"])
+
+    x, y = defop(int, name="x"), defop(int, name="y")
+    p1 = Point(x(), y())
+    p2 = Point(x() + 1, y() + 1)
+    line = Line(p1, p2)
+    lines = Lines(p1, [line])
+
+    assert {x, y} <= fvsof(lines)
+
+    assert p1 == lines.origin
+
+    with handler({x: lambda: 3, y: lambda: 4}):
+        evaluated_lines = evaluate(lines)
+
+    assert isinstance(evaluated_lines, Lines)
+    assert evaluated_lines == Lines(
+        origin=Point(3, 4),
+        lines=[Line(Point(3, 4), Point(4, 5))],
+    )
+
+
 def test_lambda_calculus_1():
     x, y = defop(int), defop(int)
 


### PR DESCRIPTION
Resolves #354 

This PR adds a pattern for `namedtuple` instance evaluation in `evaluate` that is general enough to cover `jax.scipy.spatial.transform.Rotation`. It includes a couple of unit tests that failed before this PR and pass after.