### PR TITLE
updated build docs workflow to compile jupyter notebook to markdown

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -15,12 +15,40 @@ jobs:
       pages: write
       id-token: write
     steps:
-    - id: pandoc-install
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Install pandoc
+      run: sudo apt install -y pandoc
+
+    - name: Cache virtual environment
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+
+    - name: Install Python dependencies
+      run: uv sync --extra docs
+
+    - name: Build docs
+      run: cd docs && uv run make html
+
+    - name: Generate LLM agent reference markdown
       run: |
-        sudo apt install -y pandoc
+        uv run jupyter nbconvert --to markdown docs/source/llm.ipynb --output llm.md --output-dir docs/build/html/
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: docs/build/html
 
     - id: deployment
-      uses: sphinx-notes/pages@v3
-      with:
-        documentation_path: ./docs/source/
-        pyproject_extras: docs
+      name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -36,3 +36,7 @@ jobs:
       - name: Build docs
         run: |
           cd docs && uv run make html
+
+      - name: Generate LLM agent reference markdown
+        run: |
+          uv run jupyter nbconvert --to markdown docs/source/llm.ipynb --output llm.md --output-dir docs/build/html/

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,21 @@ We can make the evaluation strategy smarter by taking advantage of the commutati
    >>>     print(evaluate(e))
    add(8, add(x(), y()))
 
+Using with AI Agents
+--------------------
+
+A standalone Markdown reference for building effectful LLM applications is
+published with each documentation build. Point your AI coding agent (e.g.
+Claude Code, Cursor, Copilot) to:
+
+::
+
+   https://basisresearch.github.io/effectful/llm.md
+
+This file is auto-generated from the `LLM tutorial notebook <https://basisresearch.github.io/effectful/llm.html>`_
+and contains complete API usage examples for templates, tool calling,
+structured output, retries, and more.
+
 Learn More
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,12 @@ Table of Contents
    named_tensor_notation
    llm
 
+.. tip::
+
+   **For AI coding agents:** A standalone Markdown version of the LLM guide is
+   available at `llm.md <llm.md>`_ — point your agent there for a complete
+   reference on building effectful LLM applications.
+
 .. toctree::
    :maxdepth: 1
    :caption: Examples


### PR DESCRIPTION
closes #606, compiles the llm.ipynb notebook to a single markdown file `llm.md` that we can point coding agents to.