### PR TITLE
Update encodable type class to have optional prompt prefix (closes #498)

### DIFF
--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -42,6 +42,11 @@ class EncodableAs[T, U](ABC):
         pass
 
     @classmethod
+    def encoding_instructions(cls) -> str | None:
+        """Optional instructions to be prefixed onto synthesis prompts to tune the encoding of the result."""
+        return None
+
+    @classmethod
     def serialize(cls, value: U) -> list[OpenAIMessageContentListBlock]:
         return [{"type": "text", "text": str(value)}]
 


### PR DESCRIPTION
- Updates `EncodableAs` to have an optional class method `encoding_instructions`
```python
class EncodableAs[T, U](ABC):
    ...
    @classmethod
    def encoding_instructions(cls) -> str | None:
        """Optional instructions to be prefixed onto synthesis prompts to tune the encoding of the result."""
        return None

```
- Updates the default implementation for `format_model_input` to retrieve the encodable type for the return type and append a prompt prefix if encoding instructions is defined.
```python
    ret_type = template.__signature__.return_annotation
    origin = typing.get_origin(ret_type)
    ret_type = ret_type if origin is None else origin
    ret_type_encoder = type_to_encodable_type(ret_type)
    prompt_prefix = ret_type_encoder.encoding_instructions()

    if prompt_prefix:
        prefix: list[ChatCompletionTextObject] = [
            {"type": "text", "text": prompt_prefix}
        ]
        prompt = prefix + prompt
```

Closes #498