### PR TITLE
Fix recursion error in sizesof

### DIFF
--- a/effectful/handlers/jax/_handlers.py
+++ b/effectful/handlers/jax/_handlers.py
@@ -13,7 +13,7 @@ except ImportError:
 import tree
 
 from effectful.internals.runtime import interpreter
-from effectful.ops.semantics import apply, evaluate, fvsof, handler, typeof
+from effectful.ops.semantics import apply, evaluate, fvsof, typeof
 from effectful.ops.syntax import (
     Scoped,
     _CustomSingleDispatchCallable,


### PR DESCRIPTION
Bug introduced by #399. `handler` should have been `interpreter`; we don't want to evaluate any other handlers in `sizesof`.