### PR TITLE
Break ReduceArrayGather rule into 2 steps

### DIFF
--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -156,7 +156,17 @@ class CartesianProductPlusJax(ObjectInterpretation):
 
 
 class ReduceArrayGather(ObjectInterpretation):
-    """M.reduce(body, {k: a} ∪ S) ≡ M.reduce(body[k := a[k']], {k': range(a.shape[0])} ∪ S)"""
+    """Split an array-valued stream into an index range and a length-1 stream:
+
+    M.reduce(body, {k: a} ∪ S) ≡ M.reduce(body, {i: range(a.shape[0]), k: (a[i()],)} ∪ S)
+
+    where ``i`` is fresh and ``a[i()] = unbind_dims(a, i)``. The length-1 stream
+    ``{k: (a[i()],)}`` is then eliminated by
+    :class:`~effectful.ops.monoid.EliminateSingletonStreams`, which substitutes
+    ``k := a[i()]`` into the body and the remaining streams. Together the two
+    steps perform the gather
+    ``M.reduce(body[k := a[i()]], {i: range(a.shape[0])} ∪ S)``.
+    """
 
     @implements(Monoid.reduce)
     def reduce(self, monoid, body, streams):
@@ -169,26 +179,21 @@ class ReduceArrayGather(ObjectInterpretation):
         body_fvs = fvsof(body)
         stream_keys = set(streams)
 
-        body_subst = {}
-        streams_subst = {}
-        range_streams = {}
+        new_streams: dict = {}
         progress = False
         for k, v in streams.items():
             if is_eager_array(v) and k in body_fvs and not (fvsof(v) & stream_keys):
-                kk = Operation.define(k)
-                body_subst[k] = deffn(unbind_dims(v, kk))
-                streams_subst[k] = kk
-                range_streams[kk] = range(v.shape[0])
+                index = Operation.define(k)
+                new_streams[index] = range(v.shape[0])
+                new_streams[k] = (unbind_dims(v, index),)
                 progress = True
             else:
-                range_streams[k] = v
+                new_streams[k] = v
 
         if not progress:
             return fwd()
 
-        subst_body = handler(body_subst)(evaluate)(body)
-        subst_streams = handler(streams_subst)(evaluate)(range_streams)
-        return monoid.reduce(subst_body, subst_streams)
+        return monoid.reduce(body, new_streams)
 
 
 class Reductor(Protocol):

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -872,6 +872,57 @@ class PlusCastFloat(ObjectInterpretation):
         return fwd()
 
 
+class EliminateSingletonStreams(ObjectInterpretation):
+    """Eliminate a length-1 stream by substituting its sole element.
+
+    reduce(M, body, {k: (v,)} ∪ S) = reduce(M, body[k := v], S[k := v])
+
+    Fires only when the sole element ``v`` is a :class:`Term`, i.e. a *symbolic*
+    singleton. This is exactly the form ``ReduceArrayGather`` produces (a gather
+    ``(a[i()],)``) and, more generally, every dependent singleton that
+    :class:`ReducePartial` cannot peel -- a non-outermost stream whose element
+    references another stream var. Concrete enumerated streams (``[0]``,
+    ``range(1)``) and monoid sentinels (``CartesianProduct.identity == [()]``)
+    have non-``Term`` elements and are left to ``ReducePartial`` / the
+    per-monoid rules.
+
+    Unlike ``ReducePartial``, this peels the stream wherever it sits in the loop
+    nest and substitutes symbolically rather than unrolling, leaving a
+    vectorized index range (e.g. the gather's range) intact instead of
+    materializing it.
+    """
+
+    @implements(Monoid.reduce)
+    def reduce(self, monoid, body, streams):
+        # Eliminate *all* symbolic length-1 streams in one pass via a
+        # simultaneous substitution. Doing them together (rather than one per
+        # invocation) keeps an interleaving reduction rule -- e.g.
+        # ``ReduceArray`` consuming a now-live index range -- from firing
+        # between eliminations, so sibling index ranges stay together and fuse
+        # into a single reduction.
+        singletons = {
+            k: vs[0]
+            for k, vs in streams.items()
+            if not isinstance(vs, Term)
+            and isinstance(vs, collections.abc.Sequence)
+            and len(vs) == 1
+            and isinstance(vs[0], Term)
+        }
+        if not singletons:
+            return fwd()
+
+        subs = {k: deffn(v) for k, v in singletons.items()}
+        new_body = handler(subs)(evaluate)(body)
+        new_streams = {
+            kk: handler(subs)(evaluate)(vv)
+            for kk, vv in streams.items()
+            if kk not in singletons
+        }
+        # reduce over no streams is a single (empty) assignment, i.e. the body
+        # itself -- not the monoid identity.
+        return monoid.reduce(new_body, new_streams) if new_streams else new_body
+
+
 class _ExtensibleInterpretation(UserDict, Interpretation):
     def extend(self, *intps: Interpretation) -> typing.Self:
         for intp in intps:
