### PR TITLE
Fix `syntactic_eq` implementation for jax arrays

### DIFF
--- a/effectful/handlers/jax/_handlers.py
+++ b/effectful/handlers/jax/_handlers.py
@@ -281,7 +281,9 @@ def _indexed_func_wrapper[**P, S, T](
 
 
 @syntactic_eq.register
-def _(x: jax.typing.ArrayLike, other) -> bool:
-    return isinstance(other, jax.typing.ArrayLike) and bool(  # type: ignore[arg-type]
-        (jnp.asarray(x) == jnp.asarray(other)).all()
+def _(x: jax.Array, other) -> bool:
+    return (
+        isinstance(other, jax.Array)
+        and x.shape == other.shape
+        and bool((jnp.asarray(x) == jnp.asarray(other)).all())
     )

--- a/tests/test_handlers_jax.py
+++ b/tests/test_handlers_jax.py
@@ -374,6 +374,9 @@ def test_array_eq():
     y = jnp.array([1, 2, 3])
     assert syntactic_eq(x + y, x + y)
 
+    z = jnp.array([1, 2, 3, 4])
+    assert not syntactic_eq(x + y, x + z)
+
 
 def test_jax_rotation():
     import jax.scipy.spatial.transform


### PR DESCRIPTION
Previously didn't handle arrays of different shapes properly.