### PR TITLE
Fix `_DistributionTerm.expand` return-type annotation

### DIFF
--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -425,29 +425,16 @@ class _DistributionMethodTerm(_DistributionTerm):
 
     @functools.cached_property
     def _pos_base_dist(self) -> dist.Distribution:
-        # Materialise the deferred method op against a real NumPyro distribution
-        # built from the (now-eager) receiver. Inherited ``@defop`` methods
-        # (``batch_shape``, ``event_shape``, ``support``, ``log_prob``,
-        # ``sample``, ...) then resolve via the standard ``_DistributionTerm``
-        # machinery against this base.
+        # Materialise by recursively building the receiver's _pos_base_dist
+        # and invoking NumPyro's method of the same name on it. Works for any
+        # ``dist.Distribution``-returning method op without a per-op switch.
         receiver = self._args[0]
         base = (
             receiver._pos_base_dist
             if isinstance(receiver, _DistributionTerm)
             else receiver
         )
-        if self._op is _DistributionTerm.to_event:
-            n = (
-                self._args[1]
-                if len(self._args) > 1
-                else self._kwargs.get("reinterpreted_batch_ndims")
-            )
-            return base.to_event(n)
-        if self._op is _DistributionTerm.expand:
-            return base.expand(self._args[1])
-        raise NotImplementedError(
-            f"_DistributionMethodTerm._pos_base_dist for op {self._op}"
-        )
+        return getattr(base, self._op.__name__)(*self._args[1:], **self._kwargs)
 
 
 @defop

--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -396,6 +396,32 @@ to_event = _DistributionTerm.to_event
 expand = _DistributionTerm.expand
 
 
+@defdata.register(dist.Distribution)
+class _DistributionMethodTerm(_DistributionTerm):
+    """Fallback term for distribution-method ops whose return annotation is the
+    abstract ``dist.Distribution`` (e.g. ``expand`` and ``to_event`` when the
+    receiver is non-eager).
+
+    Without this registration, ``defdata`` dispatch on ``dist.Distribution`` falls
+    through to ``collections.abc.Callable`` (since ``Distribution`` defines
+    ``__call__``) and produces a ``_CallableTerm``, breaking chained method calls
+    like ``Normal(mu_term, 1.0).expand([J]).to_event(1)``. See #666.
+
+    The receiver of the deferred op is taken as the first positional argument; we
+    carry forward its distribution family so further chained methods remain
+    available on the resulting term.
+    """
+
+    def __init__(self, ty, op, *args, **kwargs):
+        receiver = args[0] if args else None
+        constr = (
+            receiver._constr
+            if isinstance(receiver, _DistributionTerm)
+            else dist.Distribution
+        )
+        super().__init__(constr, op, *args, **kwargs)
+
+
 @defop
 def Cauchy(loc=0.0, scale=1.0, **kwargs) -> dist.Cauchy:
     raise NotHandled

--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -226,10 +226,12 @@ class _DistributionTerm(dist.Distribution):
 
     @functools.cached_property
     def _is_eager(self) -> bool:
-        return all(
-            (not isinstance(x, Term) or is_eager_array(x))
-            for x in (*self.args, *self.kwargs.values())
-        )
+        def _arg_is_eager(x):
+            if isinstance(x, _DistributionTerm):
+                return x._is_eager
+            return not isinstance(x, Term) or is_eager_array(x)
+
+        return all(_arg_is_eager(x) for x in (*self.args, *self.kwargs.values()))
 
     @property
     def op(self):
@@ -420,6 +422,32 @@ class _DistributionMethodTerm(_DistributionTerm):
             else dist.Distribution
         )
         super().__init__(constr, op, *args, **kwargs)
+
+    @functools.cached_property
+    def _pos_base_dist(self) -> dist.Distribution:
+        # Materialise the deferred method op against a real NumPyro distribution
+        # built from the (now-eager) receiver. Inherited ``@defop`` methods
+        # (``batch_shape``, ``event_shape``, ``support``, ``log_prob``,
+        # ``sample``, ...) then resolve via the standard ``_DistributionTerm``
+        # machinery against this base.
+        receiver = self._args[0]
+        base = (
+            receiver._pos_base_dist
+            if isinstance(receiver, _DistributionTerm)
+            else receiver
+        )
+        if self._op is _DistributionTerm.to_event:
+            n = (
+                self._args[1]
+                if len(self._args) > 1
+                else self._kwargs.get("reinterpreted_batch_ndims")
+            )
+            return base.to_event(n)
+        if self._op is _DistributionTerm.expand:
+            return base.expand(self._args[1])
+        raise NotImplementedError(
+            f"_DistributionMethodTerm._pos_base_dist for op {self._op}"
+        )
 
 
 @defop

