### PR TITLE
Return original terms instead of `None` in `fvsof`

### DIFF
--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -8,7 +8,7 @@ import typing
 from collections.abc import Callable
 from typing import Any
 
-from effectful.ops.syntax import _CustomSingleDispatchCallable, defop
+from effectful.ops.syntax import _CustomSingleDispatchCallable, defdata, defop
 from effectful.ops.types import (
     Expr,
     Interpretation,
@@ -364,6 +364,7 @@ def fvsof[S](term: Expr[S]) -> collections.abc.Set[Operation]:
             assert isinstance(bound_var, Operation)
             if bound_var in _fvs:
                 _fvs.remove(bound_var)
+        return defdata(op, *args, **kwargs)
 
     with interpreter({apply: _update_fvs}):
         evaluate(term)

--- a/tests/test_ops_semantics.py
+++ b/tests/test_ops_semantics.py
@@ -1,4 +1,5 @@
 import contextlib
+import dataclasses
 import functools
 import itertools
 import logging
@@ -863,3 +864,16 @@ def test_typeof_literal():
 
     with pytest.raises(TypeError, match="Union types are not supported"):
         typeof(get_mixed())
+
+
+def test_fvsof_dataclass() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: int
+
+        def __init__(self, x: int):
+            assert x is not None
+            self.x = x
+
+    v = Operation.define(int)
+    assert fvsof(A(v())) == {v}


### PR DESCRIPTION
Closes #622 