### PR TITLE
Pin litellm < 1.82.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ pyro = ["pyro-ppl>=1.9.1"]
 jax = ["jax"]
 numpyro = ["numpyro>=0.19"]
 llm = [
-  "litellm",
+  "litellm<1.82.7",
   "tenacity",
   "mypy",
   "autoflake",


### PR DESCRIPTION
Addresses #620, pyproject 1.82.7 and above are vulnerable: https://github.com/BerriAI/litellm/issues/24512, https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/