--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -357,7 +357,7 @@ class _DistributionTerm(dist.Distribution):
         raise NotHandled
 
     @defop
-    def expand(self, batch_shape) -> jax.Array:
+    def expand(self, batch_shape) -> dist.Distribution:
         if not self._is_eager:
             raise NotHandled
 

--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -400,19 +400,9 @@ expand = _DistributionTerm.expand
 
 @defdata.register(dist.Distribution)
 class _DistributionMethodTerm(_DistributionTerm):
-    """Fallback term for distribution-method ops whose return annotation is the
-    abstract ``dist.Distribution`` (e.g. ``expand`` and ``to_event`` when the
-    receiver is non-eager).
-
-    Without this registration, ``defdata`` dispatch on ``dist.Distribution`` falls
-    through to ``collections.abc.Callable`` (since ``Distribution`` defines
-    ``__call__``) and produces a ``_CallableTerm``, breaking chained method calls
-    like ``Normal(mu_term, 1.0).expand([J]).to_event(1)``. See #666.
-
-    The receiver of the deferred op is taken as the first positional argument; we
-    carry forward its distribution family so further chained methods remain
-    available on the resulting term.
-    """
+    """Term for distribution-method ops returning the abstract ``dist.Distribution``
+    (``expand``, ``to_event``). Catches the ``defdata`` fallthrough that would
+    otherwise hit ``_CallableTerm``. See #666."""
 
     def __init__(self, ty, op, *args, **kwargs):
         receiver = args[0] if args else None
@@ -425,9 +415,7 @@ class _DistributionMethodTerm(_DistributionTerm):
 
     @functools.cached_property
     def _pos_base_dist(self) -> dist.Distribution:
-        # Materialise by recursively building the receiver's _pos_base_dist
-        # and invoking NumPyro's method of the same name on it. Works for any
-        # ``dist.Distribution``-returning method op without a per-op switch.
+        # Delegate to NumPyro's method of the same name on the materialised receiver.
         receiver = self._args[0]
         base = (
             receiver._pos_base_dist

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -932,7 +932,7 @@ def test_distribution_typeof():
 
 
 def test_distribution_method_chain_on_non_eager_term():
-    """Regression test for #666.
+    """Regression test for #666 (narrow).
 
     ``Normal(mu_term, 1.0).expand([J]).to_event(1)`` must not raise
     ``AttributeError`` mid-chain. Previously ``_DistributionTerm.expand`` was
@@ -949,3 +949,30 @@ def test_distribution_method_chain_on_non_eager_term():
 
     chained = expanded.to_event(1)
     assert isinstance(chained, numpyro.distributions.Distribution)
+
+
+def test_vectorised_hierarchical_model_mcmc():
+    """End-to-end regression for #666.
+
+    The issue framed the bug as blocking "the standard NumPyro vectorised
+    hierarchical-model idiom". With the annotation fix, the idiomatic form
+    (``numpyro.plate`` around a sample) traces correctly under MCMC and
+    produces samples of the expected shape.
+    """
+    import jax.random as jr
+
+    def model():
+        mu = numpyro.sample("mu", dist.Normal(0.0, 1.0))
+        with numpyro.plate("j", 3):
+            numpyro.sample("theta", dist.Normal(mu, 1.0))
+
+    mcmc = numpyro.infer.MCMC(
+        numpyro.infer.NUTS(model),
+        num_warmup=20,
+        num_samples=20,
+        progress_bar=False,
+    )
+    mcmc.run(jr.PRNGKey(0))
+    samples = mcmc.get_samples()
+    assert samples["mu"].shape == (20,)
+    assert samples["theta"].shape == (20, 3)

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -929,3 +929,23 @@ def test_distribution_typeof():
         typeof(dist.Normal(jax_getitem(jnp.array([0, 1, 2]), [defop(jax.Array)()])))
         is numpyro.distributions.continuous.Normal
     )
