### PR TITLE
calculate cache key from pyproject.toml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,15 +15,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-
-      - name: Cache virtual environment
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install dependencies
         run: |
@@ -31,6 +25,3 @@ jobs:
 
       - name: Lint
         run: uv run ./scripts/lint.sh
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Lint
         run: uv run ./scripts/lint.sh
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Python
+        run: uv python install
+
       - name: Install dependencies
         run: |
           uv sync --all-extras --dev

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -52,3 +52,6 @@ jobs:
     - id: deployment
       name: Deploy to GitHub Pages
       uses: actions/deploy-pages@v4
+
+    - name: Minimize uv cache
+      run: uv cache prune --ci

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Install pandoc
       run: sudo apt install -y pandoc
 
+    - name: Set up Python
+      run: uv python install
+
     - name: Install Python dependencies
       run: uv sync --extra docs
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+        key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
       run: uv sync --extra docs

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -18,18 +18,12 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
     - name: Install pandoc
       run: sudo apt install -y pandoc
-
-    - name: Cache virtual environment
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
       run: uv sync --extra docs
@@ -52,6 +46,3 @@ jobs:
     - id: deployment
       name: Deploy to GitHub Pages
       uses: actions/deploy-pages@v4
-
-    - name: Minimize uv cache
-      run: uv cache prune --ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,6 @@ jobs:
         env:
           MKL_NUM_THREADS: 1
         run: uv run pytest ${{ matrix.test-group.paths }} -n auto
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-	  python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,11 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+	  python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
         run: |
-          uv sync --all-extras --dev --python ${{ matrix.python-version }}
+          uv sync --all-extras --dev
 
       - name: Run tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,15 +36,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-
-      - name: Cache virtual environment
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python dependencies
         run: |
@@ -54,6 +48,3 @@ jobs:
         env:
           MKL_NUM_THREADS: 1
         run: uv run pytest ${{ matrix.test-group.paths }} -n auto
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up Python
+        run: uv python install
+
       - name: Install Python dependencies
         run: |
           uv sync --all-extras --dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["'<3.13'", "'3.13'"]
+        python-version: ["<3.13", "3.13"]
         test-group:
           - name: indexed
             paths: tests/test_handlers_indexed*.py

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -40,3 +40,6 @@ jobs:
       - name: Generate LLM agent reference markdown
         run: |
           uv run jupyter nbconvert --to markdown docs/source/llm.ipynb --output llm.md --output-dir docs/build/html/
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -23,6 +23,9 @@ jobs:
         run: |
           sudo apt install -y pandoc
 
+      - name: Set up Python
+        run: uv python install
+
       - name: Install Python dependencies
         run: |
           uv sync --all-extras --dev

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -15,19 +15,13 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Install pandoc
         run: |
           sudo apt install -y pandoc
-
-      - name: Cache virtual environment
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python dependencies
         run: |
@@ -40,6 +34,3 @@ jobs:
       - name: Generate LLM agent reference markdown
         run: |
           uv run jupyter nbconvert --to markdown docs/source/llm.ipynb --output llm.md --output-dir docs/build/html/
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/test_llm.yml
+++ b/.github/workflows/test_llm.yml
@@ -24,6 +24,9 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up Python
+        run: uv python install
+
       - name: Install Python dependencies
         run: |
           uv sync --all-extras --dev

--- a/.github/workflows/test_llm.yml
+++ b/.github/workflows/test_llm.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-	  python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_llm.yml
+++ b/.github/workflows/test_llm.yml
@@ -19,15 +19,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-
-      - name: Cache virtual environment
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python dependencies
         run: |
@@ -40,6 +34,3 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           uv run pytest tests/test_handlers_llm_provider.py tests/test_handlers_llm_tool_calling_poem.py tests/test_handlers_llm_tool_calling_book.py -v --tb=short
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/test_llm.yml
+++ b/.github/workflows/test_llm.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_llm.yml
+++ b/.github/workflows/test_llm.yml
@@ -40,3 +40,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           uv run pytest tests/test_handlers_llm_provider.py tests/test_handlers_llm_tool_calling_poem.py tests/test_handlers_llm_tool_calling_book.py -v --tb=short
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/test_llm.yml
+++ b/.github/workflows/test_llm.yml
@@ -22,10 +22,11 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+	  python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
         run: |
-          uv sync --all-extras --dev --python ${{ matrix.python-version }}
+          uv sync --all-extras --dev
 
       - name: Run LLM integration tests
         env:

--- a/.github/workflows/test_llm.yml
+++ b/.github/workflows/test_llm.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["'3.13'"]
+        python-version: ["3.13"]
         model: ["gpt-4o-mini"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python packages
         run: |

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -46,3 +46,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           uv run ./scripts/test_notebooks.sh
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Python
+        run: uv python install
+
       - name: Install pandoc
         run: |
           sudo apt install -y pandoc

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -22,19 +22,13 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Install pandoc
         run: |
           sudo apt install -y pandoc
-
-      - name: Cache virtual environment
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install Python packages
         run: |
@@ -46,6 +40,3 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           uv run ./scripts/test_notebooks.sh
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci


### PR DESCRIPTION
uv.lock doesn't exist and we want the cache to properly refresh when we change pyproject.toml, which is the de facto source for supported package versions.

Fixes #635 