@@ -881,6 +932,7 @@ class _ExtensibleInterpretation(UserDict, Interpretation):
 
 NormalizeIntp = _ExtensibleInterpretation().extend(
     ReducePartial(),
+    EliminateSingletonStreams(),
     MonoidOverSequence(),
     MonoidOverMapping(),
     MonoidOverCallable(),

--- a/tests/test_handlers_jax_monoid.py
+++ b/tests/test_handlers_jax_monoid.py
@@ -17,7 +17,12 @@ from effectful.handlers.jax.monoid import (
     delta,
     einsum,
 )
-from effectful.ops.monoid import NormalizeIntp, Product, Sum
+from effectful.ops.monoid import (
+    EliminateSingletonStreams,
+    NormalizeIntp,
+    Product,
+    Sum,
+)
 from effectful.ops.semantics import coproduct, handler
 from tests._monoid_helpers import JaxBackend
 
@@ -44,6 +49,23 @@ def test_reduce_array_gather(monoid, reductor, backend: JaxBackend):
 
     lhs = monoid.reduce(x(), {x: X})
     rhs = monoid.reduce(unbind_dims(X, k), {k: range(X.shape[0])})
+    backend.check_rewrite(
+        lhs=lhs,
+        rhs=rhs,
+        rule=coproduct(ReduceArrayGather(), EliminateSingletonStreams()),
+    )
+
+
+@pytest.mark.parametrize("monoid,reductor", MONOIDS)
+def test_reduce_array_gather_step1(monoid, reductor, backend: JaxBackend):
+    """Step 1 alone: an array stream becomes an index range plus a length-1
+    stream holding the gathered element. ``ReduceArrayGather`` does not perform
+    the gather substitution itself -- that is ``EliminateSingletonStreams``."""
+    (x, k) = backend.define_vars("x", "k", ret="scalar")
+    X = jnp.arange(3)
+
+    lhs = monoid.reduce(x(), {x: X})
+    rhs = monoid.reduce(x(), {k: range(X.shape[0]), x: (unbind_dims(X, k),)})
     backend.check_rewrite(lhs=lhs, rhs=rhs, rule=ReduceArrayGather())
 
 
@@ -56,12 +78,17 @@ def test_reduce_array_gather_dep(monoid, reductor, backend: JaxBackend):
     )
     X = jnp.arange(3)
 
+    # The dependent stream ``y: f(x())`` gets the *gathered element* X[x]
+    # substituted for x -- i.e. ``f(X[x])`` -- not the bare index.
     lhs = monoid.reduce(g(x(), y()), {y: f(x()), x: X})
     rhs = monoid.reduce(
-        g(unbind_dims(X[:3], x), y()), {y: f(x()), x: range(X.shape[0])}
+        g(unbind_dims(X, x), y()),
+        {y: f(unbind_dims(X, x)), x: range(X.shape[0])},
     )
     backend.check_rewrite(
-        lhs=lhs, rhs=rhs, rule=coproduct(ReduceArrayGather(), ReduceDeltaSimpleRange())
+        lhs=lhs,
+        rhs=rhs,
+        rule=coproduct(ReduceArrayGather(), EliminateSingletonStreams()),
     )
 
 
