### PR TITLE
Avoid naming collision during synthesis

### DIFF
--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -586,14 +586,10 @@ def mypy_type_check(
     # (variable declarations and class stubs) that could collide with
     # function definitions in the synthesized module.
     declared_names = {
-        stmt.target.id  # type: ignore[union-attr]
+        stmt.target.id
         for stmt in variables
         if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
-    } | {
-        stmt.name  # type: ignore[union-attr]
-        for stmt in stubs
-        if isinstance(stmt, ast.ClassDef)
-    }
+    } | {stmt.name for stmt in stubs if isinstance(stmt, ast.ClassDef)}
 
     # Find all function names in the synthesized module that collide
     synthesized_func_names = {

--- a/tests/test_handlers_llm_type_checking.py
+++ b/tests/test_handlers_llm_type_checking.py
@@ -1365,13 +1365,13 @@ class TestMypyTypeCheckNameCollision:
                 return s.count('a')
         """)
         module = ast.parse(source)
-        original_name = module.body[-1].name  # type: ignore[union-attr]
+        original_name = module.body[-1].name
 
         ctx = get_context()
         mypy_type_check(module, ctx, [str], int)
 
         # Original AST must be untouched
-        assert module.body[-1].name == original_name  # type: ignore[union-attr]
+        assert module.body[-1].name == original_name
 
     def test_helper_reference_updated_after_rename(self):
         """When a helper function is renamed, calls to it inside other


### PR DESCRIPTION
This PR:
1. Add a AST-walking procedure to rename all colliding functions within the synthesized module.
2. Also walk the body/FunctionDef recursively for renaming.
3. Corresponding tests.

closes #542 