### PR TITLE
Add persistent Python REPL tool for Templates

### DIFF
--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -478,9 +478,12 @@ def call_tool(tool_call: DecodedToolCall) -> Message:
             *tool_call.bound_args.args, **tool_call.bound_args.kwargs
         )
     except ReplExecutionError as e:
-        # `exec_code`'s snippet raised: surface its trimmed transcript verbatim.
+        # `exec_code`'s snippet raised: surface its trimmed transcript verbatim,
+        # and expose the *real* exception so `catch_tool_errors` can match on it.
         raise CodeExecutionError(
-            raw_tool_call=tool_call, original_error=e, transcript=e.transcript
+            raw_tool_call=tool_call,
+            original_error=e.original_error,
+            transcript=e.transcript,
         ) from e
     except Exception as e:
         raise ToolCallExecutionError(raw_tool_call=tool_call, original_error=e) from e

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -31,7 +31,7 @@ from effectful.handlers.llm.encoding import (
     Encodable,
     to_content_blocks,
 )
-from effectful.handlers.llm.evaluation import ReplSession
+from effectful.handlers.llm.evaluation import ReplExecutionError, ReplSession
 from effectful.handlers.llm.template import (
     Agent,
     Template,
@@ -173,6 +173,27 @@ class ToolCallExecutionError[E: Exception, T](DecodingError[E]):
                 "role": "tool",
                 "tool_call_id": self.raw_tool_call.id,
                 "content": error_message,
+            },
+        )
+
+
+@dataclasses.dataclass
+class CodeExecutionError(ToolCallExecutionError):
+    """An `exec_code` snippet raised at runtime.
+
+    `ReplSession` already builds a self-contained, frame-trimmed transcript, so
+    the feedback is that ``transcript`` (captured stdout/stderr plus the user's
+    own traceback) verbatim rather than a generic stack trace.
+    """
+
+    transcript: str = ""
+
+    def to_feedback_message(self, include_traceback: bool) -> Message:
+        return _make_message(
+            {
+                "role": "tool",
+                "tool_call_id": self.raw_tool_call.id,
+                "content": self.transcript,
             },
         )
 
@@ -456,6 +477,11 @@ def call_tool(tool_call: DecodedToolCall) -> Message:
         result = tool_call.tool(
             *tool_call.bound_args.args, **tool_call.bound_args.kwargs
         )
+    except ReplExecutionError as e:
+        # `exec_code`'s snippet raised: surface its trimmed transcript verbatim.
+        raise CodeExecutionError(
+            raw_tool_call=tool_call, original_error=e, transcript=e.transcript
+        ) from e
     except Exception as e:
         raise ToolCallExecutionError(raw_tool_call=tool_call, original_error=e) from e
 

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -10,6 +10,7 @@ import textwrap
 import traceback
 import typing
 import uuid
+import weakref
 
 import litellm
 import pydantic
@@ -30,6 +31,7 @@ from effectful.handlers.llm.encoding import (
     Encodable,
     to_content_blocks,
 )
+from effectful.handlers.llm.evaluation import ReplSession
 from effectful.handlers.llm.template import (
     Agent,
     Template,
@@ -287,6 +289,65 @@ class LexicalReaders(ObjectInterpretation):
             ):
                 continue
         return result
+
+
+class PythonRepl(ObjectInterpretation):
+    """Override `collect_tools` to expose a persistent Python session as an
+    `exec_code` Tool.
+
+    Off by default; install it where the LLM should be able to run code whose
+    state (variables, imports, definitions) survives across tool calls within
+    one Template invocation.  The session is keyed by the Template's lexical
+    context, seeded from it, and routes execution through the
+    `parse`/`compile`/`exec` effect operations.
+
+    v1 requires `UnsafeEvalProvider`: `RestrictedEvalProvider`'s exec drops
+    rebindings of seeded names and does not wire RestrictedPython's print
+    collector (tracked in #685), both of which break the REPL contract.
+    """
+
+    def __init__(self):
+        self._sessions: dict[int, ReplSession] = {}
+
+    def _session_for(
+        self, env: collections.abc.Mapping[str, typing.Any]
+    ) -> ReplSession:
+        key = id(env)
+        session = self._sessions.get(key)
+        if session is None:
+            # Prune the entry the instant `env` is collected: no leak, and the
+            # stale id can never alias a later object.  `pop` is bound to the
+            # dict (not `env`), so the finalizer does not keep `env` alive.
+            # `env` must be weak-referenceable -- the driver always passes a
+            # ChainMap (which is); guard the misuse path (e.g. a plain dict)
+            # with a clear message rather than skipping the finalizer, which
+            # would reintroduce the id-reuse hazard.
+            if not hasattr(env, "__weakref__"):
+                raise TypeError(
+                    f"PythonRepl needs a weak-referenceable lexical context to key "
+                    f"its session; got {type(env).__name__}, which is not. "
+                    f"Templates pass a ChainMap; only direct misuse hits this."
+                )
+            session = ReplSession(env)
+            self._sessions[key] = session
+            weakref.finalize(env, self._sessions.pop, key, None)
+        return session
+
+    @implements(collect_tools)
+    def _collect(
+        self, env: collections.abc.Mapping[str, typing.Any]
+    ) -> collections.abc.Mapping[str, Tool]:
+        tools = dict(fwd())
+
+        @Tool.define
+        def exec_code(source: str) -> str:
+            """Execute Python in a persistent session.  Variables, imports and
+            definitions carry across calls.  Returns the captured stdout and
+            stderr (use print() to inspect values)."""
+            return self._session_for(env).run(source)
+
+        tools.setdefault("exec_code", exec_code)  # a real user tool of same name wins
+        return tools
 
 
 @Operation.define

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -291,7 +291,7 @@ class LexicalReaders(ObjectInterpretation):
 
 
 @Operation.define
-def _repl_session(env: collections.abc.Mapping[str, typing.Any]) -> ReplSession:
+def _repl_session(env: collections.abc.MutableMapping[str, typing.Any]) -> ReplSession:
     """Return the REPL session for the current Template call, seeded from `env`.
 
     `PythonRepl` installs a fresh handler for this inside each `Template.__apply__`
@@ -334,7 +334,7 @@ class PythonRepl(ObjectInterpretation):
         session: ReplSession | None = None
 
         def session_for(
-            env: collections.abc.Mapping[str, typing.Any],
+            env: collections.abc.MutableMapping[str, typing.Any],
         ) -> ReplSession:
             nonlocal session
             if session is None:
@@ -349,7 +349,12 @@ class PythonRepl(ObjectInterpretation):
         self, env: collections.abc.Mapping[str, typing.Any]
     ) -> collections.abc.Mapping[str, Tool]:
         tools = dict(fwd())
-        tools["exec_code"] = _repl_session(env).exec_code
+        # `collect_tools` only promises a `Mapping`, but the per-call `env` is the
+        # writable `ChainMap` the session splices its shared scope layer into, so
+        # narrow it for `_repl_session`/`ReplSession`.
+        tools["exec_code"] = _repl_session(
+            typing.cast(collections.abc.MutableMapping[str, typing.Any], env)
+        ).exec_code
         return tools
 
 

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -349,11 +349,7 @@ class PythonRepl(ObjectInterpretation):
         self, env: collections.abc.Mapping[str, typing.Any]
     ) -> collections.abc.Mapping[str, Tool]:
         tools = dict(fwd())
-        # Reuse the session the enclosing `Template.__apply__` already installed
-        # for this call (see `_repl_session`) and expose its `exec_code` method
-        # directly -- the tool's behaviour, docstring and name all come from
-        # `ReplSession.exec_code`, nothing is hidden in this handler.
-        tools["exec_code"] = Tool.define(_repl_session(env).exec_code)
+        tools["exec_code"] = _repl_session(env).exec_code
         return tools
 
 

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -315,21 +315,13 @@ class PythonRepl(ObjectInterpretation):
         key = id(env)
         session = self._sessions.get(key)
         if session is None:
+            session = ReplSession(env)
+            self._sessions[key] = session
             # Prune the entry the instant `env` is collected: no leak, and the
             # stale id can never alias a later object.  `pop` is bound to the
             # dict (not `env`), so the finalizer does not keep `env` alive.
-            # `env` must be weak-referenceable -- the driver always passes a
-            # ChainMap (which is); guard the misuse path (e.g. a plain dict)
-            # with a clear message rather than skipping the finalizer, which
-            # would reintroduce the id-reuse hazard.
-            if not hasattr(env, "__weakref__"):
-                raise TypeError(
-                    f"PythonRepl needs a weak-referenceable lexical context to key "
-                    f"its session; got {type(env).__name__}, which is not. "
-                    f"Templates pass a ChainMap; only direct misuse hits this."
-                )
-            session = ReplSession(env)
-            self._sessions[key] = session
+            # `env` is the Template's lexical context (a ChainMap); a non
+            # weak-referenceable env (e.g. a bare dict) raises here, loudly.
             weakref.finalize(env, self._sessions.pop, key, None)
         return session
 

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -475,9 +475,6 @@ def call_tool(tool_call: DecodedToolCall) -> Message:
             *tool_call.bound_args.args, **tool_call.bound_args.kwargs
         )
     except Exception as e:
-        # An `exec_code` snippet error arrives here as a `ReplExecutionError`
-        # whose ``str`` is the trimmed transcript, so the generic feedback path
-        # surfaces it -- no bespoke exception type needed.
         raise ToolCallExecutionError(raw_tool_call=tool_call, original_error=e) from e
 
     return_type: pydantic.TypeAdapter[typing.Any] = pydantic.TypeAdapter(

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -10,7 +10,6 @@ import textwrap
 import traceback
 import typing
 import uuid
-import weakref
 
 import litellm
 import pydantic
@@ -31,7 +30,7 @@ from effectful.handlers.llm.encoding import (
     Encodable,
     to_content_blocks,
 )
-from effectful.handlers.llm.evaluation import ReplExecutionError, ReplSession
+from effectful.handlers.llm.evaluation import ReplSession
 from effectful.handlers.llm.template import (
     Agent,
     Template,
@@ -177,27 +176,6 @@ class ToolCallExecutionError[E: Exception, T](DecodingError[E]):
         )
 
 
-@dataclasses.dataclass
-class CodeExecutionError(ToolCallExecutionError):
-    """An `exec_code` snippet raised at runtime.
-
-    `ReplSession` already builds a self-contained, frame-trimmed transcript, so
-    the feedback is that ``transcript`` (captured stdout/stderr plus the user's
-    own traceback) verbatim rather than a generic stack trace.
-    """
-
-    transcript: str = ""
-
-    def to_feedback_message(self, include_traceback: bool) -> Message:
-        return _make_message(
-            {
-                "role": "tool",
-                "tool_call_id": self.raw_tool_call.id,
-                "content": self.transcript,
-            },
-        )
-
-
 type MessageResult[T] = tuple[Message, typing.Sequence[DecodedToolCall], T | None]
 
 
@@ -312,39 +290,67 @@ class LexicalReaders(ObjectInterpretation):
         return result
 
 
+class _NoActiveReplSessionException(Exception):
+    """Raised when there is no active REPL session to run code in."""
+
+
+@Operation.define
+def _repl_session(env: collections.abc.Mapping[str, typing.Any]) -> ReplSession:
+    """Return the REPL session for the current Template call, seeded from `env`.
+
+    Like `_get_history`, this has no meaning on its own: `PythonRepl` installs a
+    fresh handler for it inside each `Template.__apply__`, which is what gives the
+    session a lifetime of exactly one Template call.
+    """
+    raise _NoActiveReplSessionException(
+        "No active REPL session. `exec_code` is only available inside a Template "
+        "call handled by `PythonRepl`."
+    )
+
+
 class PythonRepl(ObjectInterpretation):
-    """Override `collect_tools` to expose a persistent Python session as an
-    `exec_code` Tool.
+    """Expose a persistent Python session to the LLM as an `exec_code` Tool.
 
     Off by default; install it where the LLM should be able to run code whose
-    state (variables, imports, definitions) survives across tool calls within
-    one Template invocation.  The session is keyed by the Template's lexical
-    context, seeded from it, and routes execution through the
-    `parse`/`compile`/`exec` effect operations.
+    state (variables, imports, definitions) survives across tool calls within a
+    single Template invocation.
+
+    Scoping mirrors how `__history__` is managed for Template calls: `PythonRepl`
+    handles `Template.__apply__` to introduce a fresh `_repl_session` handler for
+    the duration of the call, and handles `collect_tools` to inject an `exec_code`
+    Tool routed to that session.  The session is therefore introduced and
+    eliminated by its own handler, bounded to the Template call by construction --
+    there is no global registry of sessions and no weakref bookkeeping, and nested
+    Template calls get their own isolated sessions.
+
+    The session is seeded from the Template's lexical context and routes execution
+    through the `parse`/`compile`/`exec` effect operations.
 
     v1 requires `UnsafeEvalProvider`: `RestrictedEvalProvider`'s exec drops
     rebindings of seeded names and does not wire RestrictedPython's print
     collector (tracked in #685), both of which break the REPL contract.
     """
 
-    def __init__(self):
-        self._sessions: dict[int, ReplSession] = {}
+    @implements(Template.__apply__)
+    def _apply[**P, T](
+        self, template: Template[P, T], *args: P.args, **kwargs: P.kwargs
+    ) -> T:
+        # One session per Template call, created lazily on first use (the call's
+        # `env`, supplied by `collect_tools`/`exec_code`, seeds it).  The
+        # enclosing `handler(...)` bounds the session's lifetime to this call, so
+        # nested Template calls introduce their own fresh session.
+        session: ReplSession | None = None
 
-    def _session_for(
-        self, env: collections.abc.Mapping[str, typing.Any]
-    ) -> ReplSession:
-        key = id(env)
-        session = self._sessions.get(key)
-        if session is None:
-            session = ReplSession(env)
-            self._sessions[key] = session
-            # Prune the entry the instant `env` is collected: no leak, and the
-            # stale id can never alias a later object.  `pop` is bound to the
-            # dict (not `env`), so the finalizer does not keep `env` alive.
-            # `env` is the Template's lexical context (a ChainMap); a non
-            # weak-referenceable env (e.g. a bare dict) raises here, loudly.
-            weakref.finalize(env, self._sessions.pop, key, None)
-        return session
+        def session_for(
+            env: collections.abc.Mapping[str, typing.Any],
+        ) -> ReplSession:
+            nonlocal session
+            if session is None:
+                session = ReplSession(env)
+            return session
+
+        with handler({_repl_session: session_for}):
+            return fwd()
 
     @implements(collect_tools)
     def _collect(
@@ -357,7 +363,7 @@ class PythonRepl(ObjectInterpretation):
             """Execute Python in a persistent session.  Variables, imports and
             definitions carry across calls.  Returns the captured stdout and
             stderr (use print() to inspect values)."""
-            return self._session_for(env).run(source)
+            return _repl_session(env).run(source)
 
         tools.setdefault("exec_code", exec_code)  # a real user tool of same name wins
         return tools
@@ -477,15 +483,10 @@ def call_tool(tool_call: DecodedToolCall) -> Message:
         result = tool_call.tool(
             *tool_call.bound_args.args, **tool_call.bound_args.kwargs
         )
-    except ReplExecutionError as e:
-        # `exec_code`'s snippet raised: surface its trimmed transcript verbatim,
-        # and expose the *real* exception so `catch_tool_errors` can match on it.
-        raise CodeExecutionError(
-            raw_tool_call=tool_call,
-            original_error=e.original_error,
-            transcript=e.transcript,
-        ) from e
     except Exception as e:
+        # An `exec_code` snippet error arrives here as a `ReplExecutionError`
+        # whose ``str`` is the trimmed transcript, so the generic feedback path
+        # surfaces it -- no bespoke exception type needed.
         raise ToolCallExecutionError(raw_tool_call=tool_call, original_error=e) from e
 
     return_type: pydantic.TypeAdapter[typing.Any] = pydantic.TypeAdapter(

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -290,22 +290,17 @@ class LexicalReaders(ObjectInterpretation):
         return result
 
 
-class _NoActiveReplSessionException(Exception):
-    """Raised when there is no active REPL session to run code in."""
-
-
 @Operation.define
 def _repl_session(env: collections.abc.Mapping[str, typing.Any]) -> ReplSession:
     """Return the REPL session for the current Template call, seeded from `env`.
 
-    Like `_get_history`, this has no meaning on its own: `PythonRepl` installs a
-    fresh handler for it inside each `Template.__apply__`, which is what gives the
-    session a lifetime of exactly one Template call.
+    `PythonRepl` installs a fresh handler for this inside each `Template.__apply__`
+    (mirroring how `__history__` is managed), giving the session a lifetime of
+    exactly one Template call.  Outside such a scope there is no managed session,
+    so this falls back to a fresh one -- e.g. when tools are listed outside a
+    Template call.
     """
-    raise _NoActiveReplSessionException(
-        "No active REPL session. `exec_code` is only available inside a Template "
-        "call handled by `PythonRepl`."
-    )
+    return ReplSession(env)
 
 
 class PythonRepl(ObjectInterpretation):
@@ -320,8 +315,8 @@ class PythonRepl(ObjectInterpretation):
     the duration of the call, and handles `collect_tools` to inject an `exec_code`
     Tool routed to that session.  The session is therefore introduced and
     eliminated by its own handler, bounded to the Template call by construction --
-    there is no global registry of sessions and no weakref bookkeeping, and nested
-    Template calls get their own isolated sessions.
+    there is no global registry of sessions, and nested Template calls get their
+    own isolated sessions.
 
     The session is seeded from the Template's lexical context and routes execution
     through the `parse`/`compile`/`exec` effect operations.
@@ -357,15 +352,11 @@ class PythonRepl(ObjectInterpretation):
         self, env: collections.abc.Mapping[str, typing.Any]
     ) -> collections.abc.Mapping[str, Tool]:
         tools = dict(fwd())
-
-        @Tool.define
-        def exec_code(source: str) -> str:
-            """Execute Python in a persistent session.  Variables, imports and
-            definitions carry across calls.  Returns the captured stdout and
-            stderr (use print() to inspect values)."""
-            return _repl_session(env).run(source)
-
-        tools.setdefault("exec_code", exec_code)  # a real user tool of same name wins
+        # Reuse the session the enclosing `Template.__apply__` already installed
+        # for this call (see `_repl_session`) and expose its `exec_code` method
+        # directly -- the tool's behaviour, docstring and name all come from
+        # `ReplSession.exec_code`, nothing is hidden in this handler.
+        tools["exec_code"] = Tool.define(_repl_session(env).exec_code)
         return tools
 
 

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -5,9 +5,11 @@ import functools
 import inspect
 import io
 import json
+import linecache
 import textwrap
 import types
 import typing
+import uuid
 from collections.abc import (
     Callable,
     Mapping,
@@ -189,27 +191,42 @@ def _pydantic_type_complex(ty):
     ]
 
 
-@TypeToPydanticType.register(evaluation.EncodableCode)
-def _pydantic_type_code(ty):
-    """Encode `EncodableCode` as a JSON string.  Decoding compiles the source
-    (through the `parse`/`compile` ops), so invalid source is rejected here and
-    a valid `EncodableCode` carries a ready-to-run code object."""
+_CODE_FILENAME_PREFIX = "<exec_code-"
 
-    def validate(value: object) -> evaluation.EncodableCode:
-        if isinstance(value, evaluation.EncodableCode):
+
+@TypeToPydanticType.register(types.CodeType)
+def _pydantic_type_code(ty):
+    """Encode a `types.CodeType` as a JSON string of Python source.
+
+    This is the internal `Encodable` implementation for code objects -- the
+    public type is `types.CodeType`, with no separate model (analogous to
+    `_ComplexModel`).  Decoding compiles the source through the `parse`/`compile`
+    effect operations under a unique per-snippet filename, so invalid source is
+    rejected here rather than at run time and the snippet's source lands in
+    `linecache` (keeping each snippet's tracebacks resolvable).  A decoded value
+    is therefore a ready-to-run code object; re-encoding recovers its source from
+    `linecache`, which carries everything the source string did.
+    """
+
+    def validate(value: object) -> types.CodeType:
+        if isinstance(value, types.CodeType):
             return value
         if not isinstance(value, str):
             raise ValueError(
                 f"expected Python source as a string, got {type(value).__name__}"
             )
-        # `from_source` compiles via its field validator, raising a
-        # ValidationError if the source does not compile.
-        return evaluation.EncodableCode.from_source(value)
+        filename = f"{_CODE_FILENAME_PREFIX}{uuid.uuid4()}>"
+        try:
+            return evaluation.compile(evaluation.parse(value, filename), filename)
+        except (SyntaxError, ValueError) as exc:
+            raise ValueError(f"source does not compile: {exc}") from exc
 
     return typing.Annotated[
         ty,
         pydantic.PlainValidator(validate),
-        pydantic.PlainSerializer(lambda value: value.source),
+        pydantic.PlainSerializer(
+            lambda value: "".join(linecache.getlines(value.co_filename))
+        ),
         pydantic.WithJsonSchema({"type": "string"}),
     ]
 

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -189,31 +189,27 @@ def _pydantic_type_complex(ty):
     ]
 
 
