### PR TITLE
Fix names of Agent method Tools

### DIFF
--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -621,7 +621,10 @@ class ToolEncodable[**P, T](Encodable[Tool[P, T], pydantic.BaseModel]):
             {
                 "type": "function",
                 "function": {
-                    "name": value.__name__,
+                    "name": next(
+                        (k for k, v in self.ctx.items() if v is value),
+                        value.__name__,
+                    ),
                     "description": textwrap.dedent(value.__default__.__doc__),
                     "parameters": response_format["json_schema"]["schema"],
                     "strict": True,
@@ -669,7 +672,10 @@ class ToolCallEncodable[T](
                 "type": "tool_call",
                 "id": value.id,
                 "function": {
-                    "name": value.tool.__name__,
+                    "name": next(
+                        (k for k, v in self.ctx.items() if v is value.tool),
+                        value.tool.__name__,
+                    ),
                     "arguments": encoded_args.model_dump_json(),
                 },
             }

--- a/effectful/handlers/llm/template.py
+++ b/effectful/handlers/llm/template.py
@@ -228,7 +228,7 @@ class Template[**P, T](Tool[P, T]):
                 for cls in type(obj).__mro__:
                     for attr_name in vars(cls):
                         if isinstance(getattr(obj, attr_name), Tool):
-                            result[attr_name] = getattr(obj, attr_name)
+                            result[f"{name}.{attr_name}"] = getattr(obj, attr_name)
 
         # Deduplicate by tool identity and remove self-references.
         #


### PR DESCRIPTION
Resolves #588 

This PR fixes the bug in #588 where `Tool`s from different `Agent` instances could collide with one another due to insufficiently precise names.