### PR TITLE
Add support for methods in `Template.define` (#377)

### DIFF
--- a/effectful/handlers/llm/__init__.py
+++ b/effectful/handlers/llm/__init__.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import inspect
 from collections.abc import Callable, Iterable
 
@@ -15,6 +16,12 @@ class Template[**P, T]:
     @defop
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
         raise NotHandled
+
+    def __get__(self, instance, _owner):
+        if instance is not None:
+            return functools.partial(self, instance)
+        else:
+            return self
 
     @classmethod
     def define(cls, _func=None, *, tools: Iterable[Operation] = ()):


### PR DESCRIPTION
Implements support for methods for `Template.define` closing #377 .