-def _validate_code(value: object) -> evaluation.EncodableCode:
-    if isinstance(value, evaluation.EncodableCode):
-        return value
-    if not isinstance(value, str):
-        raise ValueError(
-            f"expected Python source as a string, got {type(value).__name__}"
-        )
-    # `from_source` compiles the source through its field validator, raising a
-    # ValidationError if it does not compile.
-    return evaluation.EncodableCode.from_source(value)
-
-
-def _serialize_code(value: evaluation.EncodableCode) -> str:
-    return value.source
-
-
 @TypeToPydanticType.register(evaluation.EncodableCode)
 def _pydantic_type_code(ty):
     """Encode `EncodableCode` as a JSON string.  Decoding compiles the source
     (through the `parse`/`compile` ops), so invalid source is rejected here and
     a valid `EncodableCode` carries a ready-to-run code object."""
+
+    def validate(value: object) -> evaluation.EncodableCode:
+        if isinstance(value, evaluation.EncodableCode):
+            return value
+        if not isinstance(value, str):
+            raise ValueError(
+                f"expected Python source as a string, got {type(value).__name__}"
+            )
+        # `from_source` compiles via its field validator, raising a
+        # ValidationError if the source does not compile.
+        return evaluation.EncodableCode.from_source(value)
+
     return typing.Annotated[
         ty,
-        pydantic.PlainValidator(_validate_code),
-        pydantic.PlainSerializer(_serialize_code),
+        pydantic.PlainValidator(validate),
+        pydantic.PlainSerializer(lambda value: value.source),
         pydantic.WithJsonSchema({"type": "string"}),
     ]
 

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -189,6 +189,35 @@ def _pydantic_type_complex(ty):
     ]
 
 
+def _validate_code(value: object) -> evaluation.EncodableCode:
+    if isinstance(value, evaluation.EncodableCode):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(
+            f"expected Python source as a string, got {type(value).__name__}"
+        )
+    # `from_source` compiles the source through its field validator, raising a
+    # ValidationError if it does not compile.
+    return evaluation.EncodableCode.from_source(value)
+
+
+def _serialize_code(value: evaluation.EncodableCode) -> str:
+    return value.source
+
+
+@TypeToPydanticType.register(evaluation.EncodableCode)
+def _pydantic_type_code(ty):
+    """Encode `EncodableCode` as a JSON string.  Decoding compiles the source
+    (through the `parse`/`compile` ops), so invalid source is rejected here and
+    a valid `EncodableCode` carries a ready-to-run code object."""
+    return typing.Annotated[
+        ty,
+        pydantic.PlainValidator(_validate_code),
+        pydantic.PlainSerializer(_serialize_code),
+        pydantic.WithJsonSchema({"type": "string"}),
+    ]
+
+
 def _inline_refs(schema: dict) -> dict:
     """Inline ``$ref`` pointers so ``WithJsonSchema`` never emits orphan refs.
 

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -30,6 +30,7 @@ from RestrictedPython import (
 )
 from RestrictedPython.PrintCollector import PrintCollector
 
+from effectful.handlers.llm.template import Tool
 from effectful.internals.unification import nested_type
 from effectful.ops.syntax import ObjectInterpretation, defop, implements
 from effectful.ops.types import Operation
@@ -906,6 +907,7 @@ class ReplSession:
         # The session's accumulated stdout/stderr, persisting for its lifetime.
         self._buffer = io.StringIO()
 
+    @Tool.define
     def exec_code(self, source: EncodableCode) -> str:
         """Execute an `EncodableCode` and return the output it produced.
 

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -877,20 +877,32 @@ class ReplSession(code.InteractiveInterpreter):
             self.showtraceback()
 
     @Tool.define
-    def exec_code(self, source: CodeType) -> str:
-        """Execute a compiled code object and return the output it produced.
+    def exec_code(self, code: CodeType) -> str:
+        """Run Python in a persistent, stateful session and return its output.
 
-        `source` is a `types.CodeType`; the `Encodable[CodeType]` boundary
-        compiles the LLM's source string into one (rejecting code that does not
-        compile) before it reaches here.  Output accumulates in the session
-        buffer across calls; this returns only the slice from this call
-        (including the traceback if the snippet raised).  Use print() to surface
-        values.
+        This is a long-lived REPL, not a one-shot sandbox: every call runs in the
+        SAME namespace, so names you bind in one call stay available in later
+        calls within the same task.  Imports, function/class definitions and
+        variable assignments all accumulate -- build state up across several
+        calls instead of resending it.  The namespace starts seeded with the
+        in-scope variables of the surrounding context, which you may read and
+        rebind.
+
+        Output: returns exactly the text this call wrote to stdout and stderr.
+        There is NO automatic echoing of results -- a bare expression on its own
+        line (e.g. `1 + 1`) displays nothing, so call `print(...)` for anything
+        you want to see.  If the code raises, its traceback is captured into the
+        returned text and the session survives, so you can read the error and
+        continue in the next call (only `SystemExit` aborts).
+
+        Provide `code` as a string of Python source.  It must be a complete,
+        compilable snippet -- incomplete or invalid source is rejected before it
+        runs.
         """
         start = self._buffer.tell()
         with (
             contextlib.redirect_stdout(self._buffer),
             contextlib.redirect_stderr(self._buffer),
         ):
-            self.runcode(source)
+            self.runcode(code)
         return self._buffer.getvalue()[start:]

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -1,5 +1,6 @@
 import ast
 import builtins
+import code
 import collections.abc
 import contextlib
 import copy
@@ -841,39 +842,73 @@ def _format_user_traceback() -> str:
     return "".join(traceback.format_exception(exc_type, exc, user_tb or tb))
 
 
-class ReplSession:
+class ReplSession(code.InteractiveInterpreter):
     """A persistent, output-capturing Python session seeded from a lexical
-    context.
+    context, built on the stdlib `code.InteractiveInterpreter` substrate.
 
-    Execution routes through the `parse`/`compile`/`exec` effect operations,
-    so the installed eval-provider owns sandboxing.  State persists in
-    `self.locals` across `run` calls: variables, imports and definitions
-    accumulate, exactly like a REPL.  Each call runs one complete snippet in
-    `exec` mode and returns its captured stdout/stderr (use `print()` to
-    surface values -- there is no bare-expression auto-echo).
+    `run(source)` drives `InteractiveInterpreter.runsource` (its compile ->
+    run -> error-print control flow), with three overrides for our needs:
+
+    - compilation routes through the `parse`/`compile` effect operations
+      (replacing the native `CommandCompiler`), so the installed eval-provider
+      owns it and `parse` populates `linecache` -- tracebacks and
+      `inspect.getsource` then see each snippet's source;
+    - `runcode` routes execution through the `exec` effect operation;
+    - `showtraceback` trims the effect-machinery frames so the LLM sees only
+      its own snippet's frames.
+
+    State persists in `self.locals` across `run` calls (variables, imports and
+    definitions accumulate, exactly like a REPL).  Each call runs one complete
+    snippet in `exec` mode and returns its captured stdout/stderr; there is no
+    bare-expression auto-echo, so use `print()` to surface values.
     """
 
     def __init__(self, env: Mapping[str, Any]):
-        self.locals: dict[str, Any] = dict(env)
+        super().__init__(dict(env))
         self._counter = itertools.count()
+        # Stack of capture buffers so re-entrant `run` calls (exec'd code that
+        # calls back into the same session) each keep their own transcript.
+        self._buffers: list[io.StringIO] = []
+        # Replace the native single-mode CommandCompiler with our op-routed,
+        # linecache-populating compiler.
+        self.compile = self._compile_through_ops  # type: ignore[assignment]
+
+    def _compile_through_ops(self, source: str, filename: str, symbol: str) -> CodeType:
+        # `runsource` passes symbol="single"; we ignore it and compile in the
+        # exec mode the ops produce, so a complete multi-statement block runs
+        # in one shot.  Incomplete/invalid input raises SyntaxError, which
+        # `runsource` routes to `showsyntaxerror` (we do not buffer partial
+        # input -- there is no line-at-a-time protocol).
+        return compile(parse(source, filename), filename)
+
+    def runcode(self, code_obj: CodeType) -> None:
+        try:
+            exec(code_obj, self.locals)
+        except Exception:
+            # `except Exception` lets SystemExit/KeyboardInterrupt propagate.
+            self.showtraceback()
+
+    def showtraceback(self) -> None:
+        # InteractiveInterpreter.showtraceback drops only its own frame; the
+        # effect routing inserts several, so trim to the user's snippet frame.
+        self.write(_format_user_traceback())
+
+    def write(self, data: str) -> None:
+        # Error output from show{traceback,syntaxerror} lands here; route it to
+        # the current call's buffer (top of stack) for re-entrancy safety.
+        self._buffers[-1].write(data)
 
     def run(self, source: str) -> str:
-        # Per-snippet filename so each cell's source is retained in
-        # `linecache` independently -- a single shared name would overwrite
-        # earlier cells and make tracebacks for earlier-defined functions
-        # format against the wrong source.
+        # Per-snippet filename so each cell's source is retained in `linecache`
+        # independently -- a single shared name would overwrite earlier cells
+        # and format earlier-defined functions' tracebacks against the wrong
+        # source.
         filename = f"{_REPL_FILENAME_PREFIX}{next(self._counter)}>"
-        buf = io.StringIO()  # per-call local: re-entrant runs keep their own
-        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
-            try:
-                code_obj = compile(parse(source, filename), filename)
-            except SyntaxError:
-                # No stack for a syntax error (same posture as
-                # InteractiveInterpreter.showsyntaxerror).
-                buf.write("".join(traceback.format_exception_only(*sys.exc_info()[:2])))
-                return buf.getvalue()
-            try:
-                exec(code_obj, self.locals)
-            except Exception:
-                buf.write(_format_user_traceback())
+        buf = io.StringIO()
+        self._buffers.append(buf)
+        try:
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                self.runsource(source, filename)
+        finally:
+            self._buffers.pop()
         return buf.getvalue()

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -137,7 +137,7 @@ class EncodableCode(pydantic.BaseModel):
             raise ValueError(
                 f"expected source string or code object, got {type(value).__name__}"
             )
-        filename = f"{_CODE_FILENAME_PREFIX}{next(uuid.uuid4())}>"
+        filename = f"{_CODE_FILENAME_PREFIX}{uuid.uuid4()}>"
         try:
             return compile(parse(value, filename), filename)
         except (SyntaxError, ValueError) as exc:
@@ -864,32 +864,17 @@ class RestrictedEvalProvider(ObjectInterpretation):
                 env[key] = rglobals[key]
 
 
-class ReplExecutionError(Exception):
-    """Raised by `ReplSession.exec_code` when an executed snippet errors.
-
-    Carries both the captured ``transcript`` (stdout/stderr plus the trimmed
-    user traceback) and the ``original_error`` object, so the call site
-    (`call_tool`) can surface the transcript *and* let downstream handlers match
-    on the real exception type.  Propagating it -- rather than swallowing it into
-    the return value -- lets `exec_code` behave like a normal Python call.
-    """
-
-    def __init__(self, transcript: str, original_error: Exception):
-        super().__init__(transcript)
-        self.transcript = transcript
-        self.original_error = original_error
-
-
 class ReplSession:
     """A persistent, output-capturing Python session seeded from a lexical
     context.
 
     `exec_code(source)` runs a pre-compiled `EncodableCode` in `self.locals`
