### PR TITLE
store source of generated functions in `__src__` attribute

### DIFF
--- a/effectful/handlers/llm/synthesis.py
+++ b/effectful/handlers/llm/synthesis.py
@@ -1,6 +1,7 @@
 import ast
 import collections.abc
 import dataclasses
+import linecache
 import re
 import textwrap
 import typing
@@ -43,10 +44,18 @@ class ProgramSynthesis(ObjectInterpretation):
         if not isinstance(last_decl, ast.FunctionDef):
             raise SynthesisError("last definition not a function", content)
 
+        source_code = textwrap.dedent(code)
+        lines = code.splitlines(keepends=True)
+        filename = f"<generated-{hash(code)}>"
+
+        # register into linecache
+        linecache.cache[filename] = (len(source_code), None, lines, filename)
+
         # TODO: assert callable type compatibility
         gs: dict = {}
         try:
-            exec(code, gs)
+            code_obj = compile(source_code, filename, "exec")
+            exec(code_obj, gs)
         except Exception as exc:
             raise SynthesisError("evaluation failed", content) from exc
 
@@ -87,6 +96,5 @@ class ProgramSynthesis(ObjectInterpretation):
         )
 
         functional = self._parse_and_eval(ret_type, response)
-        setattr(functional, "__src__", response)
 
         return functional


### PR DESCRIPTION
Proposal to close #402. Stash the source code into `__src__` of the generated functional