### PR TITLE
Remove ignore: type that's triggering an error

### DIFF
--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -392,7 +392,7 @@ def signature_to_ast(name: str, sig: inspect.Signature) -> ast.FunctionDef:
         except TypeError:
             returns = type_to_ast(typing.Any)
 
-    node = ast.FunctionDef(  # type: ignore
+    node = ast.FunctionDef(
         name=name,
         args=ast.arguments(
             posonlyargs=[],

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -415,6 +415,7 @@ def signature_to_ast(name: str, sig: inspect.Signature) -> ast.FunctionDef:
         ],
         decorator_list=[],
         returns=returns,
+        type_params=[]
     )
     return ast.fix_missing_locations(node)
 

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -415,7 +415,7 @@ def signature_to_ast(name: str, sig: inspect.Signature) -> ast.FunctionDef:
         ],
         decorator_list=[],
         returns=returns,
-        type_params=[]
+        type_params=[],
     )
     return ast.fix_missing_locations(node)
 


### PR DESCRIPTION
Just a dummy PR to see what error message the CI generates. Running `act` locally isn't feasible because I need the specific configuration cached by the CI, which sadly can't be accessed directly.