@@ -77,7 +104,12 @@ def test_reduce_array_1(monoid, reductor, backend: JaxBackend):
         rhs=rhs,
         rule=functools.reduce(
             coproduct,  # type: ignore[arg-type]
-            [ReduceArrayGather(), ReduceArray(), ReduceDeltaSimpleRange()],
+            [
+                ReduceArrayGather(),
+                EliminateSingletonStreams(),
+                ReduceArray(),
+                ReduceDeltaSimpleRange(),
+            ],
         ),
     )
 
@@ -100,7 +132,12 @@ def test_reduce_array_2(monoid, reductor, backend: JaxBackend):
         rhs=rhs,
         rule=functools.reduce(
             coproduct,  # type: ignore[arg-type]
-            [ReduceArrayGather(), ReduceArray(), ReduceDeltaSimpleRange()],
+            [
+                ReduceArrayGather(),
+                EliminateSingletonStreams(),
+                ReduceArray(),
+                ReduceDeltaSimpleRange(),
+            ],
         ),
     )
 
@@ -131,6 +168,7 @@ def test_reduce_array_3(monoid, reductor, backend: JaxBackend):
             coproduct,  # type: ignore[arg-type]
             [
                 ReduceArrayGather(),
+                EliminateSingletonStreams(),
                 ReduceArray(),
                 ReduceDeltaSimpleRange(),
                 DeltaEmpty(),

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -10,6 +10,7 @@ import effectful.handlers.jax.monoid  # noqa: F401
 import effectful.handlers.jax.numpy as jnp
 from effectful.ops.monoid import (
     CartesianProduct,
+    EliminateSingletonStreams,
     Max,
     Min,
     Monoid,
@@ -352,6 +353,33 @@ def test_partial_4(monoid, backend: Backend):
     lhs = monoid.reduce(x(), {y: f(x()), x: [a(), b()]})
     rhs = monoid.plus(monoid.reduce(a(), {y: f(a())}), monoid.reduce(b(), {y: f(b())}))
     backend.check_rewrite(lhs=lhs, rhs=rhs, rule=ReducePartial())
+
+
+@pytest.mark.parametrize("monoid", ALL_MONOIDS)
+def test_eliminate_singleton_into_sibling(monoid, backend: Backend):
+    """A length-1 stream substitutes its element into the body *and* into a
+    sibling stream's definition, then drops out of the nest."""
+    x, y, a = backend.define_vars("x", "y", "a", ret="scalar")
+    f = backend.define_vars("f", arg_types=(backend.scalar_typ,), ret="stream")
+    g = backend.define_vars(
+        "g", arg_types=(backend.scalar_typ, backend.scalar_typ), ret="scalar"
+    )
+
+    lhs = monoid.reduce(g(x(), y()), {x: (a(),), y: f(x())})
+    rhs = monoid.reduce(g(a(), y()), {y: f(a())})
+    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=EliminateSingletonStreams())
+
+
+@pytest.mark.parametrize("monoid", ALL_MONOIDS)
+def test_eliminate_singleton_only_stream(monoid, backend: Backend):
+    """When the length-1 stream is the only stream, reducing over the now-empty
+    nest yields the substituted body itself (not the monoid identity)."""
+    x, a = backend.define_vars("x", "a", ret="scalar")
+    f = backend.define_vars("f", arg_types=(backend.scalar_typ,), ret="scalar")
+
+    lhs = monoid.reduce(f(x()), {x: (a(),)})
+    rhs = f(a())
+    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=EliminateSingletonStreams())
 
 
 @pytest.mark.parametrize("monoid", ALL_MONOIDS)


### PR DESCRIPTION
This PR breaks `ReduceArrayGather` into two separate rules (rewriting an array stream to a range and single-element dependent stream, and inlining the single-element stream) and generalizes the second one beyond array terms into something that lives in `ops.monoid`.