### PR TITLE
Make instance operations compatible with `super()`

### DIFF
--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -451,7 +451,9 @@ class Operation[**Q, V]:
     def __set_name__[T](self, owner: type[T], name: str) -> None:
         if not issubclass(owner, Term):
             assert not hasattr(self, "_name_on_instance"), "should only be called once"
-            self._name_on_instance: str = f"{INSTANCE_OP_PREFIX}_{name}"
+            self._name_on_instance: str = (
+                f"{INSTANCE_OP_PREFIX}_{owner.__name__}_{name}"
+            )
 
     def __get__[T](self, instance: T | None, owner: type[T] | None = None):
         if hasattr(instance, "__dict__") and hasattr(self, "_name_on_instance"):

--- a/tests/test_ops_semantics.py
+++ b/tests/test_ops_semantics.py
@@ -905,3 +905,6 @@ def test_instanceop_super() -> None:
     with handler({B.f: lambda self: super(B, self).f() + " and *B*"}):
         assert A().f() == "A"
         assert B().f() == "A and *B*"
+    b = B()
+    with handler({b.f: lambda: "*B*"}):
+        assert b.f() == "*B*"

--- a/tests/test_ops_semantics.py
+++ b/tests/test_ops_semantics.py
@@ -877,3 +877,31 @@ def test_fvsof_dataclass() -> None:
 
     v = Operation.define(int)
     assert fvsof(A(v())) == {v}
+
+
+def test_instanceop_super() -> None:
+    class A:
+        @Operation.define
+        def f(self):
+            return "A"
+
+    class B(A):
+        @Operation.define
+        def f(self):
+            return super().f() + " and B"
+
+    assert isinstance(A.f, Operation)
+    assert isinstance(A().f, Operation)
+    assert isinstance(B.f, Operation)
+    assert isinstance(B().f, Operation)
+
+    assert A.f != A().f != B.f != B().f
+
+    assert A().f() == "A"
+    assert B().f() == "A and B"
+    with handler({A.f: lambda self: "*A*"}):
+        assert A().f() == "*A*"
+        assert B().f() == "*A* and B"
+    with handler({B.f: lambda self: super(B, self).f() + " and *B*"}):
+        assert A().f() == "A"
+        assert B().f() == "A and *B*"


### PR DESCRIPTION
Without this modification, `B().f()` produces infinite recursion, because `super().f()` resolves to `self.f()`.