### PR TITLE
Enabled term construction for all numerical comparison operators

### DIFF
--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -981,7 +981,6 @@ def implements[**P, V](op: Operation[P, V]):
 
 
 @defdata.register(numbers.Number)
-@functools.total_ordering
 class _NumberTerm[T: numbers.Number](_BaseTerm[T], numbers.Number):
     def __init__(self, ty, op, *args, **kwargs):
         super().__init__(op, *args, **kwargs)
@@ -1111,6 +1110,27 @@ class _NumberTerm[T: numbers.Number](_BaseTerm[T], numbers.Number):
     def __lt__(self, other) -> bool:
         if not isinstance(self, Term) and not isinstance(other, Term):
             return self.__lt__(other)
+        else:
+            raise NotHandled
+
+    @defop
+    def __gt__(self, other) -> bool:
+        if not isinstance(self, Term) and not isinstance(other, Term):
+            return self.__gt__(other)
+        else:
+            raise NotHandled
+
+    @defop
+    def __le__(self, other) -> bool:
+        if not isinstance(self, Term) and not isinstance(other, Term):
+            return self.__le__(other)
+        else:
+            raise NotHandled
+
+    @defop
+    def __ge__(self, other) -> bool:
+        if not isinstance(self, Term) and not isinstance(other, Term):
+            return self.__ge__(other)
         else:
             raise NotHandled
 

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -62,7 +62,6 @@ class _ClassMethodOpDescriptor(classmethod):
             return bound_op
 
 
-@functools.total_ordering
 class Operation[**Q, V]:
     """An abstract class representing an effect that can be implemented by an effect handler.
 
@@ -96,6 +95,21 @@ class Operation[**Q, V]:
         if not isinstance(other, Operation):
             return NotImplemented
         return id(self) < id(other)
+
+    def __gt__(self, other):
+        if not isinstance(other, Operation):
+            return NotImplemented
+        return id(self) > id(other)
+
+    def __le__(self, other):
+        if not isinstance(other, Operation):
+            return NotImplemented
+        return id(self) <= id(other)
+
+    def __ge__(self, other):
+        if not isinstance(other, Operation):
+            return NotImplemented
+        return id(self) >= id(other)
 
     def __hash__(self):
         return hash(self.__default__)

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -740,6 +740,13 @@ def test_arithmetic_5():
         assert syntactic_eq(Let(x, x() + 3, Let(x, x() + 4, x() + y())), x() + y() + 7)
 
 
+def test_arithmetic_6():
+    assert isinstance(defop(int)() > 1, Term)
+    assert isinstance(defop(int)() < 1, Term)
+    assert isinstance(defop(int)() >= 1, Term)
+    assert isinstance(defop(int)() <= 1, Term)
+
+
 def test_defun_1():
     x, y = defop(int), defop(int)
 


### PR DESCRIPTION
Closes #446 

```python
def test_arithmetic_6():
    assert isinstance(defop(int)() > 1, Term)
    assert isinstance(defop(int)() < 1, Term)
    assert isinstance(defop(int)() >= 1, Term)
    assert isinstance(defop(int)() <= 1, Term)
```

Fix was to remove uses of `@functools.total_ordering` and instead define all comparisons manually.