### PR TITLE
Add system prompt and tools for reading lexical variables

### DIFF
--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -396,33 +396,7 @@ def call_user(
 @Operation.define
 def call_system(template: Template) -> Message:
     """Get system instruction message(s) to prepend to all LLM prompts."""
-    assert inspect.getdoc(type(template)) is not None
-
-    system_prompt = inspect.cleandoc(f"""
-    You are responsible for implementing the `Template` '{template.__name__}' defined in the module source code below.
-
-    First, as background, here is the class-level documentation for the `Template` class::
-
-    {inspect.getdoc(type(template))}
-    """)
-
-    try:
-        system_prompt += inspect.cleandoc(f"""
-        Here is the source code of the module defining the `Template` instance '{template.__name__}'::
-
-        {inspect.getsource(inspect.getmodule(template))}
-        """)
-    except (TypeError, OSError):
-        system_prompt += inspect.cleandoc(f"""
-        The source code for the module defining '{template.__name__}' is not available.
-        Instead, here are the signature and docstring of '{template.__name__}'::
-
-        {template.__name__} :: {template.__signature__.format()}
-
-        {inspect.cleandoc(template.__prompt_template__)}
-        """)
-
-    message = _make_message(dict(role="system", content=system_prompt))
+    message = _make_message(dict(role="system", content=template.__system_prompt__))
     try:
         history: collections.OrderedDict[str, Message] = _get_history()
         if any(m["role"] == "system" for m in history.values()):

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -610,7 +610,7 @@ def test_template_method():
     assert "random" in a.f.tools
     # f is the template itself — found via self but correctly removed (non-recursive)
     assert "f" not in a.f.tools
-    assert "local_variable" in a.f.__context__ and "local_variable" not in a.f.tools
+    assert "local_variable" in a.f.__context__ and "local_variable" in a.f.tools
     assert a.f.tools["random"]() == 4
 
     class B(A):
@@ -623,7 +623,7 @@ def test_template_method():
     assert isinstance(b.f, Template)
     assert "random" in b.f.tools
     assert "reverse" in b.f.tools
-    assert "local_variable" in b.f.__context__ and "local_variable" not in a.f.tools
+    assert "local_variable" in b.f.__context__ and "local_variable" in b.f.tools
 
 
 def test_template_method_nested_class():
@@ -654,7 +654,7 @@ def test_template_method_nested_class():
     assert "random" in a.f.tools
     # f is the template itself — found via self but correctly removed (non-recursive)
     assert "f" not in a.f.tools
-    assert "local_variable" in a.f.__context__ and "local_variable" not in a.f.tools
+    assert "local_variable" in a.f.__context__ and "local_variable" in a.f.tools
     assert a.f.tools["random"]() == 4
 
 


### PR DESCRIPTION
Addresses #513 #497 

This PR adds a system prompt for `Template` calls consisting of the docstring of `Template` and the source code of the module where the `Template` is defined. Since dumping the entire lexical context into the prompt is infeasible in general, it also adds special tools that allow the LLM to read values of individual lexical variables into its context on demand.