### PR TITLE
Unpin litellm dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ numpyro = [
   "jax<0.10"
 ]
 llm = [
-  "litellm<1.82.7",
+  "litellm",
   "tenacity",
   "mypy",
   "autoflake",


### PR DESCRIPTION
Removed version constraint for `litellm` package that isn't doing anything useful anymore.