### PR TITLE
Add Sphinx autodoc stub for missing `handlers.llm` submodules

### DIFF
--- a/docs/source/effectful.rst
+++ b/docs/source/effectful.rst
@@ -47,6 +47,13 @@ LLM
    :members:
    :undoc-members:
 
+Template
+""""""""
+
+.. automodule:: effectful.handlers.llm.template
+   :members:
+   :undoc-members:
+
 Encoding
 """"""""
 
@@ -60,6 +67,14 @@ Completions
 .. automodule:: effectful.handlers.llm.completions
    :members:
    :undoc-members:
+
+Evaluation
+""""""""""
+      
+.. automodule:: effectful.handlers.llm.evaluation
+   :members:
+   :undoc-members:
+
    
 Jax
 ^^^


### PR DESCRIPTION
Docs for these modules are currently not visible on GitHub Pages.