+
+
+def test_distribution_method_chain_on_non_eager_term():
+    """Regression test for #666.
+
+    ``Normal(mu_term, 1.0).expand([J]).to_event(1)`` must not raise
+    ``AttributeError`` mid-chain. Previously ``_DistributionTerm.expand`` was
+    ``@defop``-annotated to return ``jax.Array``, routing ``.expand([J])``'s
+    result through ``_ArrayTerm`` (no ``.to_event``). The fix annotates
+    ``expand`` to return ``dist.Distribution`` and registers a fallback
+    ``_DistributionMethodTerm`` for ``defdata`` dispatch on the abstract base,
+    so the chain stays in the distribution-term surface.
+    """
+    mu = defop(jax.Array, name="mu")
+
+    expanded = dist.Normal(mu(), 1.0).expand([3])
+    assert isinstance(expanded, numpyro.distributions.Distribution)
+
+    chained = expanded.to_event(1)
+    assert isinstance(chained, numpyro.distributions.Distribution)

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -951,3 +951,72 @@ def test_distribution_method_chain_on_non_eager_term():
     assert isinstance(chained, numpyro.distributions.Distribution)
 
 
+def test_expand_to_event_shape_laws():
+    """Equational laws for ``.expand`` and ``.to_event`` on a distribution term
+    whose free-variable arg has been bound by an effectful handler.
+
+    These hold for any NumPyro distribution and should survive any future
+    refactor of how deferred method ops are encoded:
+
+      d.expand(s).batch_shape == tuple(s)
+      d.expand(s).event_shape == d.event_shape
+      d.to_event(k).event_shape == d.batch_shape[-k:] + d.event_shape
+      d.to_event(k).batch_shape == d.batch_shape[:-k]
+    """
+    import jax.numpy as jnp
+
+    from effectful.ops.semantics import handler
+
+    mu = defop(jax.Array, name="mu")
+
+    with handler({mu: lambda: jnp.array(0.0)}):
+        d = dist.Normal(mu(), 1.0)
+        assert d.batch_shape == ()
+        assert d.event_shape == ()
+
+        expanded = d.expand([3, 4])
+        assert expanded.batch_shape == (3, 4)
+        assert expanded.event_shape == ()
+
+        indep = expanded.to_event(1)
+        assert indep.batch_shape == (3,)
+        assert indep.event_shape == (4,)
+
+        chained = d.expand([3]).to_event(1)
+        assert chained.batch_shape == ()
+        assert chained.event_shape == (3,)
+        assert not chained.support.is_discrete
+
+
+def test_expand_to_event_chain_end_to_end_mcmc():
+    """End-to-end regression: the literal #666 idiom — ``Normal(mu_term, 1.0)
+    .expand([J]).to_event(1)`` with ``mu_term`` bound by an effectful handler —
+    must trace, build a potential, and run MCMC to completion.
+
+    Before the fix this raised ``AttributeError: '_ArrayTerm' object has no
+    attribute 'to_event'`` at chain construction. After the fix, the chain
+    constructs a ``_DistributionMethodTerm`` whose materialised
+    ``_pos_base_dist`` resolves to a real ``dist.Independent`` wrapping the
+    handler-bound receiver, so NumPyro's downstream property/sample/log_prob
+    accesses all resolve.
+    """
+    import jax.numpy as jnp
+    import jax.random as jr
+
+    from effectful.ops.semantics import handler
+
+    mu = defop(jax.Array, name="mu")
+
+    def model():
+        numpyro.sample("theta", dist.Normal(mu(), 1.0).expand([3]).to_event(1))
+
+    with handler({mu: lambda: jnp.array(0.0)}):
+        mcmc = numpyro.infer.MCMC(
+            numpyro.infer.NUTS(model),
+            num_warmup=20,
+            num_samples=20,
+            progress_bar=False,
+        )
+        mcmc.run(jr.PRNGKey(0))
+
+    assert mcmc.get_samples()["theta"].shape == (20, 3)

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -480,7 +480,6 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
                 ("concentration0", f"exp(rand({batch_shape + indep_shape}))"),
             ),
             batch_shape,
