### PR TITLE
Implemented `ReducedKAheadSampler`

### DIFF
--- a/effectful/handlers/llm/sampling.py
+++ b/effectful/handlers/llm/sampling.py
@@ -1,4 +1,5 @@
-from collections import Counter
+from collections import Counter, defaultdict
+from collections.abc import Callable
 from concurrent import futures
 from concurrent.futures.thread import ThreadPoolExecutor
 
@@ -45,3 +46,60 @@ class KAheadSampler[**P, T](ObjectInterpretation):
                 tasks.append(executor.submit(interpreter(intp)(fwd), *args, **kwargs))
         executor.shutdown()
         return self.votes.most_common(1)[0][0]
+
+
+class ReducedKAheadSampler[**P, T, K](ObjectInterpretation):
+    """KAheadSampler for LLM calls, where votes are generated from LLM outputs."""
+
+    no_voters: int
+    k: int
+    """Number of votes ahead before an answer is accepted"""
+
+    votes: Counter[K] = Counter()
+    results: dict[K, set[T]] = defaultdict(set)
+    reducer: Callable[[T], K]
+    select_best: Callable[[set[T]], T]
+
+    def __init__(
+        self,
+        reducer: Callable[[T], K],
+        select_best: Callable[[set[T]], T] = lambda s: next(iter(s)),
+        no_voters: int = 6,
+        k: int = 3,
+    ):
+        self.no_voters = no_voters
+        self.k = k
+        self.reducer = reducer
+        self.select_best = select_best
+
+    @implements(Template.__call__)
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
+        executor = ThreadPoolExecutor()
+        intp = get_interpretation()
+        tasks = [
+            executor.submit(interpreter(intp)(fwd), *args, **kwargs)
+            for _ in range(self.no_voters)
+        ]
+
+        def n_votes_ahead():
+            match self.votes.most_common(2):
+                case [[_, v1], [_, v2]]:
+                    return v1 >= v2 + self.k
+                case [[_, v1]]:
+                    return v1 >= self.k
+                case _:
+                    return False
+
+        while not n_votes_ahead():
+            done, remain = futures.wait(tasks, return_when=futures.FIRST_COMPLETED)
+            tasks = list(remain)
+            for fut in done:
+                res = fut.result()
+                vote = self.reducer(res)
+                self.votes[vote] += 1
+                self.results[vote].add(res)
+                tasks.append(executor.submit(interpreter(intp)(fwd), *args, **kwargs))
+        executor.shutdown()
+        vote = self.votes.most_common(1)[0][0]
+        res = self.select_best(self.results[vote])
+        return res

--- a/effectful/handlers/llm/sampling.py
+++ b/effectful/handlers/llm/sampling.py
@@ -56,14 +56,14 @@ class ReducedKAheadSampler[**P, T, K](ObjectInterpretation):
     """Number of votes ahead before an answer is accepted"""
 
     votes: Counter[K] = Counter()
-    results: dict[K, set[T]] = defaultdict(set)
+    results: dict[K, list[T]] = defaultdict(list)
     reducer: Callable[[T], K]
-    select_best: Callable[[set[T]], T]
+    select_best: Callable[[list[T]], T]
 
     def __init__(
         self,
         reducer: Callable[[T], K],
-        select_best: Callable[[set[T]], T] = lambda s: next(iter(s)),
+        select_best: Callable[[list[T]], T] = lambda s: next(iter(s)),
         no_voters: int = 6,
         k: int = 3,
     ):
@@ -97,7 +97,7 @@ class ReducedKAheadSampler[**P, T, K](ObjectInterpretation):
                 res = fut.result()
                 vote = self.reducer(res)
                 self.votes[vote] += 1
-                self.results[vote].add(res)
+                self.results[vote].append(res)
                 tasks.append(executor.submit(interpreter(intp)(fwd), *args, **kwargs))
         executor.shutdown()
         vote = self.votes.most_common(1)[0][0]


### PR DESCRIPTION
This PR builds on top of #412. Often we would like to use an LLM to generate types that can not be hashed, or whose outputs do not lie within a small enough set such that voting is likely to complete in any reasonable amount of time (think generating anything with a string component, or callables). Yet these outputs may still have some "essense" in a smaller set which would still provide useful signal for voting.

This PR implements a `ReducedKAheadSampler` which allows the user to provide a `reducer` function which maps LLM generated outputs to a reduced key-set for voting, and then runs the usual k-ahead sampling algorithm.
```python
class MovieGenre(str, Enum):
    ACTION = "action"
    COMEDY = "comedy"
    DRAMA = "drama"
    HORROR = "horror"
    SCIFI = "sci-fi"
    ROMANCE = "romance"

@dataclass(frozen=True)
class MovieClassification:
    genre: MovieGenre
    explanation: str = Field(..., description="explanation for the given movie classification")

@Template.define
def classify_genre(plot: str) -> MovieClassification:
    """Classify the movie genre based on this plot: {plot}"""
    raise NotImplementedError


plot = "A rogue cop must stop a terrorist group from detonating bombs across the city."

with handler(LLMLoggingHandler()), handler(OpenAIAPIProvider(openai.OpenAI())):

    def reducer(classification: MovieClassification) -> MovieGenre:
        return classification.genre
    def select_best(results: list[MovieClassification]) -> MovieClassification:
        return max(results, key=lambda res: len(res.explanation))
    
    sampler = ReducedKAheadSampler(reducer, select_best=select_best)
    classification = handler(sampler)(classify_genre)(plot)
    print(classification)
```