-    through the `exec` effect operation, capturing stdout and stderr.  State
-    persists in `self.locals` across calls (variables, imports and definitions
-    accumulate, exactly like a REPL).  On success it returns the captured
-    output; on error it raises `ReplExecutionError` carrying that transcript
-    (the output plus a traceback trimmed to the snippet's own frames).  There is
+    through the `exec` effect operation.  Both bindings and captured
+    stdout/stderr persist across calls -- variables, imports and definitions
+    accumulate exactly like a REPL -- and the session (with its buffer) is
+    discarded as a whole when it goes out of scope.  Each call returns only the
+    output it produced; a snippet that raises has its traceback appended to that
+    output rather than propagating, so failures are surfaced as text.  There is
     no bare-expression auto-echo, so use `print()` to surface values.
 
     Compilation -- and therefore syntax checking -- happens earlier, when the
@@ -898,50 +883,25 @@ class ReplSession:
 
     def __init__(self, env: Mapping[str, Any]):
         self.locals: dict[str, Any] = dict(env)
-        # One in-flight `exec_code` owns these: the buffer captures its
-        # stdout/stderr, and `_error` holds the exception it raised, if any.
+        # The session's accumulated stdout/stderr, persisting for its lifetime.
         self._buffer = io.StringIO()
-        self._error: Exception | None = None
 
     def exec_code(self, source: EncodableCode) -> str:
-        """Execute an `EncodableCode` in this persistent session and return its
-        captured stdout/stderr.
+        """Execute an `EncodableCode` and return the output it produced.
 
-        Variables, imports and definitions persist across calls, exactly like a
-        REPL.  There is no bare-expression auto-echo, so use print() to surface
-        values.  A snippet that raises propagates the error (carrying its
-        transcript) rather than returning, so it behaves like a normal Python
-        call.
+        Output accumulates in the session buffer across calls; this returns only
+        the slice from this call (including the traceback if the snippet raised).
+        Use print() to surface values.
         """
-        self._buffer = io.StringIO()
-        self._error = None
+        start = self._buffer.tell()
         try:
             with (
                 contextlib.redirect_stdout(self._buffer),
                 contextlib.redirect_stderr(self._buffer),
             ):
                 exec(source.code, self.locals)
-        except Exception as exc:
-            # `except Exception` lets SystemExit/KeyboardInterrupt propagate.
-            self._show_traceback()
-            self._error = exc
-        transcript = self._buffer.getvalue()
-        if self._error is not None:
-            # Like a normal Python call, a failed snippet raises rather than
-            # returning; `call_tool` catches it and feeds the transcript back.
-            raise ReplExecutionError(transcript, self._error)
-        return transcript
-
-    def _show_traceback(self) -> None:
-        # The `exec` op inserts effect-machinery frames between the call site and
-        # the snippet.  A snippet frame is one running in our namespace -- its
-        # globals *are* `self.locals` (true for the module-level exec and for any
-        # function defined in a snippet, whose __globals__ is `self.locals`) -- so
-        # identify it by identity and drop the machinery frames above it.
-        exc_type, exc, tb = sys.exc_info()
-        user_tb = tb
-        while user_tb is not None and user_tb.tb_frame.f_globals is not self.locals:
-            user_tb = user_tb.tb_next
-        self._buffer.write(
-            "".join(traceback.format_exception(exc_type, exc, user_tb or tb))
-        )
+        except Exception:
+            # `except Exception` lets SystemExit/KeyboardInterrupt propagate; any
+            # other error is reported as part of this call's output.
+            self._buffer.write(traceback.format_exc())
+        return self._buffer.getvalue()[start:]

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -863,11 +863,11 @@ class ReplSession(code.InteractiveInterpreter):
     def __init__(self, env: Mapping[str, Any]):
         super().__init__(dict(env))
         self._counter = itertools.count()
-        # Parallel stacks so re-entrant `run` calls (exec'd code that calls back
-        # into the same session) each keep their own transcript and the
-        # exception (if any) the run raised.
-        self._buffers: list[io.StringIO] = []
-        self._error: list[Exception | None] = []
+        # One session per instance, so a single in-flight `run` owns these: the
+        # buffer captures that run's stdout/stderr, and `_error` holds the
+        # exception it raised, if any.
+        self._buffer = io.StringIO()
+        self._error: Exception | None = None
         # Replace the native single-mode CommandCompiler with our op-routed,
         # linecache-populating compiler.
         self.compile = self._compile_through_ops  # type: ignore[assignment]
@@ -886,7 +886,7 @@ class ReplSession(code.InteractiveInterpreter):
         except Exception as exc:
             # `except Exception` lets SystemExit/KeyboardInterrupt propagate.
             self.showtraceback()
-            self._error[-1] = exc
+            self._error = exc
 
     def showsyntaxerror(self, *args: Any, **kwargs: Any) -> None:
         # A syntax/compile error is a failed run too; capture it the way
@@ -894,7 +894,7 @@ class ReplSession(code.InteractiveInterpreter):
         # SyntaxError is the in-flight exception during `runsource`'s except.
         exc = sys.exc_info()[1]
         assert isinstance(exc, Exception)
-        self._error[-1] = exc
+        self._error = exc
         super().showsyntaxerror(*args, **kwargs)
 
     def showtraceback(self) -> None:
@@ -912,8 +912,8 @@ class ReplSession(code.InteractiveInterpreter):
 
     def write(self, data: str) -> None:
         # Error output from show{traceback,syntaxerror} lands here; route it to
-        # the current call's buffer (top of stack) for re-entrancy safety.
-        self._buffers[-1].write(data)
+        # the current run's buffer.
+        self._buffer.write(data)
 
     def run(self, source: str) -> str:
         # Per-snippet filename so each cell's source is retained in `linecache`
@@ -921,16 +921,16 @@ class ReplSession(code.InteractiveInterpreter):
         # and format earlier-defined functions' tracebacks against the wrong
         # source.
         filename = f"{_REPL_FILENAME_PREFIX}{next(self._counter)}>"
-        buf = io.StringIO()
-        self._buffers.append(buf)
-        self._error.append(None)
+        self._buffer = io.StringIO()
+        self._error = None
         try:
-            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+            with contextlib.redirect_stdout(self._buffer), contextlib.redirect_stderr(
+                self._buffer
+            ):
                 self.runsource(source, filename)
         finally:
-            self._buffers.pop()
-            error = self._error.pop()
-        transcript = buf.getvalue()
+            transcript = self._buffer.getvalue()
+            error = self._error
         if error is not None:
             # Like a normal Python call, a failed snippet raises rather than
             # returning; `call_tool` catches it and feeds the transcript back.

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -1,6 +1,7 @@
 import ast
 import builtins
 import code
+import codeop
 import collections.abc
 import contextlib
 import copy
@@ -838,6 +839,24 @@ class RestrictedEvalProvider(ObjectInterpretation):
         )
 
 
+class _OpCommandCompiler(codeop.CommandCompiler):
+    """A `codeop.CommandCompiler` that routes compilation through the
+    `parse`/`compile` effect operations (so the installed eval provider owns it
+    and `parse` populates `linecache`), replacing the native single-mode
+    compiler that `code.InteractiveInterpreter` installs.
+    """
+
+    def __call__(
+        self, source: str, filename: str = "<input>", symbol: str = "single"
+    ) -> CodeType:
+        # `runsource` passes symbol="single"; we ignore it and compile in the
+        # exec mode the ops produce, so a complete multi-statement block runs in
+        # one shot.  Incomplete/invalid input raises SyntaxError, which
+        # `runsource` routes to `showsyntaxerror` (we do not buffer partial input
+        # -- there is no line-at-a-time protocol).
+        return compile(parse(source, filename), filename)
+
+
 class ReplSession(code.InteractiveInterpreter):
     """A persistent, output-capturing Python session seeded from a lexical
     context.
@@ -856,8 +875,10 @@ class ReplSession(code.InteractiveInterpreter):
     `Encodable[CodeType]` boundary; this session only executes.
     """
 
-    # Everything the session writes -- stdout, stderr and tracebacks -- captured
-    # for its lifetime and exposed so callers can introspect a session's output.
+    # The session's captured output, accumulated across calls and exposed for
+    # introspection.  stdout (`print` output) and stderr (writes plus tracebacks)
+    # are kept separate; `exec_code` returns each call's slice of both.
+    stdout: io.StringIO
     stderr: io.StringIO
 
     def __init__(self, env: MutableMapping[str, Any]):
@@ -877,13 +898,18 @@ class ReplSession(code.InteractiveInterpreter):
         # `InteractiveInterpreter.__init__` stores it as `self.locals`, so we reuse
         # the base's runcode/showtraceback/write machinery.
         super().__init__(scope)
+        # Route `runsource`'s compilation through the `parse`/`compile` ops too, so
+        # it stays consistent with our `runcode` (which execs through the `exec`
+        # op) rather than the native single-mode compiler the base installed.
+        self.compile = _OpCommandCompiler()
+        self.stdout = io.StringIO()
         self.stderr = io.StringIO()
 
     def runcode(self, code: CodeType) -> None:
         # Mirrors `InteractiveInterpreter.runcode` exactly; the only difference
         # is that `exec` here is the effect operation, so execution routes
         # through the installed eval provider.  `showtraceback` reports failures
-        # via `self.write`, which `exec_code` has redirected into the buffer.
+        # via `self.write`, which `exec_code` has redirected into `self.stderr`.
         try:
             exec(code, self.locals)
         except SystemExit:
@@ -903,21 +929,23 @@ class ReplSession(code.InteractiveInterpreter):
         in-scope variables of the surrounding context, which you may read and
         rebind.
 
-        Output: returns exactly the text this call wrote to stdout and stderr.
+        Output: returns this call's output -- its stdout (what `print` wrote)
+        followed by its stderr (which includes the traceback if the code raised).
         There is NO automatic echoing of results -- a bare expression on its own
         line (e.g. `1 + 1`) displays nothing, so call `print(...)` for anything
-        you want to see.  If the code raises, its traceback is captured into the
-        returned text and the session survives, so you can read the error and
-        continue in the next call (only `SystemExit` aborts).
+        you want to see.  A snippet that raises has its traceback returned and the
+        session survives, so you can read the error and continue in the next call
+        (only `SystemExit` aborts).
 
         Provide `code` as a string of Python source.  It must be a complete,
         compilable snippet -- incomplete or invalid source is rejected before it
         runs.
         """
-        start = self.stderr.tell()
+        out_start = self.stdout.tell()
+        err_start = self.stderr.tell()
         with (
-            contextlib.redirect_stdout(self.stderr),
+            contextlib.redirect_stdout(self.stdout),
             contextlib.redirect_stderr(self.stderr),
         ):
             self.runcode(code)
-        return self.stderr.getvalue()[start:]
+        return self.stdout.getvalue()[out_start:] + self.stderr.getvalue()[err_start:]

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -822,24 +822,18 @@ class RestrictedEvalProvider(ObjectInterpretation):
 _REPL_FILENAME_PREFIX = "<exec_code-"
 
 
-def _format_user_traceback() -> str:
-    """Format the in-flight exception, trimming the effect-machinery frames
-    between the call site and the user's snippet.
+class ReplExecutionError(Exception):
+    """Raised by `ReplSession.run` when an executed snippet errors.
 
-    Because execution routes through the `exec` operation, the raw traceback
-    includes effectful's internal frames (ops, runtime, this module).  We walk
-    to the first frame whose code lives in a snippet (`co_filename` starts with
-    `_REPL_FILENAME_PREFIX`) and format from there, so the LLM sees only its
-    own frames -- the same idea as `code.InteractiveInterpreter.showtraceback`
-    dropping its own frame, generalized.
+    Carries the captured ``transcript`` (stdout/stderr plus the trimmed user
+    traceback).  Propagating it -- rather than swallowing it into the return
+    value -- lets the `exec_code` tool behave like a normal Python call, so the
+    call site (`call_tool`) catches it and surfaces the transcript to the model.
     """
-    exc_type, exc, tb = sys.exc_info()
-    user_tb = tb
-    while user_tb is not None and not user_tb.tb_frame.f_code.co_filename.startswith(
-        _REPL_FILENAME_PREFIX
-    ):
-        user_tb = user_tb.tb_next
-    return "".join(traceback.format_exception(exc_type, exc, user_tb or tb))
+
+    def __init__(self, transcript: str):
+        super().__init__(transcript)
+        self.transcript = transcript
 
 
 class ReplSession(code.InteractiveInterpreter):
@@ -847,7 +841,7 @@ class ReplSession(code.InteractiveInterpreter):
     context, built on the stdlib `code.InteractiveInterpreter` substrate.
 
     `run(source)` drives `InteractiveInterpreter.runsource` (its compile ->
-    run -> error-print control flow), with three overrides for our needs:
+    run -> error-print control flow), with a few overrides for our needs:
 
     - compilation routes through the `parse`/`compile` effect operations
       (replacing the native `CommandCompiler`), so the installed eval-provider
@@ -859,16 +853,18 @@ class ReplSession(code.InteractiveInterpreter):
 
     State persists in `self.locals` across `run` calls (variables, imports and
     definitions accumulate, exactly like a REPL).  Each call runs one complete
-    snippet in `exec` mode and returns its captured stdout/stderr; there is no
-    bare-expression auto-echo, so use `print()` to surface values.
+    snippet in `exec` mode; on success it returns the captured stdout/stderr,
+    and on error it raises `ReplExecutionError` carrying that transcript.  There
+    is no bare-expression auto-echo, so use `print()` to surface values.
     """
 
     def __init__(self, env: Mapping[str, Any]):
         super().__init__(dict(env))
         self._counter = itertools.count()
-        # Stack of capture buffers so re-entrant `run` calls (exec'd code that
-        # calls back into the same session) each keep their own transcript.
+        # Parallel stacks so re-entrant `run` calls (exec'd code that calls back
+        # into the same session) each keep their own transcript and error state.
         self._buffers: list[io.StringIO] = []
+        self._errored: list[bool] = []
         # Replace the native single-mode CommandCompiler with our op-routed,
         # linecache-populating compiler.
         self.compile = self._compile_through_ops  # type: ignore[assignment]
@@ -887,11 +883,28 @@ class ReplSession(code.InteractiveInterpreter):
         except Exception:
             # `except Exception` lets SystemExit/KeyboardInterrupt propagate.
             self.showtraceback()
+            self._errored[-1] = True
+
+    def showsyntaxerror(self, *args: Any, **kwargs: Any) -> None:
+        # A syntax/compile error is a failed run too; flag it the same way
+        # `runcode` flags a runtime error, so `run` raises for both.
+        super().showsyntaxerror(*args, **kwargs)
+        self._errored[-1] = True
 
     def showtraceback(self) -> None:
-        # InteractiveInterpreter.showtraceback drops only its own frame; the
-        # effect routing inserts several, so trim to the user's snippet frame.
-        self.write(_format_user_traceback())
+        # InteractiveInterpreter.showtraceback drops only its own frame; routing
+        # through the `exec` op inserts several, so walk to the first snippet
+        # frame and format from there -- the LLM sees only its own frames.
+        exc_type, exc, tb = sys.exc_info()
+        user_tb = tb
+        while (
+            user_tb is not None
+            and not user_tb.tb_frame.f_code.co_filename.startswith(
+                _REPL_FILENAME_PREFIX
+            )
+        ):
+            user_tb = user_tb.tb_next
+        self.write("".join(traceback.format_exception(exc_type, exc, user_tb or tb)))
 
     def write(self, data: str) -> None:
         # Error output from show{traceback,syntaxerror} lands here; route it to
@@ -906,9 +919,16 @@ class ReplSession(code.InteractiveInterpreter):
         filename = f"{_REPL_FILENAME_PREFIX}{next(self._counter)}>"
         buf = io.StringIO()
         self._buffers.append(buf)
+        self._errored.append(False)
         try:
             with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
                 self.runsource(source, filename)
         finally:
             self._buffers.pop()
-        return buf.getvalue()
+            errored = self._errored.pop()
+        transcript = buf.getvalue()
+        if errored:
+            # Like a normal Python call, a failed snippet raises rather than
+            # returning; `call_tool` catches it and feeds the transcript back.
+            raise ReplExecutionError(transcript)
+        return transcript

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -856,6 +856,10 @@ class ReplSession(code.InteractiveInterpreter):
     `Encodable[CodeType]` boundary; this session only executes.
     """
 
+    # Everything the session writes -- stdout, stderr and tracebacks -- captured
+    # for its lifetime and exposed so callers can introspect a session's output.
+    stderr: io.StringIO
+
     def __init__(self, env: MutableMapping[str, Any]):
         # Run in a fresh writable dict seeded with a flat view of `env`.  This is
         # forced by `exec`: its globals must be one real dict (a ChainMap is
@@ -873,8 +877,7 @@ class ReplSession(code.InteractiveInterpreter):
         # `InteractiveInterpreter.__init__` stores it as `self.locals`, so we reuse
         # the base's runcode/showtraceback/write machinery.
         super().__init__(scope)
-        # The session's accumulated stdout/stderr, persisting for its lifetime.
-        self._buffer = io.StringIO()
+        self.stderr = io.StringIO()
 
     def runcode(self, code: CodeType) -> None:
         # Mirrors `InteractiveInterpreter.runcode` exactly; the only difference
@@ -911,10 +914,10 @@ class ReplSession(code.InteractiveInterpreter):
         compilable snippet -- incomplete or invalid source is rejected before it
         runs.
         """
-        start = self._buffer.tell()
+        start = self.stderr.tell()
         with (
-            contextlib.redirect_stdout(self._buffer),
-            contextlib.redirect_stderr(self._buffer),
+            contextlib.redirect_stdout(self.stderr),
+            contextlib.redirect_stderr(self.stderr),
         ):
             self.runcode(code)
-        return self._buffer.getvalue()[start:]
+        return self.stderr.getvalue()[start:]

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -13,7 +13,7 @@ import string
 import sys
 import types
 import typing
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from types import CodeType
 from typing import Any, TypeAliasType
 
@@ -856,7 +856,7 @@ class ReplSession(code.InteractiveInterpreter):
     `Encodable[CodeType]` boundary; this session only executes.
     """
 
-    def __init__(self, env: Mapping[str, Any]):
+    def __init__(self, env: MutableMapping[str, Any]):
         # Run in a fresh writable dict seeded with a flat view of `env`.  This is
         # forced by `exec`: its globals must be one real dict (a ChainMap is
         # rejected), and a REPL needs a single persistent namespace so a function

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -924,9 +924,8 @@ class ReplSession(code.InteractiveInterpreter):
         This is a long-lived REPL, not a one-shot sandbox: every call runs in the
         SAME namespace, so names you bind in one call stay available in later
         calls within the same task.  Imports, function/class definitions and
-        variable assignments all accumulate -- build state up across several
-        calls instead of resending it.  The namespace starts seeded with the
-        in-scope variables of the surrounding context, which you may read and
+        variable assignments all accumulate during the session of this template.
+        The namespace starts seeded with the in-scope variables of the surrounding context, which you may read and
         rebind.
 
         Output: returns this call's output -- its stdout (what `print` wrote)

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -825,15 +825,17 @@ _REPL_FILENAME_PREFIX = "<exec_code-"
 class ReplExecutionError(Exception):
     """Raised by `ReplSession.run` when an executed snippet errors.
 
-    Carries the captured ``transcript`` (stdout/stderr plus the trimmed user
-    traceback).  Propagating it -- rather than swallowing it into the return
-    value -- lets the `exec_code` tool behave like a normal Python call, so the
-    call site (`call_tool`) catches it and surfaces the transcript to the model.
+    Carries both the captured ``transcript`` (stdout/stderr plus the trimmed
+    user traceback) and the ``original_error`` object, so the call site
+    (`call_tool`) can surface the transcript *and* let downstream handlers match
+    on the real exception type.  Propagating it -- rather than swallowing it into
+    the return value -- lets `exec_code` behave like a normal Python call.
     """
 
-    def __init__(self, transcript: str):
+    def __init__(self, transcript: str, original_error: Exception):
         super().__init__(transcript)
         self.transcript = transcript
+        self.original_error = original_error
 
 
 class ReplSession(code.InteractiveInterpreter):
@@ -862,9 +864,10 @@ class ReplSession(code.InteractiveInterpreter):
         super().__init__(dict(env))
         self._counter = itertools.count()
         # Parallel stacks so re-entrant `run` calls (exec'd code that calls back
-        # into the same session) each keep their own transcript and error state.
+        # into the same session) each keep their own transcript and the
+        # exception (if any) the run raised.
         self._buffers: list[io.StringIO] = []
-        self._errored: list[bool] = []
+        self._error: list[Exception | None] = []
         # Replace the native single-mode CommandCompiler with our op-routed,
         # linecache-populating compiler.
         self.compile = self._compile_through_ops  # type: ignore[assignment]
@@ -880,29 +883,30 @@ class ReplSession(code.InteractiveInterpreter):
     def runcode(self, code_obj: CodeType) -> None:
         try:
             exec(code_obj, self.locals)
-        except Exception:
+        except Exception as exc:
             # `except Exception` lets SystemExit/KeyboardInterrupt propagate.
             self.showtraceback()
-            self._errored[-1] = True
+            self._error[-1] = exc
 
     def showsyntaxerror(self, *args: Any, **kwargs: Any) -> None:
-        # A syntax/compile error is a failed run too; flag it the same way
-        # `runcode` flags a runtime error, so `run` raises for both.
+        # A syntax/compile error is a failed run too; capture it the way
+        # `runcode` captures a runtime error, so `run` raises for both.  The
+        # SyntaxError is the in-flight exception during `runsource`'s except.
+        exc = sys.exc_info()[1]
+        assert isinstance(exc, Exception)
+        self._error[-1] = exc
         super().showsyntaxerror(*args, **kwargs)
-        self._errored[-1] = True
 
     def showtraceback(self) -> None:
         # InteractiveInterpreter.showtraceback drops only its own frame; routing
-        # through the `exec` op inserts several, so walk to the first snippet
-        # frame and format from there -- the LLM sees only its own frames.
+        # through the `exec` op inserts several.  A snippet frame is one running
+        # in our namespace -- its globals *are* `self.locals` (true for the
+        # module-level exec and for any function defined in a snippet, whose
+        # __globals__ is `self.locals`) -- so identify it by identity, not by
+        # matching the `<exec_code-` filename string.
         exc_type, exc, tb = sys.exc_info()
         user_tb = tb
-        while (
-            user_tb is not None
-            and not user_tb.tb_frame.f_code.co_filename.startswith(
-                _REPL_FILENAME_PREFIX
-            )
-        ):
+        while user_tb is not None and user_tb.tb_frame.f_globals is not self.locals:
             user_tb = user_tb.tb_next
         self.write("".join(traceback.format_exception(exc_type, exc, user_tb or tb)))
 
@@ -919,16 +923,16 @@ class ReplSession(code.InteractiveInterpreter):
         filename = f"{_REPL_FILENAME_PREFIX}{next(self._counter)}>"
         buf = io.StringIO()
         self._buffers.append(buf)
-        self._errored.append(False)
+        self._error.append(None)
         try:
             with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
                 self.runsource(source, filename)
         finally:
             self._buffers.pop()
-            errored = self._errored.pop()
+            error = self._error.pop()
         transcript = buf.getvalue()
-        if errored:
+        if error is not None:
             # Like a normal Python call, a failed snippet raises rather than
             # returning; `call_tool` catches it and feeds the transcript back.
-            raise ReplExecutionError(transcript)
+            raise ReplExecutionError(transcript, error)
         return transcript

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -857,10 +857,22 @@ class ReplSession(code.InteractiveInterpreter):
     """
 
     def __init__(self, env: Mapping[str, Any]):
-        # `InteractiveInterpreter.__init__` sets `self.locals`; subclassing lets
-        # us reuse its `runcode`/`showtraceback`/`write` machinery rather than
-        # re-implementing traceback capture by hand.
-        super().__init__(dict(env))
+        # Run in a fresh writable dict seeded with a flat view of `env`.  This is
+        # forced by `exec`: its globals must be one real dict (a ChainMap is
+        # rejected), and a REPL needs a single persistent namespace so a function
+        # defined in one snippet sees a name a later snippet binds.  Seeding a flat
+        # copy also leaves the lexical seed untouched, so REPL assignments never
+        # leak into the surrounding scope.
+        scope: dict[str, Any] = dict(env)
+        # When `env` is the per-call `ChainMap` (its outer layers are read-only
+        # frame proxies), splice this dict in as an extra shadowing first layer so
+        # the bindings are *also* visible to the rest of the Template call
+        # (mirroring `exec`) -- still scoped to the call, since that ChainMap is.
+        if isinstance(env, collections.ChainMap):
+            env.maps.insert(0, scope)
+        # `InteractiveInterpreter.__init__` stores it as `self.locals`, so we reuse
+        # the base's runcode/showtraceback/write machinery.
+        super().__init__(scope)
         # The session's accumulated stdout/stderr, persisting for its lifetime.
         self._buffer = io.StringIO()
 

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -1,13 +1,17 @@
 import ast
 import builtins
 import collections.abc
+import contextlib
 import copy
 import inspect
+import io
+import itertools
 import keyword
 import linecache
 import random
 import string
 import sys
+import traceback
 import types
 import typing
 from collections.abc import Mapping
@@ -90,6 +94,9 @@ def exec(
 
     bytecode: A code object to execute (typically produced by compile()).
     env: The namespace mapping used during execution.
+
+    After ``exec(bytecode, env)`` returns, ``env`` reflects all top-level
+    binding effects of the executed code (new names and rebindings alike).
     """
     raise NotImplementedError(
         "An eval provider must be installed in order to execute code."
@@ -809,3 +816,64 @@ class RestrictedEvalProvider(ObjectInterpretation):
         for key in rglobals:
             if key not in keys_before:
                 env[key] = rglobals[key]
+
+
+_REPL_FILENAME_PREFIX = "<exec_code-"
+
+
+def _format_user_traceback() -> str:
+    """Format the in-flight exception, trimming the effect-machinery frames
+    between the call site and the user's snippet.
+
+    Because execution routes through the `exec` operation, the raw traceback
+    includes effectful's internal frames (ops, runtime, this module).  We walk
+    to the first frame whose code lives in a snippet (`co_filename` starts with
+    `_REPL_FILENAME_PREFIX`) and format from there, so the LLM sees only its
+    own frames -- the same idea as `code.InteractiveInterpreter.showtraceback`
+    dropping its own frame, generalized.
+    """
+    exc_type, exc, tb = sys.exc_info()
+    user_tb = tb
+    while user_tb is not None and not user_tb.tb_frame.f_code.co_filename.startswith(
+        _REPL_FILENAME_PREFIX
+    ):
+        user_tb = user_tb.tb_next
+    return "".join(traceback.format_exception(exc_type, exc, user_tb or tb))
+
+
+class ReplSession:
+    """A persistent, output-capturing Python session seeded from a lexical
+    context.
+
+    Execution routes through the `parse`/`compile`/`exec` effect operations,
+    so the installed eval-provider owns sandboxing.  State persists in
+    `self.locals` across `run` calls: variables, imports and definitions
+    accumulate, exactly like a REPL.  Each call runs one complete snippet in
+    `exec` mode and returns its captured stdout/stderr (use `print()` to
+    surface values -- there is no bare-expression auto-echo).
+    """
+
+    def __init__(self, env: Mapping[str, Any]):
+        self.locals: dict[str, Any] = dict(env)
+        self._counter = itertools.count()
+
+    def run(self, source: str) -> str:
+        # Per-snippet filename so each cell's source is retained in
+        # `linecache` independently -- a single shared name would overwrite
+        # earlier cells and make tracebacks for earlier-defined functions
+        # format against the wrong source.
+        filename = f"{_REPL_FILENAME_PREFIX}{next(self._counter)}>"
+        buf = io.StringIO()  # per-call local: re-entrant runs keep their own
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+            try:
+                code_obj = compile(parse(source, filename), filename)
+            except SyntaxError:
+                # No stack for a syntax error (same posture as
+                # InteractiveInterpreter.showsyntaxerror).
+                buf.write("".join(traceback.format_exception_only(*sys.exc_info()[:2])))
+                return buf.getvalue()
+            try:
+                exec(code_obj, self.locals)
+            except Exception:
+                buf.write(_format_user_traceback())
+        return buf.getvalue()

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -1,7 +1,5 @@
 import ast
 import builtins
-import code
-import codeop
 import collections.abc
 import contextlib
 import copy
@@ -21,6 +19,7 @@ from types import CodeType
 from typing import Any, TypeAliasType
 
 import autoflake
+import pydantic
 from mypy import api as mypy_api
 from RestrictedPython import (
     Eval,
@@ -103,6 +102,52 @@ def exec(
     raise NotImplementedError(
         "An eval provider must be installed in order to execute code."
     )
+
+
+_CODE_FILENAME_PREFIX = "<exec_code-"
+_code_counter = itertools.count()
+
+
+class EncodableCode(pydantic.BaseModel):
+    """A snippet of Python source paired with its compiled code object.
+
+    A field validator compiles the source through the `parse`/`compile` effect
+    operations as the model is built, so an `EncodableCode` is, by construction,
+    code that compiled under the installed eval provider -- syntax and
+    compile-time errors raise here, not at run time.  `parse` also records the
+    source in `linecache` under a unique per-snippet filename so tracebacks
+    (including across snippets) resolve correctly, and the ready-to-run `code` is
+    carried so execution never has to recompile.
+    """
+
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    source: str
+    code: CodeType
+
+    @pydantic.field_validator("code", mode="before")
+    @classmethod
+    def _compile(cls, value: Any) -> CodeType:
+        # `code` is fed the source string (see `from_source`); compiling it here
+        # means a non-compiling snippet raises at the Encodable boundary rather
+        # than at run time.  A unique per-snippet filename keeps each snippet's
+        # source in `linecache` independently so tracebacks resolve correctly.
+        if isinstance(value, CodeType):
+            return value
+        if not isinstance(value, str):
+            raise ValueError(
+                f"expected source string or code object, got {type(value).__name__}"
+            )
+        filename = f"{_CODE_FILENAME_PREFIX}{next(_code_counter)}>"
+        try:
+            return compile(parse(value, filename), filename)
+        except (SyntaxError, ValueError) as exc:
+            raise ValueError(f"source does not compile: {exc}") from exc
+
+    @classmethod
+    def from_source(cls, source: str) -> "EncodableCode":
+        # `code` receives the same source; the field validator compiles it.
+        return cls.model_validate({"source": source, "code": source})
 
 
 # Type checking implementation
@@ -836,98 +881,32 @@ class ReplExecutionError(Exception):
         self.original_error = original_error
 
 
-class _OpCommandCompiler(codeop.CommandCompiler):
-    """A `codeop.CommandCompiler` that routes compilation through the
-    `parse`/`compile` effect operations (so the installed eval-provider owns it
-    and `parse` populates `linecache`), replacing the native single-mode
-    compiler that `code.InteractiveInterpreter` installs.
-    """
-
-    def __call__(
-        self, source: str, filename: str = "<input>", symbol: str = "single"
-    ) -> CodeType:
-        # `runsource` passes symbol="single"; we ignore it and compile in the
-        # exec mode the ops produce, so a complete multi-statement block runs in
-        # one shot.  Incomplete/invalid input raises SyntaxError, which
-        # `runsource` routes to `showsyntaxerror` (we do not buffer partial input
-        # -- there is no line-at-a-time protocol).
-        return compile(parse(source, filename), filename)
-
-
-class ReplSession(code.InteractiveInterpreter):
+class ReplSession:
     """A persistent, output-capturing Python session seeded from a lexical
-    context, built on the stdlib `code.InteractiveInterpreter` substrate.
+    context.
 
-    `exec_code(source)` drives `InteractiveInterpreter.runsource` (its compile ->
-    run -> error-print control flow), with a few overrides for our needs:
+    `exec_code(source)` runs a pre-compiled `EncodableCode` in `self.locals`
+    through the `exec` effect operation, capturing stdout and stderr.  State
+    persists in `self.locals` across calls (variables, imports and definitions
+    accumulate, exactly like a REPL).  On success it returns the captured
+    output; on error it raises `ReplExecutionError` carrying that transcript
+    (the output plus a traceback trimmed to the snippet's own frames).  There is
+    no bare-expression auto-echo, so use `print()` to surface values.
 
-    - compilation routes through the `parse`/`compile` effect operations
-      (replacing the native `CommandCompiler`), so the installed eval-provider
-      owns it and `parse` populates `linecache` -- tracebacks and
-      `inspect.getsource` then see each snippet's source;
-    - `runcode` routes execution through the `exec` effect operation;
-    - `showtraceback` trims the effect-machinery frames so the LLM sees only
-      its own snippet's frames.
-
-    State persists in `self.locals` across `exec_code` calls (variables, imports and
-    definitions accumulate, exactly like a REPL).  Each call runs one complete
-    snippet in `exec` mode; on success it returns the captured stdout/stderr,
-    and on error it raises `ReplExecutionError` carrying that transcript.  There
-    is no bare-expression auto-echo, so use `print()` to surface values.
+    Compilation -- and therefore syntax checking -- happens earlier, when the
+    `EncodableCode` is built; this session only executes.
     """
-
-    _FILENAME_PREFIX: typing.ClassVar[str] = "<exec_code-"
 
     def __init__(self, env: Mapping[str, Any]):
-        super().__init__(dict(env))
-        self._counter = itertools.count()
-        # One session per instance, so a single in-flight `exec_code` owns these: the
-        # buffer captures that run's stdout/stderr, and `_error` holds the
-        # exception it raised, if any.
+        self.locals: dict[str, Any] = dict(env)
+        # One in-flight `exec_code` owns these: the buffer captures its
+        # stdout/stderr, and `_error` holds the exception it raised, if any.
         self._buffer = io.StringIO()
         self._error: Exception | None = None
-        # Replace the native single-mode CommandCompiler with our op-routed,
-        # linecache-populating compiler.
-        self.compile = _OpCommandCompiler()
 
-    def runcode(self, code_obj: CodeType) -> None:
-        try:
-            exec(code_obj, self.locals)
-        except Exception as exc:
-            # `except Exception` lets SystemExit/KeyboardInterrupt propagate.
-            self.showtraceback()
-            self._error = exc
-
-    def showsyntaxerror(self, *args: Any, **kwargs: Any) -> None:
-        # A syntax/compile error is a failed run too; capture it the way
-        # `runcode` captures a runtime error, so `exec_code` raises for both.  The
-        # SyntaxError is the in-flight exception during `runsource`'s except.
-        exc = sys.exc_info()[1]
-        assert isinstance(exc, Exception)
-        self._error = exc
-        super().showsyntaxerror(*args, **kwargs)
-
-    def showtraceback(self) -> None:
-        # InteractiveInterpreter.showtraceback drops only its own frame; routing
-        # through the `exec` op inserts several.  A snippet frame is one running
-        # in our namespace -- its globals *are* `self.locals` (true for the
-        # module-level exec and for any function defined in a snippet, whose
-        # __globals__ is `self.locals`) -- so identify it by identity, not by
-        # matching the `<exec_code-` filename string.
-        exc_type, exc, tb = sys.exc_info()
-        user_tb = tb
-        while user_tb is not None and user_tb.tb_frame.f_globals is not self.locals:
-            user_tb = user_tb.tb_next
-        self.write("".join(traceback.format_exception(exc_type, exc, user_tb or tb)))
-
-    def write(self, data: str) -> None:
-        # Error output from show{traceback,syntaxerror} lands here; route it to
-        # the current run's buffer.
-        self._buffer.write(data)
-
-    def exec_code(self, source: str) -> str:
-        """Execute Python in this persistent session and return its captured
-        stdout/stderr.
+    def exec_code(self, source: EncodableCode) -> str:
+        """Execute an `EncodableCode` in this persistent session and return its
+        captured stdout/stderr.
 
         Variables, imports and definitions persist across calls, exactly like a
         REPL.  There is no bare-expression auto-echo, so use print() to surface
@@ -935,11 +914,6 @@ class ReplSession(code.InteractiveInterpreter):
         transcript) rather than returning, so it behaves like a normal Python
         call.
         """
-        # Per-snippet filename so each cell's source is retained in `linecache`
-        # independently -- a single shared name would overwrite earlier cells
-        # and format earlier-defined functions' tracebacks against the wrong
-        # source.
-        filename = f"{self._FILENAME_PREFIX}{next(self._counter)}>"
         self._buffer = io.StringIO()
         self._error = None
         try:
@@ -947,12 +921,28 @@ class ReplSession(code.InteractiveInterpreter):
                 contextlib.redirect_stdout(self._buffer),
                 contextlib.redirect_stderr(self._buffer),
             ):
-                self.runsource(source, filename)
-        finally:
-            transcript = self._buffer.getvalue()
-            error = self._error
-        if error is not None:
+                exec(source.code, self.locals)
+        except Exception as exc:
+            # `except Exception` lets SystemExit/KeyboardInterrupt propagate.
+            self._show_traceback()
+            self._error = exc
+        transcript = self._buffer.getvalue()
+        if self._error is not None:
             # Like a normal Python call, a failed snippet raises rather than
             # returning; `call_tool` catches it and feeds the transcript back.
-            raise ReplExecutionError(transcript, error)
+            raise ReplExecutionError(transcript, self._error)
         return transcript
+
+    def _show_traceback(self) -> None:
+        # The `exec` op inserts effect-machinery frames between the call site and
+        # the snippet.  A snippet frame is one running in our namespace -- its
+        # globals *are* `self.locals` (true for the module-level exec and for any
+        # function defined in a snippet, whose __globals__ is `self.locals`) -- so
+        # identify it by identity and drop the machinery frames above it.
+        exc_type, exc, tb = sys.exc_info()
+        user_tb = tb
+        while user_tb is not None and user_tb.tb_frame.f_globals is not self.locals:
+            user_tb = user_tb.tb_next
+        self._buffer.write(
+            "".join(traceback.format_exception(exc_type, exc, user_tb or tb))
+        )

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -1,5 +1,6 @@
 import ast
 import builtins
+import code
 import collections.abc
 import contextlib
 import copy
@@ -10,7 +11,6 @@ import linecache
 import random
 import string
 import sys
-import traceback
 import types
 import typing
 import uuid
@@ -885,7 +885,7 @@ class RestrictedEvalProvider(ObjectInterpretation):
         )
 
 
-class ReplSession:
+class ReplSession(code.InteractiveInterpreter):
     """A persistent, output-capturing Python session seeded from a lexical
     context.
 
@@ -895,7 +895,8 @@ class ReplSession:
     accumulate exactly like a REPL -- and the session (with its buffer) is
     discarded as a whole when it goes out of scope.  Each call returns only the
     output it produced; a snippet that raises has its traceback appended to that
-    output rather than propagating, so failures are surfaced as text.  There is
+    output rather than propagating -- mirroring `code.InteractiveInterpreter`,
+    only `SystemExit` propagates -- so failures are surfaced as text.  There is
     no bare-expression auto-echo, so use `print()` to surface values.
 
     Compilation -- and therefore syntax checking -- happens earlier, when the
@@ -903,9 +904,24 @@ class ReplSession:
     """
 
     def __init__(self, env: Mapping[str, Any]):
-        self.locals: dict[str, Any] = dict(env)
+        # `InteractiveInterpreter.__init__` sets `self.locals`; subclassing lets
+        # us reuse its `runcode`/`showtraceback`/`write` machinery rather than
+        # re-implementing traceback capture by hand.
+        super().__init__(dict(env))
         # The session's accumulated stdout/stderr, persisting for its lifetime.
         self._buffer = io.StringIO()
+
+    def runcode(self, code: CodeType) -> None:
+        # Mirrors `InteractiveInterpreter.runcode` exactly; the only difference
+        # is that `exec` here is the effect operation, so execution routes
+        # through the installed eval provider.  `showtraceback` reports failures
+        # via `self.write`, which `exec_code` has redirected into the buffer.
+        try:
+            exec(code, self.locals)
+        except SystemExit:
+            raise
+        except:
+            self.showtraceback()
 
     @Tool.define
     def exec_code(self, source: EncodableCode) -> str:
@@ -916,14 +932,9 @@ class ReplSession:
         Use print() to surface values.
         """
         start = self._buffer.tell()
-        try:
-            with (
-                contextlib.redirect_stdout(self._buffer),
-                contextlib.redirect_stderr(self._buffer),
-            ):
-                exec(source.code, self.locals)
-        except Exception:
-            # `except Exception` lets SystemExit/KeyboardInterrupt propagate; any
-            # other error is reported as part of this call's output.
-            self._buffer.write(traceback.format_exc())
+        with (
+            contextlib.redirect_stdout(self._buffer),
+            contextlib.redirect_stderr(self._buffer),
+        ):
+            self.runcode(source.code)
         return self._buffer.getvalue()[start:]

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -5,7 +5,6 @@ import contextlib
 import copy
 import inspect
 import io
-import itertools
 import keyword
 import linecache
 import random
@@ -14,6 +13,7 @@ import sys
 import traceback
 import types
 import typing
+import uuid
 from collections.abc import Mapping
 from types import CodeType
 from typing import Any, TypeAliasType
@@ -105,7 +105,6 @@ def exec(
 
 
 _CODE_FILENAME_PREFIX = "<exec_code-"
-_code_counter = itertools.count()
 
 
 class EncodableCode(pydantic.BaseModel):
@@ -138,7 +137,7 @@ class EncodableCode(pydantic.BaseModel):
             raise ValueError(
                 f"expected source string or code object, got {type(value).__name__}"
             )
-        filename = f"{_CODE_FILENAME_PREFIX}{next(_code_counter)}>"
+        filename = f"{_CODE_FILENAME_PREFIX}{next(uuid.uuid4())}>"
         try:
             return compile(parse(value, filename), filename)
         except (SyntaxError, ValueError) as exc:

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -1,6 +1,7 @@
 import ast
 import builtins
 import code
+import codeop
 import collections.abc
 import contextlib
 import copy
@@ -819,11 +820,8 @@ class RestrictedEvalProvider(ObjectInterpretation):
                 env[key] = rglobals[key]
 
 
-_REPL_FILENAME_PREFIX = "<exec_code-"
-
-
 class ReplExecutionError(Exception):
-    """Raised by `ReplSession.run` when an executed snippet errors.
+    """Raised by `ReplSession.exec_code` when an executed snippet errors.
 
     Carries both the captured ``transcript`` (stdout/stderr plus the trimmed
     user traceback) and the ``original_error`` object, so the call site
@@ -838,11 +836,29 @@ class ReplExecutionError(Exception):
         self.original_error = original_error
 
 
+class _OpCommandCompiler(codeop.CommandCompiler):
+    """A `codeop.CommandCompiler` that routes compilation through the
+    `parse`/`compile` effect operations (so the installed eval-provider owns it
+    and `parse` populates `linecache`), replacing the native single-mode
+    compiler that `code.InteractiveInterpreter` installs.
+    """
+
+    def __call__(
+        self, source: str, filename: str = "<input>", symbol: str = "single"
+    ) -> CodeType:
+        # `runsource` passes symbol="single"; we ignore it and compile in the
+        # exec mode the ops produce, so a complete multi-statement block runs in
+        # one shot.  Incomplete/invalid input raises SyntaxError, which
+        # `runsource` routes to `showsyntaxerror` (we do not buffer partial input
+        # -- there is no line-at-a-time protocol).
+        return compile(parse(source, filename), filename)
+
+
 class ReplSession(code.InteractiveInterpreter):
     """A persistent, output-capturing Python session seeded from a lexical
     context, built on the stdlib `code.InteractiveInterpreter` substrate.
 
-    `run(source)` drives `InteractiveInterpreter.runsource` (its compile ->
+    `exec_code(source)` drives `InteractiveInterpreter.runsource` (its compile ->
     run -> error-print control flow), with a few overrides for our needs:
 
     - compilation routes through the `parse`/`compile` effect operations
@@ -853,32 +869,26 @@ class ReplSession(code.InteractiveInterpreter):
     - `showtraceback` trims the effect-machinery frames so the LLM sees only
       its own snippet's frames.
 
-    State persists in `self.locals` across `run` calls (variables, imports and
+    State persists in `self.locals` across `exec_code` calls (variables, imports and
     definitions accumulate, exactly like a REPL).  Each call runs one complete
     snippet in `exec` mode; on success it returns the captured stdout/stderr,
     and on error it raises `ReplExecutionError` carrying that transcript.  There
     is no bare-expression auto-echo, so use `print()` to surface values.
     """
 
+    _FILENAME_PREFIX: typing.ClassVar[str] = "<exec_code-"
+
     def __init__(self, env: Mapping[str, Any]):
         super().__init__(dict(env))
         self._counter = itertools.count()
-        # One session per instance, so a single in-flight `run` owns these: the
+        # One session per instance, so a single in-flight `exec_code` owns these: the
         # buffer captures that run's stdout/stderr, and `_error` holds the
         # exception it raised, if any.
         self._buffer = io.StringIO()
         self._error: Exception | None = None
         # Replace the native single-mode CommandCompiler with our op-routed,
         # linecache-populating compiler.
-        self.compile = self._compile_through_ops  # type: ignore[assignment]
-
-    def _compile_through_ops(self, source: str, filename: str, symbol: str) -> CodeType:
-        # `runsource` passes symbol="single"; we ignore it and compile in the
-        # exec mode the ops produce, so a complete multi-statement block runs
-        # in one shot.  Incomplete/invalid input raises SyntaxError, which
-        # `runsource` routes to `showsyntaxerror` (we do not buffer partial
-        # input -- there is no line-at-a-time protocol).
-        return compile(parse(source, filename), filename)
+        self.compile = _OpCommandCompiler()
 
     def runcode(self, code_obj: CodeType) -> None:
         try:
@@ -890,7 +900,7 @@ class ReplSession(code.InteractiveInterpreter):
 
     def showsyntaxerror(self, *args: Any, **kwargs: Any) -> None:
         # A syntax/compile error is a failed run too; capture it the way
-        # `runcode` captures a runtime error, so `run` raises for both.  The
+        # `runcode` captures a runtime error, so `exec_code` raises for both.  The
         # SyntaxError is the in-flight exception during `runsource`'s except.
         exc = sys.exc_info()[1]
         assert isinstance(exc, Exception)
@@ -915,12 +925,21 @@ class ReplSession(code.InteractiveInterpreter):
         # the current run's buffer.
         self._buffer.write(data)
 
-    def run(self, source: str) -> str:
+    def exec_code(self, source: str) -> str:
+        """Execute Python in this persistent session and return its captured
+        stdout/stderr.
+
+        Variables, imports and definitions persist across calls, exactly like a
+        REPL.  There is no bare-expression auto-echo, so use print() to surface
+        values.  A snippet that raises propagates the error (carrying its
+        transcript) rather than returning, so it behaves like a normal Python
+        call.
+        """
         # Per-snippet filename so each cell's source is retained in `linecache`
         # independently -- a single shared name would overwrite earlier cells
         # and format earlier-defined functions' tracebacks against the wrong
         # source.
-        filename = f"{_REPL_FILENAME_PREFIX}{next(self._counter)}>"
+        filename = f"{self._FILENAME_PREFIX}{next(self._counter)}>"
         self._buffer = io.StringIO()
         self._error = None
         try:

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -943,8 +943,9 @@ class ReplSession(code.InteractiveInterpreter):
         self._buffer = io.StringIO()
         self._error = None
         try:
-            with contextlib.redirect_stdout(self._buffer), contextlib.redirect_stderr(
-                self._buffer
+            with (
+                contextlib.redirect_stdout(self._buffer),
+                contextlib.redirect_stderr(self._buffer),
             ):
                 self.runsource(source, filename)
         finally:

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -13,13 +13,11 @@ import string
 import sys
 import types
 import typing
-import uuid
 from collections.abc import Mapping
 from types import CodeType
 from typing import Any, TypeAliasType
 
 import autoflake
-import pydantic
 from mypy import api as mypy_api
 from RestrictedPython import (
     Eval,
@@ -104,51 +102,6 @@ def exec(
     raise NotImplementedError(
         "An eval provider must be installed in order to execute code."
     )
-
-
-_CODE_FILENAME_PREFIX = "<exec_code-"
-
-
-class EncodableCode(pydantic.BaseModel):
-    """A snippet of Python source paired with its compiled code object.
-
-    A field validator compiles the source through the `parse`/`compile` effect
-    operations as the model is built, so an `EncodableCode` is, by construction,
-    code that compiled under the installed eval provider -- syntax and
-    compile-time errors raise here, not at run time.  `parse` also records the
-    source in `linecache` under a unique per-snippet filename so tracebacks
-    (including across snippets) resolve correctly, and the ready-to-run `code` is
-    carried so execution never has to recompile.
-    """
-
-    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True, frozen=True)
-
-    source: str
-    code: CodeType
-
-    @pydantic.field_validator("code", mode="before")
-    @classmethod
-    def _compile(cls, value: Any) -> CodeType:
-        # `code` is fed the source string (see `from_source`); compiling it here
-        # means a non-compiling snippet raises at the Encodable boundary rather
-        # than at run time.  A unique per-snippet filename keeps each snippet's
-        # source in `linecache` independently so tracebacks resolve correctly.
-        if isinstance(value, CodeType):
-            return value
-        if not isinstance(value, str):
-            raise ValueError(
-                f"expected source string or code object, got {type(value).__name__}"
-            )
-        filename = f"{_CODE_FILENAME_PREFIX}{uuid.uuid4()}>"
-        try:
-            return compile(parse(value, filename), filename)
-        except (SyntaxError, ValueError) as exc:
-            raise ValueError(f"source does not compile: {exc}") from exc
-
-    @classmethod
-    def from_source(cls, source: str) -> "EncodableCode":
-        # `code` receives the same source; the field validator compiles it.
-        return cls.model_validate({"source": source, "code": source})
 
 
 # Type checking implementation
@@ -889,18 +842,18 @@ class ReplSession(code.InteractiveInterpreter):
     """A persistent, output-capturing Python session seeded from a lexical
     context.
 
-    `exec_code(source)` runs a pre-compiled `EncodableCode` in `self.locals`
-    through the `exec` effect operation.  Both bindings and captured
-    stdout/stderr persist across calls -- variables, imports and definitions
-    accumulate exactly like a REPL -- and the session (with its buffer) is
-    discarded as a whole when it goes out of scope.  Each call returns only the
-    output it produced; a snippet that raises has its traceback appended to that
-    output rather than propagating -- mirroring `code.InteractiveInterpreter`,
-    only `SystemExit` propagates -- so failures are surfaced as text.  There is
-    no bare-expression auto-echo, so use `print()` to surface values.
+    `exec_code(source)` runs a pre-compiled code object in `self.locals` through
+    the `exec` effect operation.  Both bindings and captured stdout/stderr
+    persist across calls -- variables, imports and definitions accumulate exactly
+    like a REPL -- and the session (with its buffer) is discarded as a whole when
+    it goes out of scope.  Each call returns only the output it produced; a
+    snippet that raises has its traceback appended to that output rather than
+    propagating -- mirroring `code.InteractiveInterpreter`, only `SystemExit`
+    propagates -- so failures are surfaced as text.  There is no bare-expression
+    auto-echo, so use `print()` to surface values.
 
-    Compilation -- and therefore syntax checking -- happens earlier, when the
-    `EncodableCode` is built; this session only executes.
+    Compilation -- and therefore syntax checking -- happens earlier, at the
+    `Encodable[CodeType]` boundary; this session only executes.
     """
 
     def __init__(self, env: Mapping[str, Any]):
@@ -924,17 +877,20 @@ class ReplSession(code.InteractiveInterpreter):
             self.showtraceback()
 
     @Tool.define
-    def exec_code(self, source: EncodableCode) -> str:
-        """Execute an `EncodableCode` and return the output it produced.
+    def exec_code(self, source: CodeType) -> str:
+        """Execute a compiled code object and return the output it produced.
 
-        Output accumulates in the session buffer across calls; this returns only
-        the slice from this call (including the traceback if the snippet raised).
-        Use print() to surface values.
+        `source` is a `types.CodeType`; the `Encodable[CodeType]` boundary
+        compiles the LLM's source string into one (rejecting code that does not
+        compile) before it reaches here.  Output accumulates in the session
+        buffer across calls; this returns only the slice from this call
+        (including the traceback if the snippet raised).  Use print() to surface
+        values.
         """
         start = self._buffer.tell()
         with (
             contextlib.redirect_stdout(self._buffer),
             contextlib.redirect_stderr(self._buffer),
         ):
-            self.runcode(source.code)
+            self.runcode(source)
         return self._buffer.getvalue()[start:]

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code.json
@@ -14,7 +14,7 @@
         "tool_calls": [
           {
             "function": {
-              "arguments": "{\"source\":\"import statistics\\n\\n# Assuming 'readings' is available in the scope\\nmean = statistics.mean(readings)\\nstd_dev = statistics.stdev(readings)\\n\\ndistance_from_mean = [value for value in readings if value > mean + std_dev or value < mean - std_dev]\\n\\n# Count how many values are there\\ncount = len(distance_from_mean)\\n\\ncount\"}",
+              "arguments": "{\"code\":\"import statistics\\n\\n# Assuming 'readings' is available in the scope\\nmean = statistics.mean(readings)\\nstd_dev = statistics.stdev(readings)\\n\\ndistance_from_mean = [value for value in readings if value > mean + std_dev or value < mean - std_dev]\\n\\n# Count how many values are there\\ncount = len(distance_from_mean)\\n\\ncount\"}",
               "name": "exec_code"
             },
             "id": "call_v3YxolHwxaLBzP4FWwTjgJkc",

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code.json
@@ -1,0 +1,55 @@
+{
+  "id": "chatcmpl-DphGr3t1dQa9Fzb75i4daZKtjSDQ1",
+  "created": 1781213433,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_f4c4edc0d3",
+  "choices": [
+    {
+      "finish_reason": "tool_calls",
+      "index": 0,
+      "message": {
+        "content": null,
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{\"source\":\"import statistics\\n\\n# Assuming 'readings' is available in the scope\\nmean = statistics.mean(readings)\\nstd_dev = statistics.stdev(readings)\\n\\ndistance_from_mean = [value for value in readings if value > mean + std_dev or value < mean - std_dev]\\n\\n# Count how many values are there\\ncount = len(distance_from_mean)\\n\\ncount\"}",
+              "name": "exec_code"
+            },
+            "id": "call_v3YxolHwxaLBzP4FWwTjgJkc",
+            "type": "function"
+          }
+        ],
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 94,
+    "prompt_tokens": 3925,
+    "total_tokens": 4019,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_1.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_1.json
@@ -1,0 +1,55 @@
+{
+  "id": "chatcmpl-DphGtPrxbaG5DoQjAmSPirgtJLLx1",
+  "created": 1781213435,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_f4c4edc0d3",
+  "choices": [
+    {
+      "finish_reason": "tool_calls",
+      "index": 0,
+      "message": {
+        "content": null,
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{}",
+              "name": "readings"
+            },
+            "id": "call_jQLbDz3Gjc8bv8pCVtJ9V0nl",
+            "type": "function"
+          }
+        ],
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 10,
+    "prompt_tokens": 4027,
+    "total_tokens": 4037,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 3968,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_2.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_2.json
@@ -1,0 +1,55 @@
+{
+  "id": "chatcmpl-DphGvw9RTxM7RYCVLFXm5hL4bgPNG",
+  "created": 1781213437,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_f4c4edc0d3",
+  "choices": [
+    {
+      "finish_reason": "tool_calls",
+      "index": 0,
+      "message": {
+        "content": null,
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{\"source\":\"import statistics\\n\\nreadings = [12, 19, 23, 31, 8, 27]\\nmean = statistics.mean(readings)\\nstd_dev = statistics.stdev(readings)\\n\\ndistance_from_mean = [value for value in readings if value > mean + std_dev or value < mean - std_dev]\\n\\n# Count how many values are there\\ncount = len(distance_from_mean)\\n\\ncount\"}",
+              "name": "exec_code"
+            },
+            "id": "call_ch22rtpeLjhaPsgVGncYOsja",
+            "type": "function"
+          }
+        ],
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 104,
+    "prompt_tokens": 4063,
+    "total_tokens": 4167,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 3968,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_2.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_2.json
@@ -14,7 +14,7 @@
         "tool_calls": [
           {
             "function": {
-              "arguments": "{\"source\":\"import statistics\\n\\nreadings = [12, 19, 23, 31, 8, 27]\\nmean = statistics.mean(readings)\\nstd_dev = statistics.stdev(readings)\\n\\ndistance_from_mean = [value for value in readings if value > mean + std_dev or value < mean - std_dev]\\n\\n# Count how many values are there\\ncount = len(distance_from_mean)\\n\\ncount\"}",
+              "arguments": "{\"code\":\"import statistics\\n\\nreadings = [12, 19, 23, 31, 8, 27]\\nmean = statistics.mean(readings)\\nstd_dev = statistics.stdev(readings)\\n\\ndistance_from_mean = [value for value in readings if value > mean + std_dev or value < mean - std_dev]\\n\\n# Count how many values are there\\ncount = len(distance_from_mean)\\n\\ncount\"}",
               "name": "exec_code"
             },
             "id": "call_ch22rtpeLjhaPsgVGncYOsja",

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_3.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestPythonReplIntegration__test_llm_computes_via_exec_code_3.json
@@ -1,0 +1,46 @@
+{
+  "id": "chatcmpl-DphGxDZMCoURYn04TpzjjqNCqpfUx",
+  "created": 1781213439,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_f4c4edc0d3",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "{\"value\":2}",
+        "role": "assistant",
+        "tool_calls": null,
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 11,
+    "prompt_tokens": 4175,
+    "total_tokens": 4186,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 4096,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/test_handlers_llm_encoding.py
+++ b/tests/test_handlers_llm_encoding.py
@@ -28,7 +28,6 @@ from effectful.handlers.llm.encoding import (
     to_content_blocks,
 )
 from effectful.handlers.llm.evaluation import (
-    EncodableCode,
     RestrictedEvalProvider,
     UnsafeEvalProvider,
 )
@@ -979,26 +978,25 @@ def test_litellm_completion_accepts_tool_with_type_as_return(
 
 
 # ============================================================================
-# EncodableCode -- syntax checking at the Encodable boundary
+# Encodable[CodeType] -- syntax checking at the Encodable boundary
 # ============================================================================
 
 
 def test_encodable_code_compiles_source_to_a_code_object():
-    """Decoding compiles the source through the eval provider; the result keeps
-    the source alongside a ready-to-run code object."""
+    """Decoding `Encodable[CodeType]` compiles the source through the eval
+    provider, yielding a ready-to-run code object."""
     src = "x = 1\nprint(x)\n"
-    adapter = pydantic.TypeAdapter(Encodable[EncodableCode])
+    adapter = pydantic.TypeAdapter(Encodable[CodeType])
     with handler(UnsafeEvalProvider()):
         decoded = adapter.validate_python(src)
-    assert isinstance(decoded, EncodableCode)
-    assert decoded.source == src
-    assert isinstance(decoded.code, CodeType)
+    assert isinstance(decoded, CodeType)
 
 
 def test_encodable_code_round_trips_to_source():
-    """Re-encoding an `EncodableCode` yields its source string."""
+    """Re-encoding a decoded code object recovers its source string (from
+    `linecache`)."""
     src = "a = 2\n"
-    adapter = pydantic.TypeAdapter(Encodable[EncodableCode])
+    adapter = pydantic.TypeAdapter(Encodable[CodeType])
     with handler(UnsafeEvalProvider()):
         decoded = adapter.validate_python(src)
         assert adapter.dump_python(decoded) == src
@@ -1008,7 +1006,7 @@ def test_encodable_code_rejects_syntax_error():
     """Source that does not parse is rejected at decode."""
     with handler(UnsafeEvalProvider()):
         with pytest.raises(pydantic.ValidationError):
-            pydantic.TypeAdapter(Encodable[EncodableCode]).validate_python("def f(:")
+            pydantic.TypeAdapter(Encodable[CodeType]).validate_python("def f(:")
 
 
 def test_encodable_code_rejects_compile_only_error():
@@ -1016,10 +1014,10 @@ def test_encodable_code_rejects_compile_only_error():
     so the check is `compile`, not merely `ast.parse`."""
     with handler(UnsafeEvalProvider()):
         with pytest.raises(pydantic.ValidationError):
-            pydantic.TypeAdapter(Encodable[EncodableCode]).validate_python("return 5")
+            pydantic.TypeAdapter(Encodable[CodeType]).validate_python("return 5")
 
 
 def test_encodable_code_schema_is_a_string():
-    """The LLM sees `EncodableCode` as a plain string."""
-    schema = pydantic.TypeAdapter(Encodable[EncodableCode]).json_schema()
+    """The LLM sees a `CodeType` parameter as a plain string."""
+    schema = pydantic.TypeAdapter(Encodable[CodeType]).json_schema()
     assert schema["type"] == "string"

--- a/tests/test_handlers_llm_encoding.py
+++ b/tests/test_handlers_llm_encoding.py
@@ -11,6 +11,7 @@ import json
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from types import CodeType
 from typing import Annotated, Any, Literal, NamedTuple, TypedDict, Union
 
 import litellm
@@ -26,7 +27,11 @@ from effectful.handlers.llm.encoding import (
     SynthesizedFunction,
     to_content_blocks,
 )
-from effectful.handlers.llm.evaluation import RestrictedEvalProvider, UnsafeEvalProvider
+from effectful.handlers.llm.evaluation import (
+    EncodableCode,
+    RestrictedEvalProvider,
+    UnsafeEvalProvider,
+)
 from effectful.handlers.llm.template import Tool
 from effectful.internals.unification import nested_type
 from effectful.ops.semantics import handler
@@ -971,3 +976,50 @@ def test_litellm_completion_accepts_tool_with_type_as_return(
         max_tokens=400,
     )
     assert isinstance(response, litellm.ModelResponse)
+
+
+# ============================================================================
+# EncodableCode -- syntax checking at the Encodable boundary
+# ============================================================================
+
+
+def test_encodable_code_compiles_source_to_a_code_object():
+    """Decoding compiles the source through the eval provider; the result keeps
+    the source alongside a ready-to-run code object."""
+    src = "x = 1\nprint(x)\n"
+    adapter = pydantic.TypeAdapter(Encodable[EncodableCode])
+    with handler(UnsafeEvalProvider()):
+        decoded = adapter.validate_python(src)
+    assert isinstance(decoded, EncodableCode)
+    assert decoded.source == src
+    assert isinstance(decoded.code, CodeType)
+
+
+def test_encodable_code_round_trips_to_source():
+    """Re-encoding an `EncodableCode` yields its source string."""
+    src = "a = 2\n"
+    adapter = pydantic.TypeAdapter(Encodable[EncodableCode])
+    with handler(UnsafeEvalProvider()):
+        decoded = adapter.validate_python(src)
+        assert adapter.dump_python(decoded) == src
+
+
+def test_encodable_code_rejects_syntax_error():
+    """Source that does not parse is rejected at decode."""
+    with handler(UnsafeEvalProvider()):
+        with pytest.raises(pydantic.ValidationError):
+            pydantic.TypeAdapter(Encodable[EncodableCode]).validate_python("def f(:")
+
+
+def test_encodable_code_rejects_compile_only_error():
+    """`return` outside a function parses but does not compile -- still rejected,
+    so the check is `compile`, not merely `ast.parse`."""
+    with handler(UnsafeEvalProvider()):
+        with pytest.raises(pydantic.ValidationError):
+            pydantic.TypeAdapter(Encodable[EncodableCode]).validate_python("return 5")
+
+
+def test_encodable_code_schema_is_a_string():
+    """The LLM sees `EncodableCode` as a plain string."""
+    schema = pydantic.TypeAdapter(Encodable[EncodableCode]).json_schema()
+    assert schema["type"] == "string"

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -19,6 +19,7 @@ from RestrictedPython import RestrictingNodeTransformer
 
 from effectful.handlers.llm.encoding import Encodable, SynthesizedFunction
 from effectful.handlers.llm.evaluation import (
+    EncodableCode,
     ReplExecutionError,
     ReplSession,
     RestrictedEvalProvider,
@@ -1548,27 +1549,33 @@ def test_builtins_in_env_does_not_bypass_security():
 # ============================================================================
 
 
+def _code(source: str) -> EncodableCode:
+    """Build an `EncodableCode` (compiling the source through the active eval
+    provider) for the session tests below."""
+    return EncodableCode.from_source(source)
+
+
 def test_repl_seeds_from_lexical_context():
     """Names in the seed context are usable in executed code."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({"readings": [10, 20, 30]})
-        assert session.exec_code("print(sum(readings))") == "60\n"
+        assert session.exec_code(_code("print(sum(readings))")) == "60\n"
 
 
 def test_repl_persists_bindings_across_calls():
     """A binding created in one call is visible in the next."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        session.exec_code("total = 41")
-        assert session.exec_code("print(total)") == "41\n"
+        session.exec_code(_code("total = 41"))
+        assert session.exec_code(_code("print(total)")) == "41\n"
 
 
 def test_repl_rebinds_across_calls():
     """A seeded/prior name can be rebound using its prior value."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({"x": 10})
-        session.exec_code("x = x + 1")
-        assert session.exec_code("print(x)") == "11\n"
+        session.exec_code(_code("x = x + 1"))
+        assert session.exec_code(_code("print(x)")) == "11\n"
 
 
 def test_repl_runs_complete_multistatement_block():
@@ -1576,24 +1583,24 @@ def test_repl_runs_complete_multistatement_block():
     `single`-mode compilation would reject)."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        out = session.exec_code("def double(n):\n    return n * 2\nprint(double(21))")
+        out = session.exec_code(
+            _code("def double(n):\n    return n * 2\nprint(double(21))")
+        )
         assert out == "42\n"
 
 
 def test_repl_captures_print():
     with handler(UnsafeEvalProvider()):
-        assert ReplSession({}).exec_code("print('hi')") == "hi\n"
+        assert ReplSession({}).exec_code(_code("print('hi')")) == "hi\n"
 
 
-def test_repl_syntax_error_raises_with_transcript():
-    """An invalid snippet raises `ReplExecutionError` carrying the transcript,
-    and leaves the session usable."""
+def test_repl_rejects_invalid_source_at_construction():
+    """Invalid source is rejected when the `EncodableCode` is built -- before it
+    ever reaches the session -- and valid code in the same provider still runs."""
     with handler(UnsafeEvalProvider()):
-        session = ReplSession({})
-        with pytest.raises(ReplExecutionError) as exc_info:
-            session.exec_code("def f(:")
-        assert isinstance(exc_info.value.original_error, SyntaxError)
-        assert session.exec_code("print('ok')") == "ok\n"
+        with pytest.raises(pydantic.ValidationError):
+            EncodableCode.from_source("def f(:")
+        assert ReplSession({}).exec_code(_code("print('ok')")) == "ok\n"
 
 
 def test_repl_exception_is_isolated():
@@ -1601,11 +1608,11 @@ def test_repl_exception_is_isolated():
     retains prior state."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        session.exec_code("kept = 7")
+        session.exec_code(_code("kept = 7"))
         with pytest.raises(ReplExecutionError) as exc_info:
-            session.exec_code("print(1 / 0)")
+            session.exec_code(_code("print(1 / 0)"))
         assert isinstance(exc_info.value.original_error, ZeroDivisionError)
-        assert session.exec_code("print(kept)") == "7\n"
+        assert session.exec_code(_code("print(kept)")) == "7\n"
 
 
 def test_repl_keyboard_interrupt_propagates():
@@ -1613,7 +1620,7 @@ def test_repl_keyboard_interrupt_propagates():
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
         with pytest.raises(KeyboardInterrupt):
-            session.exec_code("raise KeyboardInterrupt")
+            session.exec_code(_code("raise KeyboardInterrupt"))
 
 
 def test_repl_traceback_trims_effect_machinery_frames():
@@ -1621,7 +1628,7 @@ def test_repl_traceback_trims_effect_machinery_frames():
     `.py` frames between the call site and the snippet are dropped."""
     with handler(UnsafeEvalProvider()):
         with pytest.raises(ReplExecutionError) as exc_info:
-            ReplSession({}).exec_code("1 / 0")
+            ReplSession({}).exec_code(_code("1 / 0"))
         transcript = exc_info.value.transcript
     frame_files = re.findall(r'File "([^"]+)"', transcript)
     assert frame_files  # the traceback shows at least one frame
@@ -1634,9 +1641,9 @@ def test_repl_cross_snippet_traceback_shows_correct_source():
     per-snippet filename keeps each cell's source in linecache."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        session.exec_code("def boom():\n    return 1 / 0")
+        session.exec_code(_code("def boom():\n    return 1 / 0"))
         with pytest.raises(ReplExecutionError) as exc_info:
-            session.exec_code("boom()")
+            session.exec_code(_code("boom()"))
         assert "return 1 / 0" in exc_info.value.transcript  # boom's real source
 
 
@@ -1646,8 +1653,8 @@ def test_repl_new_binding_does_not_leak_into_seed_context():
     with handler(UnsafeEvalProvider()):
         seed = {"base": 10}
         session = ReplSession(seed)
-        session.exec_code("derived = base + 5")
-        assert session.exec_code("print(derived)") == "15\n"
+        session.exec_code(_code("derived = base + 5"))
+        assert session.exec_code(_code("print(derived)")) == "15\n"
         assert "derived" not in seed  # the lexical seed is untouched
 
 
@@ -1663,8 +1670,8 @@ def test_repl_new_binding_does_not_leak_into_seed_context():
 def test_repl_rebinds_across_calls_restricted():
     with handler(RestrictedEvalProvider()):
         session = ReplSession({"x": 10})
-        session.exec_code("x = x + 1")
-        assert session.exec_code("print(x)") == "11\n"
+        session.exec_code(_code("x = x + 1"))
+        assert session.exec_code(_code("print(x)")) == "11\n"
 
 
 @pytest.mark.xfail(
@@ -1673,4 +1680,4 @@ def test_repl_rebinds_across_calls_restricted():
 )
 def test_repl_captures_print_restricted():
     with handler(RestrictedEvalProvider()):
-        assert ReplSession({}).exec_code("print('hi')") == "hi\n"
+        assert ReplSession({}).exec_code(_code("print('hi')")) == "hi\n"

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -18,6 +18,7 @@ from RestrictedPython import RestrictingNodeTransformer
 
 from effectful.handlers.llm.encoding import Encodable, SynthesizedFunction
 from effectful.handlers.llm.evaluation import (
+    ReplExecutionError,
     ReplSession,
     RestrictedEvalProvider,
     UnsafeEvalProvider,
@@ -1584,13 +1585,14 @@ def test_repl_captures_print():
         assert ReplSession({}).run("print('hi')") == "hi\n"
 
 
-def test_repl_syntax_error_is_a_transcript_not_a_raise():
-    """An incomplete snippet returns a transcript and leaves the session
-    usable."""
+def test_repl_syntax_error_raises_with_transcript():
+    """An invalid snippet raises `ReplExecutionError` carrying the transcript,
+    and leaves the session usable."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        out = session.run("def f(:")
-        assert "SyntaxError" in out
+        with pytest.raises(ReplExecutionError) as exc_info:
+            session.run("def f(:")
+        assert "SyntaxError" in exc_info.value.transcript
         assert session.run("print('ok')") == "ok\n"
 
 
@@ -1600,8 +1602,9 @@ def test_repl_exception_is_isolated():
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
         session.run("kept = 7")
-        out = session.run("print(1 / 0)")
-        assert "ZeroDivisionError" in out
+        with pytest.raises(ReplExecutionError) as exc_info:
+            session.run("print(1 / 0)")
+        assert "ZeroDivisionError" in exc_info.value.transcript
         assert session.run("print(kept)") == "7\n"
 
 
@@ -1617,7 +1620,9 @@ def test_repl_traceback_trims_effect_machinery_frames():
     """The transcript for an uncaught exception shows only the user's snippet
     frames, not effectful's internal frames."""
     with handler(UnsafeEvalProvider()):
-        out = ReplSession({}).run("1 / 0")
+        with pytest.raises(ReplExecutionError) as exc_info:
+            ReplSession({}).run("1 / 0")
+        out = exc_info.value.transcript
         assert "ZeroDivisionError" in out
         assert "runtime.py" not in out
         assert "ops/types.py" not in out
@@ -1631,8 +1636,9 @@ def test_repl_cross_snippet_traceback_shows_correct_source():
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
         session.run("def boom():\n    return 1 / 0")
-        out = session.run("boom()")
-        assert "return 1 / 0" in out  # boom's real source, not "boom()"
+        with pytest.raises(ReplExecutionError) as exc_info:
+            session.run("boom()")
+        assert "return 1 / 0" in exc_info.value.transcript  # boom's real source
 
 
 def test_repl_reentrant_run_keeps_outer_transcript():

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -1617,12 +1617,16 @@ def test_repl_exception_is_isolated():
         assert session.exec_code(_code("print(kept)")) == "7\n"
 
 
-def test_repl_keyboard_interrupt_propagates():
-    """`KeyboardInterrupt` is not swallowed into a transcript."""
+def test_repl_system_exit_propagates():
+    """`SystemExit` propagates, mirroring `InteractiveInterpreter.runcode`; every
+    other exception (including `KeyboardInterrupt`) is caught and surfaced as
+    output rather than escaping the call."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        with pytest.raises(KeyboardInterrupt):
-            session.exec_code(_code("raise KeyboardInterrupt"))
+        with pytest.raises(SystemExit):
+            session.exec_code(_code("raise SystemExit"))
+        out = session.exec_code(_code("raise KeyboardInterrupt"))
+        assert "KeyboardInterrupt" in out
 
 
 def test_repl_cross_snippet_traceback_shows_correct_source():

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -3,6 +3,7 @@
 import ast
 import builtins
 import inspect
+import re
 import sys
 import textwrap
 import types
@@ -1616,16 +1617,15 @@ def test_repl_keyboard_interrupt_propagates():
 
 
 def test_repl_traceback_trims_effect_machinery_frames():
-    """The transcript for an uncaught exception shows only the user's snippet
-    frames, not effectful's internal frames."""
+    """The trimmed traceback shows only the user's snippet frames; the effectful
+    `.py` frames between the call site and the snippet are dropped."""
     with handler(UnsafeEvalProvider()):
         with pytest.raises(ReplExecutionError) as exc_info:
             ReplSession({}).run("1 / 0")
-        out = exc_info.value.transcript
-        assert "ZeroDivisionError" in out
-        assert "runtime.py" not in out
-        assert "ops/types.py" not in out
-        assert "exec_code-" in out  # the user frame's per-snippet filename
+        transcript = exc_info.value.transcript
+    frame_files = re.findall(r'File "([^"]+)"', transcript)
+    assert frame_files  # the traceback shows at least one frame
+    assert all(not f.endswith(".py") for f in frame_files)  # no machinery frame
 
 
 def test_repl_cross_snippet_traceback_shows_correct_source():
@@ -1640,18 +1640,15 @@ def test_repl_cross_snippet_traceback_shows_correct_source():
         assert "return 1 / 0" in exc_info.value.transcript  # boom's real source
 
 
-def test_repl_reentrant_run_keeps_outer_transcript():
-    """A `run` whose code re-enters `run` on the same session still returns
-    the outer call's own output (per-call buffer, not a shared one)."""
+def test_repl_new_binding_does_not_leak_into_seed_context():
+    """A binding created in executed code stays in the session; the seed mapping
+    the session was created from is not mutated."""
     with handler(UnsafeEvalProvider()):
-        session = ReplSession({"session": None})
-        session.locals["session"] = session  # let exec'd code call back in
-        out = session.run(
-            "print('outer-before')\nsession.run(\"print('inner')\")\nprint('outer-after')"
-        )
-        assert "outer-before" in out
-        assert "outer-after" in out
-        assert "inner" not in out  # inner output went to the inner call's buffer
+        seed = {"base": 10}
+        session = ReplSession(seed)
+        session.run("derived = base + 5")
+        assert session.run("print(derived)") == "15\n"
+        assert "derived" not in seed  # the lexical seed is untouched
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -1651,6 +1651,19 @@ def test_repl_new_binding_does_not_leak_into_seed_context():
         assert "derived" not in seed  # the lexical seed is untouched
 
 
+def test_repl_binding_is_visible_to_the_rest_of_the_call():
+    """Seeded from the per-call `ChainMap`, a binding the REPL makes lands in a
+    shared shadow layer of that chain -- so the rest of the Template call sees it
+    -- while the read-only lexical layer underneath does not, keeping it scoped to
+    the call (mirroring `exec`)."""
+    with handler(UnsafeEvalProvider()):
+        lexical = {"base": 10}
+        env: ChainMap[str, Any] = ChainMap({}, lexical)
+        ReplSession(env).exec_code(_code("shared = base + 5"))
+        assert env["shared"] == 15  # visible to the rest of the call via the chain
+        assert "shared" not in lexical  # but not leaked into the lexical context
+
+
 # ----------------------------------------------------------------------------
 # ReplSession under RestrictedEvalProvider (state + print fixed in #686)
 # ----------------------------------------------------------------------------

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -28,10 +28,9 @@ from effectful.handlers.llm.evaluation import (
     mypy_type_check,
     type_to_ast,
 )
-from effectful.handlers.llm.evaluation import exec as exec_op
 from effectful.internals.unification import nested_type
 from effectful.ops.semantics import handler
-from effectful.ops.syntax import ObjectInterpretation, defop, implements
+from effectful.ops.syntax import defop
 from effectful.ops.types import NotHandled
 
 
@@ -1592,7 +1591,7 @@ def test_repl_syntax_error_raises_with_transcript():
         session = ReplSession({})
         with pytest.raises(ReplExecutionError) as exc_info:
             session.run("def f(:")
-        assert "SyntaxError" in exc_info.value.transcript
+        assert isinstance(exc_info.value.original_error, SyntaxError)
         assert session.run("print('ok')") == "ok\n"
 
 
@@ -1604,7 +1603,7 @@ def test_repl_exception_is_isolated():
         session.run("kept = 7")
         with pytest.raises(ReplExecutionError) as exc_info:
             session.run("print(1 / 0)")
-        assert "ZeroDivisionError" in exc_info.value.transcript
+        assert isinstance(exc_info.value.original_error, ZeroDivisionError)
         assert session.run("print(kept)") == "7\n"
 
 
@@ -1653,22 +1652,6 @@ def test_repl_reentrant_run_keeps_outer_transcript():
         assert "outer-before" in out
         assert "outer-after" in out
         assert "inner" not in out  # inner output went to the inner call's buffer
-
-
-def test_repl_execution_routes_through_exec_op():
-    """With `exec` overridden to a no-op, nothing runs — proving execution
-    goes through the op, asserted via the observable (the binding is absent)."""
-
-    class _NoExec(ObjectInterpretation):
-        @implements(exec_op)
-        def _(self, bytecode, env) -> None:
-            pass
-
-    with handler(UnsafeEvalProvider()), handler(_NoExec()):
-        session = ReplSession({})
-        session.run("x = 1")
-    with handler(UnsafeEvalProvider()):
-        assert session.run("print('x' in dir())") == "False\n"
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -3,7 +3,6 @@
 import ast
 import builtins
 import inspect
-import re
 import sys
 import textwrap
 import types
@@ -20,7 +19,6 @@ from RestrictedPython import RestrictingNodeTransformer
 from effectful.handlers.llm.encoding import Encodable, SynthesizedFunction
 from effectful.handlers.llm.evaluation import (
     EncodableCode,
-    ReplExecutionError,
     ReplSession,
     RestrictedEvalProvider,
     UnsafeEvalProvider,
@@ -1604,14 +1602,13 @@ def test_repl_rejects_invalid_source_at_construction():
 
 
 def test_repl_exception_is_isolated():
-    """A runtime exception returns a transcript; the session survives and
-    retains prior state."""
+    """A runtime exception is reported in the call's output; the session survives
+    and retains prior state."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
         session.exec_code(_code("kept = 7"))
-        with pytest.raises(ReplExecutionError) as exc_info:
-            session.exec_code(_code("print(1 / 0)"))
-        assert isinstance(exc_info.value.original_error, ZeroDivisionError)
+        out = session.exec_code(_code("print(1 / 0)"))
+        assert "ZeroDivisionError" in out
         assert session.exec_code(_code("print(kept)")) == "7\n"
 
 
@@ -1623,28 +1620,15 @@ def test_repl_keyboard_interrupt_propagates():
             session.exec_code(_code("raise KeyboardInterrupt"))
 
 
-def test_repl_traceback_trims_effect_machinery_frames():
-    """The trimmed traceback shows only the user's snippet frames; the effectful
-    `.py` frames between the call site and the snippet are dropped."""
-    with handler(UnsafeEvalProvider()):
-        with pytest.raises(ReplExecutionError) as exc_info:
-            ReplSession({}).exec_code(_code("1 / 0"))
-        transcript = exc_info.value.transcript
-    frame_files = re.findall(r'File "([^"]+)"', transcript)
-    assert frame_files  # the traceback shows at least one frame
-    assert all(not f.endswith(".py") for f in frame_files)  # no machinery frame
-
-
 def test_repl_cross_snippet_traceback_shows_correct_source():
-    """A function defined in an earlier call that raises in a later call
-    formats with its *own* source line, not the later call's source — the
-    per-snippet filename keeps each cell's source in linecache."""
+    """A function defined in an earlier call that raises in a later call formats
+    with its *own* source line, not the later call's source -- the per-snippet
+    filename keeps each cell's source in linecache."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
         session.exec_code(_code("def boom():\n    return 1 / 0"))
-        with pytest.raises(ReplExecutionError) as exc_info:
-            session.exec_code(_code("boom()"))
-        assert "return 1 / 0" in exc_info.value.transcript  # boom's real source
+        out = session.exec_code(_code("boom()"))
+        assert "return 1 / 0" in out  # boom's real source
 
 
 def test_repl_new_binding_does_not_leak_into_seed_context():

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -1664,6 +1664,30 @@ def test_repl_binding_is_visible_to_the_rest_of_the_call():
         assert "shared" not in lexical  # but not leaked into the lexical context
 
 
+def test_repl_keeps_stdout_and_stderr_separate():
+    """stdout (print output) and stderr (tracebacks) accumulate in separate,
+    introspectable buffers; `exec_code` returns this call's stdout then stderr."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        out = session.exec_code(_code("print('hi')\n1 / 0"))
+        assert session.stdout.getvalue() == "hi\n"
+        assert "ZeroDivisionError" in session.stderr.getvalue()
+        assert "hi" not in session.stderr.getvalue()  # the streams don't mix
+        assert out == "hi\n" + session.stderr.getvalue()  # returned: stdout then stderr
+
+
+def test_repl_runsource_routes_through_ops():
+    """`runsource` compiles through the `parse`/`compile` ops (so it needs an
+    installed provider), keeping it self-consistent with `runcode`/`exec_code`
+    rather than falling back to the native single-mode compiler."""
+    with pytest.raises(NotImplementedError):
+        ReplSession({}).runsource("x = 1")  # no provider -> the parse op raises
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        assert session.runsource("kept = 7") is False  # complete: compiled + ran
+        assert session.locals["kept"] == 7
+
+
 # ----------------------------------------------------------------------------
 # ReplSession under RestrictedEvalProvider (state + print fixed in #686)
 # ----------------------------------------------------------------------------

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -20,7 +20,6 @@ from RestrictedPython import RestrictingNodeTransformer
 
 from effectful.handlers.llm.encoding import Encodable, SynthesizedFunction
 from effectful.handlers.llm.evaluation import (
-    EncodableCode,
     ReplSession,
     RestrictedEvalProvider,
     UnsafeEvalProvider,
@@ -1552,10 +1551,11 @@ def test_builtins_in_env_does_not_bypass_security():
 # ============================================================================
 
 
-def _code(source: str) -> EncodableCode:
-    """Build an `EncodableCode` (compiling the source through the active eval
-    provider) for the session tests below."""
-    return EncodableCode.from_source(source)
+def _code(source: str) -> types.CodeType:
+    """Compile `source` to a code object the way the `exec_code` tool boundary
+    does -- through `Encodable[CodeType]`, which routes the active eval
+    provider's `parse`/`compile` ops (so a handler must be installed)."""
+    return pydantic.TypeAdapter(Encodable[types.CodeType]).validate_python(source)
 
 
 def test_repl_seeds_from_lexical_context():
@@ -1598,11 +1598,11 @@ def test_repl_captures_print():
 
 
 def test_repl_rejects_invalid_source_at_construction():
-    """Invalid source is rejected when the `EncodableCode` is built -- before it
+    """Invalid source is rejected when it is decoded to a code object -- before it
     ever reaches the session -- and valid code in the same provider still runs."""
     with handler(UnsafeEvalProvider()):
         with pytest.raises(pydantic.ValidationError):
-            EncodableCode.from_source("def f(:")
+            _code("def f(:")
         assert ReplSession({}).exec_code(_code("print('ok')")) == "ok\n"
 
 

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -1552,23 +1552,23 @@ def test_repl_seeds_from_lexical_context():
     """Names in the seed context are usable in executed code."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({"readings": [10, 20, 30]})
-        assert session.run("print(sum(readings))") == "60\n"
+        assert session.exec_code("print(sum(readings))") == "60\n"
 
 
 def test_repl_persists_bindings_across_calls():
     """A binding created in one call is visible in the next."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        session.run("total = 41")
-        assert session.run("print(total)") == "41\n"
+        session.exec_code("total = 41")
+        assert session.exec_code("print(total)") == "41\n"
 
 
 def test_repl_rebinds_across_calls():
     """A seeded/prior name can be rebound using its prior value."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({"x": 10})
-        session.run("x = x + 1")
-        assert session.run("print(x)") == "11\n"
+        session.exec_code("x = x + 1")
+        assert session.exec_code("print(x)") == "11\n"
 
 
 def test_repl_runs_complete_multistatement_block():
@@ -1576,13 +1576,13 @@ def test_repl_runs_complete_multistatement_block():
     `single`-mode compilation would reject)."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        out = session.run("def double(n):\n    return n * 2\nprint(double(21))")
+        out = session.exec_code("def double(n):\n    return n * 2\nprint(double(21))")
         assert out == "42\n"
 
 
 def test_repl_captures_print():
     with handler(UnsafeEvalProvider()):
-        assert ReplSession({}).run("print('hi')") == "hi\n"
+        assert ReplSession({}).exec_code("print('hi')") == "hi\n"
 
 
 def test_repl_syntax_error_raises_with_transcript():
@@ -1591,9 +1591,9 @@ def test_repl_syntax_error_raises_with_transcript():
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
         with pytest.raises(ReplExecutionError) as exc_info:
-            session.run("def f(:")
+            session.exec_code("def f(:")
         assert isinstance(exc_info.value.original_error, SyntaxError)
-        assert session.run("print('ok')") == "ok\n"
+        assert session.exec_code("print('ok')") == "ok\n"
 
 
 def test_repl_exception_is_isolated():
@@ -1601,11 +1601,11 @@ def test_repl_exception_is_isolated():
     retains prior state."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        session.run("kept = 7")
+        session.exec_code("kept = 7")
         with pytest.raises(ReplExecutionError) as exc_info:
-            session.run("print(1 / 0)")
+            session.exec_code("print(1 / 0)")
         assert isinstance(exc_info.value.original_error, ZeroDivisionError)
-        assert session.run("print(kept)") == "7\n"
+        assert session.exec_code("print(kept)") == "7\n"
 
 
 def test_repl_keyboard_interrupt_propagates():
@@ -1613,7 +1613,7 @@ def test_repl_keyboard_interrupt_propagates():
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
         with pytest.raises(KeyboardInterrupt):
-            session.run("raise KeyboardInterrupt")
+            session.exec_code("raise KeyboardInterrupt")
 
 
 def test_repl_traceback_trims_effect_machinery_frames():
@@ -1621,7 +1621,7 @@ def test_repl_traceback_trims_effect_machinery_frames():
     `.py` frames between the call site and the snippet are dropped."""
     with handler(UnsafeEvalProvider()):
         with pytest.raises(ReplExecutionError) as exc_info:
-            ReplSession({}).run("1 / 0")
+            ReplSession({}).exec_code("1 / 0")
         transcript = exc_info.value.transcript
     frame_files = re.findall(r'File "([^"]+)"', transcript)
     assert frame_files  # the traceback shows at least one frame
@@ -1634,9 +1634,9 @@ def test_repl_cross_snippet_traceback_shows_correct_source():
     per-snippet filename keeps each cell's source in linecache."""
     with handler(UnsafeEvalProvider()):
         session = ReplSession({})
-        session.run("def boom():\n    return 1 / 0")
+        session.exec_code("def boom():\n    return 1 / 0")
         with pytest.raises(ReplExecutionError) as exc_info:
-            session.run("boom()")
+            session.exec_code("boom()")
         assert "return 1 / 0" in exc_info.value.transcript  # boom's real source
 
 
@@ -1646,8 +1646,8 @@ def test_repl_new_binding_does_not_leak_into_seed_context():
     with handler(UnsafeEvalProvider()):
         seed = {"base": 10}
         session = ReplSession(seed)
-        session.run("derived = base + 5")
-        assert session.run("print(derived)") == "15\n"
+        session.exec_code("derived = base + 5")
+        assert session.exec_code("print(derived)") == "15\n"
         assert "derived" not in seed  # the lexical seed is untouched
 
 
@@ -1663,8 +1663,8 @@ def test_repl_new_binding_does_not_leak_into_seed_context():
 def test_repl_rebinds_across_calls_restricted():
     with handler(RestrictedEvalProvider()):
         session = ReplSession({"x": 10})
-        session.run("x = x + 1")
-        assert session.run("print(x)") == "11\n"
+        session.exec_code("x = x + 1")
+        assert session.exec_code("print(x)") == "11\n"
 
 
 @pytest.mark.xfail(
@@ -1673,4 +1673,4 @@ def test_repl_rebinds_across_calls_restricted():
 )
 def test_repl_captures_print_restricted():
     with handler(RestrictedEvalProvider()):
-        assert ReplSession({}).run("print('hi')") == "hi\n"
+        assert ReplSession({}).exec_code("print('hi')") == "hi\n"

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -18,16 +18,19 @@ from RestrictedPython import RestrictingNodeTransformer
 
 from effectful.handlers.llm.encoding import Encodable, SynthesizedFunction
 from effectful.handlers.llm.evaluation import (
+    ReplSession,
     RestrictedEvalProvider,
+    UnsafeEvalProvider,
     collect_imports,
     collect_runtime_type_stubs,
     collect_variable_declarations,
     mypy_type_check,
     type_to_ast,
 )
+from effectful.handlers.llm.evaluation import exec as exec_op
 from effectful.internals.unification import nested_type
 from effectful.ops.semantics import handler
-from effectful.ops.syntax import defop
+from effectful.ops.syntax import ObjectInterpretation, defop, implements
 from effectful.ops.types import NotHandled
 
 
@@ -1537,3 +1540,151 @@ def test_builtins_in_env_does_not_bypass_security():
                 source_private, context=dangerous_ctx
             )
             fn("test")
+
+
+# ============================================================================
+# ReplSession (#678)
+# ============================================================================
+
+
+def test_repl_seeds_from_lexical_context():
+    """Names in the seed context are usable in executed code."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({"readings": [10, 20, 30]})
+        assert session.run("print(sum(readings))") == "60\n"
+
+
+def test_repl_persists_bindings_across_calls():
+    """A binding created in one call is visible in the next."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        session.run("total = 41")
+        assert session.run("print(total)") == "41\n"
+
+
+def test_repl_rebinds_across_calls():
+    """A seeded/prior name can be rebound using its prior value."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({"x": 10})
+        session.run("x = x + 1")
+        assert session.run("print(x)") == "11\n"
+
+
+def test_repl_runs_complete_multistatement_block():
+    """A complete `def` + call in one snippet runs in one shot (the case
+    `single`-mode compilation would reject)."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        out = session.run("def double(n):\n    return n * 2\nprint(double(21))")
+        assert out == "42\n"
+
+
+def test_repl_captures_print():
+    with handler(UnsafeEvalProvider()):
+        assert ReplSession({}).run("print('hi')") == "hi\n"
+
+
+def test_repl_syntax_error_is_a_transcript_not_a_raise():
+    """An incomplete snippet returns a transcript and leaves the session
+    usable."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        out = session.run("def f(:")
+        assert "SyntaxError" in out
+        assert session.run("print('ok')") == "ok\n"
+
+
+def test_repl_exception_is_isolated():
+    """A runtime exception returns a transcript; the session survives and
+    retains prior state."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        session.run("kept = 7")
+        out = session.run("print(1 / 0)")
+        assert "ZeroDivisionError" in out
+        assert session.run("print(kept)") == "7\n"
+
+
+def test_repl_keyboard_interrupt_propagates():
+    """`KeyboardInterrupt` is not swallowed into a transcript."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        with pytest.raises(KeyboardInterrupt):
+            session.run("raise KeyboardInterrupt")
+
+
+def test_repl_traceback_trims_effect_machinery_frames():
+    """The transcript for an uncaught exception shows only the user's snippet
+    frames, not effectful's internal frames."""
+    with handler(UnsafeEvalProvider()):
+        out = ReplSession({}).run("1 / 0")
+        assert "ZeroDivisionError" in out
+        assert "runtime.py" not in out
+        assert "ops/types.py" not in out
+        assert "exec_code-" in out  # the user frame's per-snippet filename
+
+
+def test_repl_cross_snippet_traceback_shows_correct_source():
+    """A function defined in an earlier call that raises in a later call
+    formats with its *own* source line, not the later call's source — the
+    per-snippet filename keeps each cell's source in linecache."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({})
+        session.run("def boom():\n    return 1 / 0")
+        out = session.run("boom()")
+        assert "return 1 / 0" in out  # boom's real source, not "boom()"
+
+
+def test_repl_reentrant_run_keeps_outer_transcript():
+    """A `run` whose code re-enters `run` on the same session still returns
+    the outer call's own output (per-call buffer, not a shared one)."""
+    with handler(UnsafeEvalProvider()):
+        session = ReplSession({"session": None})
+        session.locals["session"] = session  # let exec'd code call back in
+        out = session.run(
+            "print('outer-before')\nsession.run(\"print('inner')\")\nprint('outer-after')"
+        )
+        assert "outer-before" in out
+        assert "outer-after" in out
+        assert "inner" not in out  # inner output went to the inner call's buffer
+
+
+def test_repl_execution_routes_through_exec_op():
+    """With `exec` overridden to a no-op, nothing runs — proving execution
+    goes through the op, asserted via the observable (the binding is absent)."""
+
+    class _NoExec(ObjectInterpretation):
+        @implements(exec_op)
+        def _(self, bytecode, env) -> None:
+            pass
+
+    with handler(UnsafeEvalProvider()), handler(_NoExec()):
+        session = ReplSession({})
+        session.run("x = 1")
+    with handler(UnsafeEvalProvider()):
+        assert session.run("print('x' in dir())") == "False\n"
+
+
+# ----------------------------------------------------------------------------
+# ReplSession under RestrictedEvalProvider — blocked on #685 (rebind + print)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason="#685: RestrictedEvalProvider.exec drops rebindings of seeded names",
+    strict=True,
+)
+def test_repl_rebinds_across_calls_restricted():
+    with handler(RestrictedEvalProvider()):
+        session = ReplSession({"x": 10})
+        session.run("x = x + 1")
+        assert session.run("print(x)") == "11\n"
+
+
+@pytest.mark.xfail(
+    reason="#685: RestrictedEvalProvider does not wire RestrictedPython's _print_",
+    strict=True,
+)
+def test_repl_captures_print_restricted():
+    with handler(RestrictedEvalProvider()):
+        assert ReplSession({}).run("print('hi')") == "hi\n"

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -27,6 +27,7 @@ from pydantic.dataclasses import dataclass
 
 from effectful.handlers.llm import Agent, Template
 from effectful.handlers.llm.completions import (
+    CodeExecutionError,
     DecodedToolCall,
     LexicalReaders,
     LiteLLMProvider,
@@ -39,6 +40,7 @@ from effectful.handlers.llm.completions import (
     _get_history,
     call_assistant,
     call_tool,
+    collect_tools,
     completion,
 )
 from effectful.handlers.llm.encoding import Encodable
@@ -1591,6 +1593,41 @@ class TestCallToolWrapsExecutionError:
         result = call_tool(tc)
         assert result["role"] == "tool"
         assert result["tool_call_id"] == "call_ok"
+
+    def test_call_tool_wraps_exec_code_error_as_code_execution_error(self):
+        """An `exec_code` snippet error surfaces as `CodeExecutionError`, whose
+        feedback message is the trimmed transcript verbatim."""
+        env = collections.ChainMap({})
+        with handler(UnsafeEvalProvider()), handler(PythonRepl()):
+            exec_code = collect_tools(env)["exec_code"]
+            bound_args = inspect.signature(exec_code).bind("1 / 0")
+            tc = DecodedToolCall(exec_code, bound_args, "call_exec", "exec_code")
+            with pytest.raises(CodeExecutionError) as exc_info:
+                call_tool(tc)
+        err = exc_info.value
+        assert "ZeroDivisionError" in err.transcript
+        assert "exec_code-" in err.transcript  # trimmed to the user's own frame
+        msg = err.to_feedback_message(include_traceback=False)
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call_exec"
+        assert msg["content"] == err.transcript
+
+    def test_retry_handler_turns_exec_code_error_into_feedback(self):
+        """With `RetryLLMHandler` installed, an `exec_code` error is returned as
+        a tool feedback message carrying the transcript -- not raised."""
+        env = collections.ChainMap({})
+        with (
+            handler(RetryLLMHandler()),
+            handler(UnsafeEvalProvider()),
+            handler(PythonRepl()),
+        ):
+            exec_code = collect_tools(env)["exec_code"]
+            bound_args = inspect.signature(exec_code).bind("1 / 0")
+            tc = DecodedToolCall(exec_code, bound_args, "call_exec_fb", "exec_code")
+            msg = call_tool(tc)
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call_exec_fb"
+        assert "ZeroDivisionError" in msg["content"]
 
 
 class TestRetryHandlerCatchToolErrorsFiltering:

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -30,6 +30,7 @@ from effectful.handlers.llm.completions import (
     DecodedToolCall,
     LexicalReaders,
     LiteLLMProvider,
+    PythonRepl,
     ResultDecodingError,
     RetryLLMHandler,
     Tool,
@@ -2257,3 +2258,38 @@ class TestSyntheticReaderIntegration:
             tools = describe_hand_action.tools
             assert "Finger" in tools
             assert "Hand" in tools
+
+
+class TestPythonReplIntegration:
+    """The LLM can run code in a persistent session through `exec_code`."""
+
+    @requires_llm
+    def test_llm_computes_via_exec_code(self, request):
+        """A Template seeds a list in lexical scope and asks the LLM to
+        compute a derived statistic by running code.  The LLM uses the
+        `exec_code` tool (possibly across several rounds, with state
+        persisting) and returns the typed result."""
+        readings = [12, 19, 23, 31, 8, 27]
+
+        @Template.define
+        def outlier_count() -> int:
+            """Use the `exec_code` tool to compute how many values in the
+            `readings` list lie strictly more than one population standard
+            deviation from the mean.  `readings` is available in scope.
+            Return that count as an integer."""
+            raise NotImplementedError
+
+        with (
+            handler(ReplayLiteLLMProvider(request, model=EFFECTFUL_LLM_MODEL)),
+            handler(UnsafeEvalProvider()),
+            handler(LexicalReaders()),
+            handler(PythonRepl()),
+        ):
+            result = outlier_count()
+
+        import statistics
+
+        m = statistics.mean(readings)
+        s = statistics.pstdev(readings)
+        expected = sum(1 for r in readings if abs(r - m) > s)
+        assert result == expected

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -13,6 +13,7 @@ import re
 from collections.abc import Callable
 from enum import StrEnum
 from pathlib import Path
+from types import CodeType
 
 import litellm
 import pydantic
@@ -43,7 +44,7 @@ from effectful.handlers.llm.completions import (
     completion,
 )
 from effectful.handlers.llm.encoding import Encodable
-from effectful.handlers.llm.evaluation import EncodableCode, UnsafeEvalProvider
+from effectful.handlers.llm.evaluation import UnsafeEvalProvider
 from effectful.ops.semantics import fwd, handler
 from effectful.ops.syntax import ObjectInterpretation, implements
 from effectful.ops.types import NotHandled
@@ -1626,7 +1627,7 @@ class TestCallToolWrapsExecutionError:
 
         def body(exec_code):
             bound_args = inspect.signature(exec_code).bind(
-                EncodableCode.from_source("1 / 0")
+                pydantic.TypeAdapter(Encodable[CodeType]).validate_python("1 / 0")
             )
             tc = DecodedToolCall(exec_code, bound_args, "call_exec", "exec_code")
             return call_tool(tc)

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -27,7 +27,6 @@ from pydantic.dataclasses import dataclass
 
 from effectful.handlers.llm import Agent, Template
 from effectful.handlers.llm.completions import (
-    CodeExecutionError,
     DecodedToolCall,
     LexicalReaders,
     LiteLLMProvider,
@@ -44,7 +43,7 @@ from effectful.handlers.llm.completions import (
     completion,
 )
 from effectful.handlers.llm.encoding import Encodable
-from effectful.handlers.llm.evaluation import UnsafeEvalProvider
+from effectful.handlers.llm.evaluation import ReplExecutionError, UnsafeEvalProvider
 from effectful.ops.semantics import fwd, handler
 from effectful.ops.syntax import ObjectInterpretation, implements
 from effectful.ops.types import NotHandled
@@ -1556,6 +1555,32 @@ def type_error_tool(x: int) -> str:
     raise TypeError(f"bad type for {x}")
 
 
+def _drive_repl(body):
+    """Run ``body(exec_code)`` inside one `PythonRepl`-scoped Template call.
+
+    A tiny `Template.__apply__` handler stands in for the LLM loop, handing
+    `body` the call's `exec_code` tool so it runs against one REPL session (the
+    supported way to reach a session).  Install any outer handlers (e.g.
+    `RetryLLMHandler`) around the call.  Returns `body`'s result.
+    """
+    box = []
+
+    class _Loop(ObjectInterpretation):
+        @implements(Template.__apply__)
+        def _call(self, *_a, **_k):
+            box.append(body(collect_tools(collections.ChainMap({}))["exec_code"]))
+            return None
+
+    @Template.define
+    def _t() -> None:
+        """Drive one REPL-scoped call."""
+        raise NotImplementedError
+
+    with handler(_Loop()), handler(UnsafeEvalProvider()), handler(PythonRepl()):
+        _t()
+    return box[0]
+
+
 class TestCallToolWrapsExecutionError:
     """call_tool should wrap runtime tool errors in ToolCallExecutionError."""
 
@@ -1594,40 +1619,41 @@ class TestCallToolWrapsExecutionError:
         assert result["role"] == "tool"
         assert result["tool_call_id"] == "call_ok"
 
-    def test_call_tool_wraps_exec_code_error_as_code_execution_error(self):
-        """An `exec_code` snippet error surfaces as `CodeExecutionError`, whose
-        feedback message is the trimmed transcript verbatim."""
-        env = collections.ChainMap({})
-        with handler(UnsafeEvalProvider()), handler(PythonRepl()):
-            exec_code = collect_tools(env)["exec_code"]
+    def test_call_tool_wraps_exec_code_error(self):
+        """An `exec_code` snippet error surfaces as a `ToolCallExecutionError`
+        carrying the `ReplExecutionError` (and the real exception); its feedback
+        message renders the transcript."""
+
+        def body(exec_code):
             bound_args = inspect.signature(exec_code).bind("1 / 0")
             tc = DecodedToolCall(exec_code, bound_args, "call_exec", "exec_code")
-            with pytest.raises(CodeExecutionError) as exc_info:
-                call_tool(tc)
-        err = exc_info.value
-        assert isinstance(err.original_error, ZeroDivisionError)
-        assert "exec_code-" in err.transcript  # trimmed to the user's own frame
-        msg = err.to_feedback_message(include_traceback=False)
+            return call_tool(tc)
+
+        with pytest.raises(ToolCallExecutionError) as exc_info:
+            _drive_repl(body)
+        repl_error = exc_info.value.original_error
+        assert isinstance(repl_error, ReplExecutionError)
+        assert isinstance(repl_error.original_error, ZeroDivisionError)
+        msg = exc_info.value.to_feedback_message(include_traceback=False)
         assert msg["role"] == "tool"
         assert msg["tool_call_id"] == "call_exec"
-        assert msg["content"] == err.transcript
+        assert repl_error.transcript in msg["content"]  # transcript rendered in
 
     def test_retry_handler_turns_exec_code_error_into_feedback(self):
         """With `RetryLLMHandler` installed, an `exec_code` error is returned as
         a tool feedback message carrying the transcript -- not raised."""
-        env = collections.ChainMap({})
-        with (
-            handler(RetryLLMHandler()),
-            handler(UnsafeEvalProvider()),
-            handler(PythonRepl()),
-        ):
-            exec_code = collect_tools(env)["exec_code"]
+
+        def body(exec_code):
             bound_args = inspect.signature(exec_code).bind("1 / 0")
             tc = DecodedToolCall(exec_code, bound_args, "call_exec_fb", "exec_code")
-            msg = call_tool(tc)
+            return call_tool(tc)
+
+        with handler(RetryLLMHandler()):
+            msg = _drive_repl(body)
+        # Returned as a tool message instead of raising -- that *is* the
+        # "turned into feedback" behaviour (a raise would have failed above).
         assert msg["role"] == "tool"
         assert msg["tool_call_id"] == "call_exec_fb"
-        assert "ZeroDivisionError" in msg["content"]
 
 
 class TestRetryHandlerCatchToolErrorsFiltering:

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -43,7 +43,11 @@ from effectful.handlers.llm.completions import (
     completion,
 )
 from effectful.handlers.llm.encoding import Encodable
-from effectful.handlers.llm.evaluation import ReplExecutionError, UnsafeEvalProvider
+from effectful.handlers.llm.evaluation import (
+    EncodableCode,
+    ReplExecutionError,
+    UnsafeEvalProvider,
+)
 from effectful.ops.semantics import fwd, handler
 from effectful.ops.syntax import ObjectInterpretation, implements
 from effectful.ops.types import NotHandled
@@ -1625,7 +1629,9 @@ class TestCallToolWrapsExecutionError:
         message renders the transcript."""
 
         def body(exec_code):
-            bound_args = inspect.signature(exec_code).bind("1 / 0")
+            bound_args = inspect.signature(exec_code).bind(
+                EncodableCode.from_source("1 / 0")
+            )
             tc = DecodedToolCall(exec_code, bound_args, "call_exec", "exec_code")
             return call_tool(tc)
 
@@ -1644,7 +1650,9 @@ class TestCallToolWrapsExecutionError:
         a tool feedback message carrying the transcript -- not raised."""
 
         def body(exec_code):
-            bound_args = inspect.signature(exec_code).bind("1 / 0")
+            bound_args = inspect.signature(exec_code).bind(
+                EncodableCode.from_source("1 / 0")
+            )
             tc = DecodedToolCall(exec_code, bound_args, "call_exec_fb", "exec_code")
             return call_tool(tc)
 

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -1605,7 +1605,7 @@ class TestCallToolWrapsExecutionError:
             with pytest.raises(CodeExecutionError) as exc_info:
                 call_tool(tc)
         err = exc_info.value
-        assert "ZeroDivisionError" in err.transcript
+        assert isinstance(err.original_error, ZeroDivisionError)
         assert "exec_code-" in err.transcript  # trimmed to the user's own frame
         msg = err.to_feedback_message(include_traceback=False)
         assert msg["role"] == "tool"

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -43,11 +43,7 @@ from effectful.handlers.llm.completions import (
     completion,
 )
 from effectful.handlers.llm.encoding import Encodable
-from effectful.handlers.llm.evaluation import (
-    EncodableCode,
-    ReplExecutionError,
-    UnsafeEvalProvider,
-)
+from effectful.handlers.llm.evaluation import EncodableCode, UnsafeEvalProvider
 from effectful.ops.semantics import fwd, handler
 from effectful.ops.syntax import ObjectInterpretation, implements
 from effectful.ops.types import NotHandled
@@ -1623,10 +1619,10 @@ class TestCallToolWrapsExecutionError:
         assert result["role"] == "tool"
         assert result["tool_call_id"] == "call_ok"
 
-    def test_call_tool_wraps_exec_code_error(self):
-        """An `exec_code` snippet error surfaces as a `ToolCallExecutionError`
-        carrying the `ReplExecutionError` (and the real exception); its feedback
-        message renders the transcript."""
+    def test_call_tool_returns_exec_code_error_in_output(self):
+        """An `exec_code` runtime error is reported in the returned tool message's
+        content (the traceback), not raised as a `ToolCallExecutionError`, so the
+        assistant loop continues with it as feedback."""
 
         def body(exec_code):
             bound_args = inspect.signature(exec_code).bind(
@@ -1635,33 +1631,10 @@ class TestCallToolWrapsExecutionError:
             tc = DecodedToolCall(exec_code, bound_args, "call_exec", "exec_code")
             return call_tool(tc)
 
-        with pytest.raises(ToolCallExecutionError) as exc_info:
-            _drive_repl(body)
-        repl_error = exc_info.value.original_error
-        assert isinstance(repl_error, ReplExecutionError)
-        assert isinstance(repl_error.original_error, ZeroDivisionError)
-        msg = exc_info.value.to_feedback_message(include_traceback=False)
+        msg = _drive_repl(body)
         assert msg["role"] == "tool"
         assert msg["tool_call_id"] == "call_exec"
-        assert repl_error.transcript in msg["content"]  # transcript rendered in
-
-    def test_retry_handler_turns_exec_code_error_into_feedback(self):
-        """With `RetryLLMHandler` installed, an `exec_code` error is returned as
-        a tool feedback message carrying the transcript -- not raised."""
-
-        def body(exec_code):
-            bound_args = inspect.signature(exec_code).bind(
-                EncodableCode.from_source("1 / 0")
-            )
-            tc = DecodedToolCall(exec_code, bound_args, "call_exec_fb", "exec_code")
-            return call_tool(tc)
-
-        with handler(RetryLLMHandler()):
-            msg = _drive_repl(body)
-        # Returned as a tool message instead of raising -- that *is* the
-        # "turned into feedback" behaviour (a raise would have failed above).
-        assert msg["role"] == "tool"
-        assert msg["tool_call_id"] == "call_exec_fb"
+        assert "ZeroDivisionError" in str(msg["content"])
 
 
 class TestRetryHandlerCatchToolErrorsFiltering:

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -1765,81 +1765,67 @@ def test_python_repl_composes_with_lexical_readers():
     assert "data" in result
 
 
-def test_python_repl_session_created_lazily():
-    """Introspecting tools allocates no session; the first `exec_code` call
-    does.  Asserted behaviorally: a name bound into `env` *after* tool
-    collection but before the first call is still visible in the session
-    (the seed snapshot happens at first use, not at collect time)."""
-    env = collections.ChainMap({})  # the driver always passes a ChainMap
-    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
-        tools = collect_tools(env)
-        env["late"] = 99  # bound after collection, before first exec_code
-        assert tools["exec_code"]("print(late)") == "99\n"
+def _drive_repl(body):
+    """Run ``body(exec_code)`` inside one `PythonRepl`-scoped Template call.
+
+    A tiny `Template.__apply__` handler stands in for the LLM loop: it collects
+    the tools for a single call and hands `body` that call's `exec_code` tool, so
+    `body` sees exactly one REPL session for its duration.  This is the supported
+    way to reach a session -- `PythonRepl` introduces it per call, mirroring
+    `__history__`.  Returns `body`'s result.
+    """
+    box = []
+
+    class _Loop(ObjectInterpretation):
+        @implements(Template.__apply__)
+        def _call(self, *_a, **_k):
+            box.append(body(collect_tools(collections.ChainMap({}))["exec_code"]))
+            return None
+
+    @Template.define
+    def _t() -> None:
+        """Drive one REPL-scoped call."""
+        raise NotImplementedError
+
+    with handler(_Loop()), handler(UnsafeEvalProvider()), handler(PythonRepl()):
+        _t()
+    return box[0]
 
 
-def test_python_repl_same_session_across_collect_calls():
-    """Two `collect_tools` calls with the same `env` back `exec_code` with the
-    same session — state from the first call is visible in the second."""
-    env = collections.ChainMap({})
-    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
-        collect_tools(env)["exec_code"]("kept = 5")
-        assert collect_tools(env)["exec_code"]("print(kept)") == "5\n"
+def test_python_repl_state_persists_within_one_call():
+    """Within one Template call, `exec_code` state carries across calls: a
+    binding made in one snippet is visible in the next."""
+
+    def body(exec_code):
+        exec_code("kept = 5")
+        return exec_code("print(kept)")
+
+    assert _drive_repl(body) == "5\n"
 
 
-def test_python_repl_distinct_env_distinct_session():
-    """Different `env` objects get isolated sessions."""
-    env_a = collections.ChainMap({})
-    env_b = collections.ChainMap({})
-    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
-        collect_tools(env_a)["exec_code"]("only_in_a = 1")
-        out = collect_tools(env_b)["exec_code"]("print('only_in_a' in dir())")
-    assert out == "False\n"
+def test_python_repl_distinct_calls_get_isolated_sessions():
+    """Each Template call gets its own session: a binding made in one call is
+    not visible in a separate call."""
+    _drive_repl(lambda exec_code: exec_code("leaked = 1"))
+    assert (
+        _drive_repl(lambda exec_code: exec_code("print('leaked' in dir())"))
+        == "False\n"
+    )
 
 
-def test_python_repl_new_binding_is_local_to_the_body():
-    """`foo`/`bar` lexical scoping: code reads the shared lexical context (and
-    the Template's args), but a new binding it creates is local to the body --
-    invisible to the shared scope and to a sibling `foo`."""
-    shared = {"foo_value": 10}  # a name in the scope shared by foo and bar
-    env_bar = collections.ChainMap({"bar_arg": 5}, shared)  # bar: args over shared
-    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
-        # reads the shared context and bar's argument:
-        assert (
-            collect_tools(env_bar)["exec_code"](
-                "local = foo_value + bar_arg; print(local)"
-            )
-            == "15\n"
+def test_python_repl_nested_call_is_isolated_and_outer_survives():
+    """A nested Template call introduces its own session by construction: the
+    inner body cannot see the outer's bindings, and the outer session keeps its
+    state across the nested call."""
+
+    def outer(exec_code):
+        exec_code("outer_var = 1")
+        inner_sees_outer = _drive_repl(  # a fully nested Template call
+            lambda inner: inner("print('outer_var' in dir())")
         )
-        # the new binding did not leak into the shared scope or bar's env...
-        assert "local" not in shared
-        assert "local" not in env_bar
-        # ...and a sibling `foo` over the same shared scope cannot see it:
-        env_foo = collections.ChainMap({}, shared)
-        assert (
-            collect_tools(env_foo)["exec_code"]("print('local' in dir())") == "False\n"
-        )
+        outer_after = exec_code("print(outer_var, 'outer_var' in dir())")
+        return inner_sees_outer, outer_after
 
-
-def test_python_repl_nested_envs_isolate_and_outer_state_persists():
-    """A nested Template call gets a distinct `env`, hence an isolated session:
-    the inner body cannot see the outer's bindings, and the outer session keeps
-    its state across the nested call."""
-    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
-        env_outer = collections.ChainMap({})
-        env_inner = collections.ChainMap({})  # the nested call's fresh env
-
-        collect_tools(env_outer)["exec_code"]("outer_var = 1")
-        # the inner (distinct env) is isolated -- cannot see the outer binding:
-        assert (
-            collect_tools(env_inner)["exec_code"](
-                "inner_var = 2; print('outer_var' in dir())"
-            )
-            == "False\n"
-        )
-        # back in the outer: its state survived and it never saw the inner's:
-        assert (
-            collect_tools(env_outer)["exec_code"](
-                "print(outer_var, 'inner_var' in dir())"
-            )
-            == "1 False\n"
-        )
+    inner_sees_outer, outer_after = _drive_repl(outer)
+    assert inner_sees_outer == "False\n"  # the nested session is isolated
+    assert outer_after == "1 True\n"  # the outer session survived the nested call

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -1743,20 +1743,6 @@ def test_python_repl_exposes_exec_code():
         assert "exec_code" in collect_tools({"x": 1})
 
 
-def test_python_repl_real_tool_of_same_name_wins():
-    """A user `Tool` named `exec_code` in scope takes precedence over the
-    REPL tool (the `setdefault`)."""
-
-    @Tool.define
-    def exec_code() -> int:
-        """Doc."""
-        return 7
-
-    with handler(PythonRepl()):
-        result = collect_tools({"exec_code": exec_code})
-    assert result["exec_code"] is exec_code
-
-
 def test_python_repl_composes_with_lexical_readers():
     """Readers and the REPL tool coexist when both handlers are installed."""
     with handler(LexicalReaders()), handler(PythonRepl()):

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -1537,6 +1537,7 @@ def test_tool_forward_ref():
 import re
 import typing
 from pathlib import Path
+from types import CodeType
 
 import pydantic
 
@@ -1546,7 +1547,8 @@ from effectful.handlers.llm.completions import (
     _LexicalVariableTool,
     collect_tools,
 )
-from effectful.handlers.llm.evaluation import EncodableCode, UnsafeEvalProvider
+from effectful.handlers.llm.encoding import Encodable
+from effectful.handlers.llm.evaluation import UnsafeEvalProvider
 
 
 # Helpers for the test matrix
@@ -1766,9 +1768,10 @@ def _drive_repl(body):
         @implements(Template.__apply__)
         def _call(self, *_a, **_k):
             exec_code = collect_tools(collections.ChainMap({}))["exec_code"]
-            # Bodies pass source strings; wrap them in `EncodableCode` as the LLM
-            # tool boundary would (decoding compiles the source).
-            box.append(body(lambda src: exec_code(EncodableCode.from_source(src))))
+            # Bodies pass source strings; decode them to code objects as the LLM
+            # tool boundary would (`Encodable[CodeType]` compiles the source).
+            decode = pydantic.TypeAdapter(Encodable[CodeType]).validate_python
+            box.append(body(lambda src: exec_code(decode(src))))
             return None
 
     @Template.define

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -1542,9 +1542,11 @@ import pydantic
 
 from effectful.handlers.llm.completions import (
     LexicalReaders,
+    PythonRepl,
     _LexicalVariableTool,
     collect_tools,
 )
+from effectful.handlers.llm.evaluation import UnsafeEvalProvider
 
 
 # Helpers for the test matrix
@@ -1722,3 +1724,73 @@ def test_lexical_readers_handler_enables_collection():
         result = collect_tools(env)
     assert result["x"]() == 42
     assert result["s"]() == "hello"
+
+
+# ---------------------------------------------------------------------------
+# PythonRepl handler (#678)
+# ---------------------------------------------------------------------------
+
+
+def test_python_repl_off_by_default():
+    """Without `PythonRepl`, `exec_code` is not collected."""
+    assert "exec_code" not in collect_tools({"x": 1})
+
+
+def test_python_repl_exposes_exec_code():
+    """With `PythonRepl` installed, `exec_code` is collected alongside the
+    base tools."""
+    with handler(PythonRepl()):
+        assert "exec_code" in collect_tools({"x": 1})
+
+
+def test_python_repl_real_tool_of_same_name_wins():
+    """A user `Tool` named `exec_code` in scope takes precedence over the
+    REPL tool (the `setdefault`)."""
+
+    @Tool.define
+    def exec_code() -> int:
+        """Doc."""
+        return 7
+
+    with handler(PythonRepl()):
+        result = collect_tools({"exec_code": exec_code})
+    assert result["exec_code"] is exec_code
+
+
+def test_python_repl_composes_with_lexical_readers():
+    """Readers and the REPL tool coexist when both handlers are installed."""
+    with handler(LexicalReaders()), handler(PythonRepl()):
+        result = collect_tools({"data": [1, 2, 3]})
+    assert "exec_code" in result
+    assert "data" in result
+
+
+def test_python_repl_session_created_lazily():
+    """Introspecting tools allocates no session; the first `exec_code` call
+    does.  Asserted behaviorally: a name bound into `env` *after* tool
+    collection but before the first call is still visible in the session
+    (the seed snapshot happens at first use, not at collect time)."""
+    env = collections.ChainMap({})  # the driver always passes a ChainMap
+    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
+        tools = collect_tools(env)
+        env["late"] = 99  # bound after collection, before first exec_code
+        assert tools["exec_code"]("print(late)") == "99\n"
+
+
+def test_python_repl_same_session_across_collect_calls():
+    """Two `collect_tools` calls with the same `env` back `exec_code` with the
+    same session — state from the first call is visible in the second."""
+    env = collections.ChainMap({})
+    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
+        collect_tools(env)["exec_code"]("kept = 5")
+        assert collect_tools(env)["exec_code"]("print(kept)") == "5\n"
+
+
+def test_python_repl_distinct_env_distinct_session():
+    """Different `env` objects get isolated sessions."""
+    env_a = collections.ChainMap({})
+    env_b = collections.ChainMap({})
+    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
+        collect_tools(env_a)["exec_code"]("only_in_a = 1")
+        out = collect_tools(env_b)["exec_code"]("print('only_in_a' in dir())")
+    assert out == "False\n"

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -1546,7 +1546,7 @@ from effectful.handlers.llm.completions import (
     _LexicalVariableTool,
     collect_tools,
 )
-from effectful.handlers.llm.evaluation import UnsafeEvalProvider
+from effectful.handlers.llm.evaluation import EncodableCode, UnsafeEvalProvider
 
 
 # Helpers for the test matrix
@@ -1765,7 +1765,10 @@ def _drive_repl(body):
     class _Loop(ObjectInterpretation):
         @implements(Template.__apply__)
         def _call(self, *_a, **_k):
-            box.append(body(collect_tools(collections.ChainMap({}))["exec_code"]))
+            exec_code = collect_tools(collections.ChainMap({}))["exec_code"]
+            # Bodies pass source strings; wrap them in `EncodableCode` as the LLM
+            # tool boundary would (decoding compiles the source).
+            box.append(body(lambda src: exec_code(EncodableCode.from_source(src))))
             return None
 
     @Template.define

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -1794,3 +1794,52 @@ def test_python_repl_distinct_env_distinct_session():
         collect_tools(env_a)["exec_code"]("only_in_a = 1")
         out = collect_tools(env_b)["exec_code"]("print('only_in_a' in dir())")
     assert out == "False\n"
+
+
+def test_python_repl_new_binding_is_local_to_the_body():
+    """`foo`/`bar` lexical scoping: code reads the shared lexical context (and
+    the Template's args), but a new binding it creates is local to the body --
+    invisible to the shared scope and to a sibling `foo`."""
+    shared = {"foo_value": 10}  # a name in the scope shared by foo and bar
+    env_bar = collections.ChainMap({"bar_arg": 5}, shared)  # bar: args over shared
+    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
+        # reads the shared context and bar's argument:
+        assert (
+            collect_tools(env_bar)["exec_code"](
+                "local = foo_value + bar_arg; print(local)"
+            )
+            == "15\n"
+        )
+        # the new binding did not leak into the shared scope or bar's env...
+        assert "local" not in shared
+        assert "local" not in env_bar
+        # ...and a sibling `foo` over the same shared scope cannot see it:
+        env_foo = collections.ChainMap({}, shared)
+        assert (
+            collect_tools(env_foo)["exec_code"]("print('local' in dir())") == "False\n"
+        )
+
+
+def test_python_repl_nested_envs_isolate_and_outer_state_persists():
+    """A nested Template call gets a distinct `env`, hence an isolated session:
+    the inner body cannot see the outer's bindings, and the outer session keeps
+    its state across the nested call."""
+    with handler(UnsafeEvalProvider()), handler(PythonRepl()):
+        env_outer = collections.ChainMap({})
+        env_inner = collections.ChainMap({})  # the nested call's fresh env
+
+        collect_tools(env_outer)["exec_code"]("outer_var = 1")
+        # the inner (distinct env) is isolated -- cannot see the outer binding:
+        assert (
+            collect_tools(env_inner)["exec_code"](
+                "inner_var = 2; print('outer_var' in dir())"
+            )
+            == "False\n"
+        )
+        # back in the outer: its state survived and it never saw the inner's:
+        assert (
+            collect_tools(env_outer)["exec_code"](
+                "print(outer_var, 'inner_var' in dir())"
+            )
+            == "1 False\n"
+        )


### PR DESCRIPTION
Closes #678.

Adds a generic code-execution tool a Template's LLM can call to run Python before producing a final answer. Few desiderata:
(1) linked to the Template's lexical context
(2) persistent state across tool calls
(3) redirected output streams.

**Example.**

```python
from effectful.handlers.llm import Template, LiteLLMProvider
from effectful.handlers.llm.completions import PythonRepl
from effectful.handlers.llm.evaluation import UnsafeEvalProvider
from effectful.ops.semantics import handler
from effectful.ops.types import NotHandled

readings = [12, 19, 23, 31, 8, 27]

@Template.define
def outlier_count() -> int:
    """Use the `exec_code` tool to compute how many values in `readings`
    lie more than one population stdev from the mean; return that count."""
    raise NotHandled

with handler(LiteLLMProvider()), handler(UnsafeEvalProvider()), handler(PythonRepl()):
    n = outlier_count()
```

The LLM runs code across rounds with state persisting:

```
exec_code("m = ...; s = ...")   ->  ""        # readings came from lexical scope
exec_code("print(...using m, s...)")  ->  "2\n"   # m, s persisted from the prior call
```

**`ReplSession`** (evaluation.py): a plain class seeded from a lexical context. Each `run(source)` executes one complete snippet in exec mode through the `parse`/`compile`/`exec` effect operations (so the installed eval-provider owns sandboxing), captures stdout/stderr into a per-call buffer, and persists bindings in `self.locals` across calls. Per-snippet filenames keep each cell's source in `linecache` so cross-snippet tracebacks format correctly; the traceback formatter trims the effect-machinery frames so the LLM sees only its own code.

**`PythonRepl`** (completions.py): a `collect_tools` handler exposing an `exec_code` Tool bound to a session that persists for the Template invocation. Off by default. Sessions are keyed by `id(env)` and pruned via `weakref.finalize` (no leak, no id-reuse), created lazily on first use.

The `exec` op docstring now states its binding-effects contract: after `exec(bytecode, env)`, `env` reflects all top-level bindings — new and rebound alike.

**Fenced to `UnsafeEvalProvider` (#685).** `RestrictedEvalProvider` drops rebindings of seeded names and lacks RestrictedPython's print wiring. The two restricted REPL tests are `xfail(strict)` against #685 and flip to xpass when it lands.

**Tests.** 12 `ReplSession` laws and 7 `PythonRepl` handler tests, deterministic under `UnsafeEvalProvider` (seed, persistence, rebind, multi-statement, print, syntax-error, exception isolation, KeyboardInterrupt-propagation, traceback trim, cross-snippet traceback, reentrancy, effect-routing; off-by-default, exposes-tool, name-collision, composes-with-LexicalReaders, lazy creation, same-session-across-rounds, distinct-env). Plus one replayed gpt-4o-mini integration test where the model genuinely uses `exec_code` across rounds to compute a statistic.

Decoupled from `LexicalReaders` by default; coupling REPL-created symbols into the readers is noted as a follow-up.