-            xfail="to_event not implemented",
         )
 
         # Dirichlet.to_event
@@ -494,7 +493,6 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
                     ),
                 ),
                 batch_shape,
-                xfail="to_event not implemented",
             )
 
         # TransformedDistribution.to_event
@@ -513,7 +511,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
                 ("high", f"2. + rand({batch_shape + indep_shape})"),
             ),
             batch_shape,
-            xfail="to_event not implemented",
+            xfail="TransformedDistribution not implemented",
         )
 
 

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -951,28 +951,3 @@ def test_distribution_method_chain_on_non_eager_term():
     assert isinstance(chained, numpyro.distributions.Distribution)
 
 
-def test_vectorised_hierarchical_model_mcmc():
-    """End-to-end regression for #666.
-
-    The issue framed the bug as blocking "the standard NumPyro vectorised
-    hierarchical-model idiom". With the annotation fix, the idiomatic form
-    (``numpyro.plate`` around a sample) traces correctly under MCMC and
-    produces samples of the expected shape.
-    """
-    import jax.random as jr
-
-    def model():
-        mu = numpyro.sample("mu", dist.Normal(0.0, 1.0))
-        with numpyro.plate("j", 3):
-            numpyro.sample("theta", dist.Normal(mu, 1.0))
-
-    mcmc = numpyro.infer.MCMC(
-        numpyro.infer.NUTS(model),
-        num_warmup=20,
-        num_samples=20,
-        progress_bar=False,
-    )
-    mcmc.run(jr.PRNGKey(0))
-    samples = mcmc.get_samples()
-    assert samples["mu"].shape == (20,)
-    assert samples["theta"].shape == (20, 3)

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -480,6 +480,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
                 ("concentration0", f"exp(rand({batch_shape + indep_shape}))"),
             ),
             batch_shape,
+            xfail="to_event composed with expand_by on indexed dims not implemented",
         )
 
         # Dirichlet.to_event
@@ -493,6 +494,7 @@ for batch_shape in [(5,), (2, 3, 4), ()]:
                     ),
                 ),
                 batch_shape,
+                xfail="to_event composed with expand_by on indexed dims not implemented",
             )
 
         # TransformedDistribution.to_event


### PR DESCRIPTION
Closes #666.

Per [@eb8680's feedback](https://github.com/BasisResearch/effectful/pull/667) — sticking to NumPyro's `Distribution.expand` signature (`-> Distribution`) rather than monkey-patching it to `-> Self`. Reverted the `typing.Self` annotation attempt and the merge of #613. Back to registering a `defdata` case for `dist.Distribution` (per @jfeser's suggestion in the same thread).

**Three small changes in `effectful/handlers/numpyro.py`:**

1. `_DistributionTerm.expand` return annotation: `jax.Array` → `dist.Distribution`. Was routing `.expand([J])` through `_ArrayTerm`, breaking `.to_event(1)` chaining.

2. `_DistributionTerm._is_eager` recurses into `_DistributionTerm`-valued args (rather than treating them as non-eager via `is_eager_array`). Otherwise a fully-eager `D.to_event(k)` would be tagged non-eager and every downstream property/sample method raised.

3. `defdata.register(dist.Distribution)` mapping to `_DistributionMethodTerm`. Without it, `dist.Distribution` falls through to `_CallableTerm` (since `Distribution` defines `__call__`). The class overrides `_pos_base_dist` to materialise by `getattr(base, self._op.__name__)(*args[1:], **kwargs)`, so every inherited `@defop` (`batch_shape`, `event_shape`, `support`, `log_prob`, `sample`, …) resolves through the standard machinery against the real NumPyro distribution.

**Three regression tests** (each verified to fail on master):
- narrow chain construction (the exact `AttributeError` from #666)
- equational shape/support laws on `.expand` / `.to_event`
- end-to-end MCMC over `Normal(mu_term, 1.0).expand([3]).to_event(1)` with `mu_term` bound via `effectful.ops.semantics.handler`

`Beta(...).to_event(k)` / `Dirichlet(...).to_event(k)` parametrised cases stay xfail — the basic chain works, but composing `.expand_by` on top with indexed (named-dim) arrays hits a deeper indexed-dim integration matter, out of scope for this PR.

Lint clean (ruff / format / mypy).