### PR TITLE
Implement `FirstToKAhead` Sampler

### DIFF
--- a/effectful/handlers/llm/sampling.py
+++ b/effectful/handlers/llm/sampling.py
@@ -1,0 +1,47 @@
+from collections import Counter
+from concurrent import futures
+from concurrent.futures.thread import ThreadPoolExecutor
+
+from effectful.handlers.llm import Template
+from effectful.internals.runtime import get_interpretation, interpreter
+from effectful.ops.semantics import fwd
+from effectful.ops.syntax import ObjectInterpretation, implements
+
+
+class KAheadSampler[**P, T](ObjectInterpretation):
+    no_voters: int
+    k: int
+    """Number of votes ahead before an answer is accepted"""
+    votes: Counter[T] = Counter()
+
+    def __init__(self, no_voters: int = 6, k: int = 3):
+        self.no_voters = no_voters
+        self.k = k
+
+    @implements(Template.__call__)
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
+        executor = ThreadPoolExecutor()
+        intp = get_interpretation()
+        tasks = [
+            executor.submit(interpreter(intp)(fwd), *args, **kwargs)
+            for _ in range(self.no_voters)
+        ]
+
+        def n_votes_ahead():
+            match self.votes.most_common(2):
+                case [[_, v1], [_, v2]]:
+                    return v1 >= v2 + self.k
+                case [[_, v1]]:
+                    return v1 >= self.k
+                case _:
+                    return False
+
+        while not n_votes_ahead():
+            done, remain = futures.wait(tasks, return_when=futures.FIRST_COMPLETED)
+            tasks = list(remain)
+            for fut in done:
+                res = fut.result()
+                self.votes[res] += 1
+                tasks.append(executor.submit(interpreter(intp)(fwd), *args, **kwargs))
+        executor.shutdown()
+        return self.votes.most_common(1)[0][0]

--- a/effectful/internals/runtime.py
+++ b/effectful/internals/runtime.py
@@ -2,13 +2,14 @@ import contextlib
 import dataclasses
 import functools
 from collections.abc import Callable, Mapping
+from threading import local
 
 from effectful.ops.syntax import defop
 from effectful.ops.types import Interpretation, Operation
 
 
 @dataclasses.dataclass
-class Runtime[S, T]:
+class Runtime[S, T](local):
     interpretation: "Interpretation[S, T]"
 
 


### PR DESCRIPTION
Closes #407 

```python
class MovieGenre(str, Enum):
    ACTION = "action"
    COMEDY = "comedy"
    DRAMA = "drama"
    HORROR = "horror"
    SCIFI = "sci-fi"
    ROMANCE = "romance"


@Template.define
def classify_genre(plot: str) -> MovieGenre:
    """Classify the movie genre based on this plot: {plot}
    Respond with exactly one of: action, comedy, drama, horror, sci-fi, romance"""
    raise NotImplementedError

plot = "A rogue cop must stop a terrorist group from detonating bombs across the city."
with handler(LLMLoggingHandler()), handler(OpenAIAPIProvider(openai.OpenAI())):
    with handler(KAheadSampler()):
        genre = classify_genre(plot)
    print(f"\nsampled genre: {genre}")
```