### PR TITLE
Replace runtime-type quotation with splice-into-source typechecking

### DIFF
--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -30,7 +30,7 @@ from effectful.handlers.llm.encoding import (
     Encodable,
     to_content_blocks,
 )
-from effectful.handlers.llm.evaluation import ReplSession
+from effectful.handlers.llm.evaluation import ReplSession, type_check_anchor
 from effectful.handlers.llm.template import (
     Agent,
     Template,
@@ -430,15 +430,18 @@ def call_assistant[T](
     encoding: pydantic.TypeAdapter[DecodedToolCall] = pydantic.TypeAdapter(
         Encodable[DecodedToolCall]
     )
-    for raw_tool_call in message.get("tool_calls") or []:
-        try:
-            tool_calls += [encoding.validate_python(raw_tool_call, context=tools)]
-        except Exception as e:
-            raise ToolCallDecodingError(
-                raw_tool_call=raw_tool_call,
-                original_error=e,
-                raw_message=raw_message,
-            ) from e
+    # Tool-argument Callables have no source anchor (out of scope for the splice
+    # type check), so suppress the anchor while decoding them.
+    with handler({type_check_anchor: lambda: None}):
+        for raw_tool_call in message.get("tool_calls") or []:
+            try:
+                tool_calls += [encoding.validate_python(raw_tool_call, context=tools)]
+            except Exception as e:
+                raise ToolCallDecodingError(
+                    raw_tool_call=raw_tool_call,
+                    original_error=e,
+                    raw_message=raw_message,
+                ) from e
 
     result = None
     if not tool_calls:
@@ -672,7 +675,15 @@ class LiteLLMProvider(ObjectInterpretation):
         )  # type: ignore
         history_copy = history.copy()
 
-        with handler({_get_history: lambda: history_copy}):
+        # Bind the type-check anchor to this Template's underlying function for the
+        # duration of the call. Handler scope (not data context) means nested or
+        # recursive synthesis sees the right anchor -- innermost wins.
+        with handler(
+            {
+                _get_history: lambda: history_copy,
+                type_check_anchor: lambda: template.__default__,
+            }
+        ):
             if (
                 not _get_history()
                 or next(iter(_get_history().values()))["role"] != "system"

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -430,8 +430,11 @@ def call_assistant[T](
     encoding: pydantic.TypeAdapter[DecodedToolCall] = pydantic.TypeAdapter(
         Encodable[DecodedToolCall]
     )
-    # Tool-argument Callables have no source anchor (out of scope for the splice
-    # type check), so suppress the anchor while decoding them.
+    # A synthesized tool-argument Callable's contract is the tool parameter's
+    # type, not the enclosing Template's return type -- so the Template anchor
+    # (bound by __apply__) is the wrong splice target for it, and it has no def of
+    # its own to splice into. Suppress the anchor to skip the check while decoding
+    # tool arguments, rather than check them against the wrong type.
     with handler({type_check_anchor: lambda: None}):
         for raw_tool_call in message.get("tool_calls") or []:
             try:

--- a/effectful/handlers/llm/completions.py
+++ b/effectful/handlers/llm/completions.py
@@ -26,11 +26,12 @@ from litellm import (
 )
 
 from effectful.handlers.llm.encoding import (
+    TYPE_CHECK_ANCHOR_KEY,
     DecodedToolCall,
     Encodable,
     to_content_blocks,
 )
-from effectful.handlers.llm.evaluation import ReplSession, type_check_anchor
+from effectful.handlers.llm.evaluation import ReplSession
 from effectful.handlers.llm.template import (
     Agent,
     Template,
@@ -392,6 +393,7 @@ def call_assistant[T](
         ResultDecodingError: If the result cannot be decoded. The error
             includes the raw assistant message for retry handling.
     """
+    anchor = kwargs.pop("anchor", None)  # ride in kwargs; pop before the LLM call
     tools = dict(collect_tools(env))
     tool_specs = {
         k: typing.cast(
@@ -430,21 +432,19 @@ def call_assistant[T](
     encoding: pydantic.TypeAdapter[DecodedToolCall] = pydantic.TypeAdapter(
         Encodable[DecodedToolCall]
     )
-    # A synthesized tool-argument Callable's contract is the tool parameter's
-    # type, not the enclosing Template's return type -- so the Template anchor
-    # (bound by __apply__) is the wrong splice target for it, and it has no def of
-    # its own to splice into. Suppress the anchor to skip the check while decoding
-    # tool arguments, rather than check them against the wrong type.
-    with handler({type_check_anchor: lambda: None}):
-        for raw_tool_call in message.get("tool_calls") or []:
-            try:
-                tool_calls += [encoding.validate_python(raw_tool_call, context=tools)]
-            except Exception as e:
-                raise ToolCallDecodingError(
-                    raw_tool_call=raw_tool_call,
-                    original_error=e,
-                    raw_message=raw_message,
-                ) from e
+    # Tool arguments decode with `context=tools` (no anchor key), so a synthesized
+    # tool-argument Callable gets no type-check anchor -- correctly: its contract
+    # is the tool parameter's type, not the enclosing Template's return type, so
+    # the Template anchor would be the wrong splice target.
+    for raw_tool_call in message.get("tool_calls") or []:
+        try:
+            tool_calls += [encoding.validate_python(raw_tool_call, context=tools)]
+        except Exception as e:
+            raise ToolCallDecodingError(
+                raw_tool_call=raw_tool_call,
+                original_error=e,
+                raw_message=raw_message,
+            ) from e
 
     result = None
     if not tool_calls:
@@ -457,8 +457,12 @@ def call_assistant[T](
             result = typing.cast(T, serialized_result)
         else:
             try:
+                # Add the type-check anchor to the decode context only (not `env`,
+                # which is exposed as tools), so a synthesized result is checked
+                # against the Template's source.
                 result = response_format.model_validate(
-                    json.loads(serialized_result), context=env
+                    json.loads(serialized_result),
+                    context={**env, TYPE_CHECK_ANCHOR_KEY: anchor},
                 ).value
             except Exception as e:
                 raise ResultDecodingError(e, raw_message=raw_message) from e
@@ -678,15 +682,7 @@ class LiteLLMProvider(ObjectInterpretation):
         )  # type: ignore
         history_copy = history.copy()
 
-        # Bind the type-check anchor to this Template's underlying function for the
-        # duration of the call. Handler scope (not data context) means nested or
-        # recursive synthesis sees the right anchor -- innermost wins.
-        with handler(
-            {
-                _get_history: lambda: history_copy,
-                type_check_anchor: lambda: template.__default__,
-            }
-        ):
+        with handler({_get_history: lambda: history_copy}):
             if (
                 not _get_history()
                 or next(iter(_get_history().values()))["role"] != "system"
@@ -700,7 +696,10 @@ class LiteLLMProvider(ObjectInterpretation):
             result: T | None = None
             while message["role"] != "assistant" or tool_calls:
                 message, tool_calls, result = call_assistant(
-                    env, template.__signature__.return_annotation, **self.config
+                    env,
+                    template.__signature__.return_annotation,
+                    anchor=template.__default__,
+                    **self.config,
                 )
                 for tool_call in tool_calls:
                     message = call_tool(tool_call)

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -39,6 +39,14 @@ from effectful.ops.types import Operation, Term
 
 type ToolCallID = str
 
+# Reserved key under which the type-check anchor (the enclosing Template's
+# underlying function) rides in the Pydantic decoding context, alongside the
+# lexical environment. `decode` reads it to type-check a synthesized function
+# against the Template's source; absent (tool-argument decoding) means skip.
+# Deliberately not a valid identifier so `LexicalReaders` skips it (no tool leak)
+# and it can never collide with a lexical name.
+TYPE_CHECK_ANCHOR_KEY = "<type_check_anchor>"
+
 CONTENT_BLOCK_TYPES: frozenset[str] = frozenset(
     literal
     for member in typing.get_args(OpenAIMessageContentListBlock)
@@ -552,19 +560,19 @@ def _pydantic_callable(callable_type: Any) -> Any:
 
         _validate_signature_ast(last_stmt, expected_params)
 
-        # `type_check_anchor` is the Template's underlying function (bound per call
-        # by Template.__apply__); None for tool-argument decoding, whose synthesized
-        # Callables are contracted by the tool param's type, not the Template's
-        # return type, so the Template anchor doesn't apply. When present, the code
-        # is spliced into the Template body, so first reject constructs illegal once
-        # nested (star / `__future__` imports), then type-check.
-        anchor = evaluation.type_check_anchor()
+        # The anchor (Template's underlying function) rides in the decoding context
+        # under TYPE_CHECK_ANCHOR_KEY; absent for tool-argument decoding, whose
+        # synthesized Callables are contracted by the tool param's type, not the
+        # Template's return type, so the Template anchor doesn't apply. When
+        # present, the code is spliced into the Template body, so first reject
+        # constructs illegal once nested (star / `__future__` imports), then check.
+        anchor = ctx.get(TYPE_CHECK_ANCHOR_KEY)
         if anchor is not None:
             evaluation.scan_non_nestable(module)
             evaluation.type_check(module, anchor)
 
         g: MutableMapping[str, Any] = {}
-        g.update(ctx)
+        g.update({k: v for k, v in ctx.items() if k != TYPE_CHECK_ANCHOR_KEY})
         bytecode: types.CodeType = evaluation.compile(module, filename)
         evaluation.exec(bytecode, g)
 

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -569,10 +569,18 @@ def _pydantic_callable(callable_type: Any) -> Any:
         anchor = ctx.get(TYPE_CHECK_ANCHOR_KEY)
         if anchor is not None:
             evaluation.scan_non_nestable(module)
-            evaluation.type_check(module, anchor)
+            spliced = evaluation.splice_into_source(module, anchor)
+            if spliced is not None:
+                evaluation.type_check(*spliced)
 
         g: MutableMapping[str, Any] = {}
-        g.update({k: v for k, v in ctx.items() if k != TYPE_CHECK_ANCHOR_KEY})
+        g.update(
+            {
+                k: v
+                for k, v in ctx.items()
+                if k.isidentifier() and k != TYPE_CHECK_ANCHOR_KEY
+            }
+        )
         bytecode: types.CodeType = evaluation.compile(module, filename)
         evaluation.exec(bytecode, g)
 

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -551,7 +551,13 @@ def _pydantic_callable(callable_type: Any) -> Any:
             )
 
         _validate_signature_ast(last_stmt, expected_params)
-        evaluation.type_check(module, ctx, expected_params, expected_return)
+
+        # `type_check_anchor` is the Template's underlying function, bound per call
+        # by Template.__apply__; it is None for tool-argument decoding, which
+        # therefore skips the source-anchored type check.
+        anchor = evaluation.type_check_anchor()
+        if anchor is not None:
+            evaluation.type_check(module, anchor)
 
         g: MutableMapping[str, Any] = {}
         g.update(ctx)

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -552,11 +552,14 @@ def _pydantic_callable(callable_type: Any) -> Any:
 
         _validate_signature_ast(last_stmt, expected_params)
 
-        # `type_check_anchor` is the Template's underlying function, bound per call
-        # by Template.__apply__; it is None for tool-argument decoding, which
-        # therefore skips the source-anchored type check.
+        # `type_check_anchor` is the Template's underlying function (bound per call
+        # by Template.__apply__); None for tool-argument decoding, which has no source
+        # anchor and so skips the splice type check. When present, the code is spliced
+        # into the Template body, so first reject constructs illegal once nested (star
+        # / `__future__` imports), then type-check.
         anchor = evaluation.type_check_anchor()
         if anchor is not None:
+            evaluation.scan_non_nestable(module)
             evaluation.type_check(module, anchor)
 
         g: MutableMapping[str, Any] = {}

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -553,10 +553,11 @@ def _pydantic_callable(callable_type: Any) -> Any:
         _validate_signature_ast(last_stmt, expected_params)
 
         # `type_check_anchor` is the Template's underlying function (bound per call
-        # by Template.__apply__); None for tool-argument decoding, which has no source
-        # anchor and so skips the splice type check. When present, the code is spliced
-        # into the Template body, so first reject constructs illegal once nested (star
-        # / `__future__` imports), then type-check.
+        # by Template.__apply__); None for tool-argument decoding, whose synthesized
+        # Callables are contracted by the tool param's type, not the Template's
+        # return type, so the Template anchor doesn't apply. When present, the code
+        # is spliced into the Template body, so first reject constructs illegal once
+        # nested (star / `__future__` imports), then type-check.
         anchor = evaluation.type_check_anchor()
         if anchor is not None:
             evaluation.scan_non_nestable(module)

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -145,11 +145,17 @@ def _unwrap(fn: Any) -> Any:
 def _recover_module_source(fn: Any) -> str | None:
     """Recover the full source of the module that lexically contains ``fn``.
 
-    Reads the real file when one exists, else the ``linecache``-registered source
-    (REPL/``exec``-defined templates, e.g. ``<synthesis:...>`` filenames). Returns
-    ``None`` when neither is available, so the caller can skip rather than guess.
-    ``inspect.getsourcefile`` and ``os.path.isfile`` are both given the *unwrapped*
-    function.
+    Resolves from the *function's own* filename: ``inspect.getsourcefile`` finds it
+    -- a real path, or a ``linecache``-registered synthetic name such as
+    ``<synthesis:...>`` for REPL/``exec``/notebook-defined templates -- and
+    ``linecache.getlines`` returns its lines, reading a real file from disk when it
+    isn't already cached (exactly as ``inspect`` does). Returns ``None`` when no
+    source is available, so the caller can skip rather than guess.
+
+    Resolving from the function rather than ``inspect.getsource(inspect.getmodule(
+    fn))`` is what makes the REPL/notebook cases work: those functions have no
+    resolvable module object (or no module-level source file), but their
+    ``co_filename`` is a valid linecache key.
     """
     try:
         filename = inspect.getsourcefile(fn)
@@ -157,12 +163,6 @@ def _recover_module_source(fn: Any) -> str | None:
         return None
     if not filename:
         return None
-    if os.path.isfile(filename):
-        try:
-            with open(filename, encoding="utf-8") as f:
-                return f.read()
-        except OSError:
-            return None
     lines = linecache.getlines(filename)
     return "".join(lines) if lines else None
 

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -48,16 +48,18 @@ def parse(source: str, filename: str) -> ast.Module:
 
 
 @defop
-def type_check(generated: ast.Module, anchor: Any) -> None:
+def type_check(source: str, lo: int | None = None, hi: int | None = None) -> None:
     """
-    Type check generated code against the lexical context of a Template.
+    Type check a module source, reporting only diagnostics inside a line region.
 
-    generated: The parsed module of LLM-generated code; its last top-level
-        function definition is the synthesized target, preceded by any helpers.
-    anchor: The Template's underlying function, whose module source supplies the
-        lexical context the generated code is checked against.
+    source: A complete module source to check (e.g. produced by
+        ``splice_into_source``, which splices generated code into a Template's real
+        module source).
+    lo, hi: Inclusive line range within ``source`` to report errors from; when
+        omitted, the whole source is in scope. Errors outside the region are
+        ignored so unrelated pre-existing code never blocks synthesis.
 
-    Returns None, raises TypeError on an in-region typechecking failure.
+    Returns None, raises TypeError on an in-region failure.
     """
     raise NotImplementedError(
         "An eval provider must be installed in order to type check code."
@@ -154,9 +156,12 @@ def _find_def_at_lineno(
     return None
 
 
-def _region_errors(stdout: str, lo: int, hi: int) -> list[dict[str, Any]]:
+def _region_errors(
+    stdout: str, lo: int | None, hi: int | None
+) -> list[dict[str, Any]]:
     """mypy ``--output=json`` diagnostics of severity ``error`` whose reported
-    line falls within ``[lo, hi]`` -- the spliced region.
+    line falls within ``[lo, hi]`` -- the spliced region. An open bound (``None``)
+    is unbounded on that side, so ``lo=hi=None`` reports every error.
 
     ``--output=json`` emits one JSON object per diagnostic carrying mypy's own
     ``severity`` and ``line`` fields, so we filter on those directly rather than
@@ -169,12 +174,14 @@ def _region_errors(stdout: str, lo: int, hi: int) -> list[dict[str, Any]]:
         if not line.strip():
             continue
         diag = json.loads(line)
-        if diag["severity"] == "error" and lo <= diag["line"] <= hi:
+        if diag["severity"] != "error":
+            continue
+        if (lo is None or lo <= diag["line"]) and (hi is None or diag["line"] <= hi):
             errors.append(diag)
     return errors
 
 
-def _splice_into_source(
+def splice_into_source(
     generated: ast.Module, anchor: Any
 ) -> tuple[str, int, int] | None:
     """Splice `generated` into the anchor Template's own function body, in its real
@@ -256,13 +263,15 @@ def _splice_into_source(
     return checked_source, lo, hi
 
 
-def _mypy_check_region(source: str, lo: int, hi: int) -> None:
+def _mypy_check_region(
+    source: str, lo: int | None = None, hi: int | None = None
+) -> None:
     """Run mypy on `source` and raise ``TypeError`` if any error diagnostic falls
     within ``[lo, hi]``; raise ``RuntimeError`` if mypy itself fails to run.
 
     Applies mypy to whatever source it's given -- spliced or otherwise -- and
-    reports only the region's errors, so pre-existing errors elsewhere in `source`
-    never block synthesis.
+    reports only the region's errors (the whole source when the region is
+    omitted), so pre-existing errors elsewhere in `source` never block synthesis.
     """
     # Run mypy on the source as a temp file (not --command: it hits an argv
     # length limit on large modules). Each call gets an isolated temp dir + cache
@@ -294,29 +303,9 @@ def _mypy_check_region(source: str, lo: int, hi: int) -> None:
         )
     errors = _region_errors(stdout or "", lo, hi)
     if errors:
-        report = "\n".join(
-            f"{e['line']}: {e['message']}  [{e['code']}]" for e in errors
-        )
-        raise TypeError("mypy type check failed:\n" + report + "\n\n" + source)
-
-
-def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
-    """Type-check LLM-generated code by splicing it into the real module source.
-
-    Splices `generated` into the ``anchor`` Template's own function body (in its
-    real module source, via `_splice_into_source`) and checks that spliced source
-    with mypy (via `_mypy_check_region`), so the generated code is checked in its
-    real lexical scope with no synthesized type stubs. Only diagnostics inside the
-    spliced region are raised, so pre-existing errors elsewhere never block
-    synthesis. Skips (logged) when the anchor's source can't be recovered; raises
-    ``TypeError`` on an in-region failure and ``RuntimeError`` if mypy itself fails
-    to run.
-    """
-    spliced = _splice_into_source(generated, anchor)
-    if spliced is None:
-        return None
-    _mypy_check_region(*spliced)
-    return None
+        # Not the source: it's large and the model already has the generated code.
+        report = "\n".join(json.dumps(e) for e in errors)
+        raise TypeError("mypy type check failed:\n" + report)
 
 
 # Eval Providers
@@ -327,8 +316,10 @@ class UnsafeEvalProvider(ObjectInterpretation):
     by shelling out to python *without* any further checks. Only use for testing."""
 
     @implements(type_check)
-    def type_check(self, generated: ast.Module, anchor: Any) -> None:
-        mypy_type_check(generated, anchor)
+    def type_check(
+        self, source: str, lo: int | None = None, hi: int | None = None
+    ) -> None:
+        _mypy_check_region(source, lo, hi)
 
     @implements(parse)
     def parse(self, source: str, filename: str) -> ast.Module:
@@ -391,8 +382,10 @@ class RestrictedEvalProvider(ObjectInterpretation):
         self.policy = policy
 
     @implements(type_check)
-    def type_check(self, generated: ast.Module, anchor: Any) -> None:
-        mypy_type_check(generated, anchor)
+    def type_check(
+        self, source: str, lo: int | None = None, hi: int | None = None
+    ) -> None:
+        _mypy_check_region(source, lo, hi)
 
     @implements(parse)
     def parse(self, source: str, filename: str) -> ast.Module:

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -6,10 +6,10 @@ import collections.abc
 import contextlib
 import inspect
 import io
+import json
 import linecache
 import logging
 import os
-import re
 import shutil
 import sys
 import tempfile
@@ -198,18 +198,24 @@ def _find_def_at_lineno(
     return None
 
 
-# mypy diagnostics under --no-pretty: ``file:line: error: ...`` or ``file:line:col: ...``.
-_MYPY_LINE_RE = re.compile(r"^.+?:(\d+):(?:\d+:)?\s+(?:error|note):")
+def _region_errors(stdout: str, lo: int, hi: int) -> list[dict[str, Any]]:
+    """mypy ``--output=json`` diagnostics of severity ``error`` whose reported
+    line falls within ``[lo, hi]`` -- the spliced region.
 
-
-def _region_diagnostics(report: str, lo: int, hi: int) -> list[str]:
-    """Diagnostic lines whose reported line number falls within ``[lo, hi]``."""
-    region: list[str] = []
-    for line in report.splitlines():
-        m = _MYPY_LINE_RE.match(line)
-        if m and lo <= int(m.group(1)) <= hi:
-            region.append(line)
-    return region
+    ``--output=json`` emits one JSON object per diagnostic carrying mypy's own
+    ``severity`` and ``line`` fields, so we filter on those directly rather than
+    parsing (and risking mis-parsing) its human-readable format.  Only reached
+    for exit status < 2; a fatal status emits text, not JSON, and is handled by
+    the caller before this runs.
+    """
+    errors: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        diag = json.loads(line)
+        if diag["severity"] == "error" and lo <= diag["line"] <= hi:
+            errors.append(diag)
+    return errors
 
 
 def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
@@ -293,23 +299,26 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
                 "--cache-dir",
                 os.path.join(tmpdir, "cache"),
                 "--no-error-summary",
-                "--no-pretty",
+                "--output=json",
                 "--ignore-missing-imports",
                 "--disable-error-code=import-untyped",
             ]
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
-    report = (stdout or "") + (stderr or "")
-    region = _region_diagnostics(report, lo, hi)
-    if any(" error:" in line for line in region):
-        raise TypeError(
-            "mypy type check failed:\n" + "\n".join(region) + "\n\n" + checked_source
-        )
     if status >= 2:
-        # Exit code >= 2 means mypy itself failed (fatal/usage/internal error),
-        # not that it found type errors -- surface it rather than silently pass.
-        raise TypeError(f"mypy could not check the spliced module:\n{report}")
+        # Exit code >= 2 means mypy itself failed (fatal/usage/internal/syntax);
+        # it emits text rather than JSON, so surface it rather than parse or
+        # silently pass.
+        raise TypeError(
+            f"mypy could not check the spliced module:\n{(stdout or '') + (stderr or '')}"
+        )
+    errors = _region_errors(stdout or "", lo, hi)
+    if errors:
+        report = "\n".join(
+            f"{e['line']}: {e['message']}  [{e['code']}]" for e in errors
+        )
+        raise TypeError("mypy type check failed:\n" + report + "\n\n" + checked_source)
     return None
 
 

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -137,36 +137,6 @@ def scan_non_nestable(generated: ast.Module) -> None:
                 )
 
 
-def _unwrap(fn: Any) -> Any:
-    """Unwrap a ``staticmethod``/``classmethod`` to its underlying function."""
-    return fn.__func__ if isinstance(fn, staticmethod | classmethod) else fn
-
-
-def _recover_module_source(fn: Any) -> str | None:
-    """Recover the full source of the module that lexically contains ``fn``.
-
-    Resolves from the *function's own* filename: ``inspect.getsourcefile`` finds it
-    -- a real path, or a ``linecache``-registered synthetic name such as
-    ``<synthesis:...>`` for REPL/``exec``/notebook-defined templates -- and
-    ``linecache.getlines`` returns its lines, reading a real file from disk when it
-    isn't already cached (exactly as ``inspect`` does). Returns ``None`` when no
-    source is available, so the caller can skip rather than guess.
-
-    Resolving from the function rather than ``inspect.getsource(inspect.getmodule(
-    fn))`` is what makes the REPL/notebook cases work: those functions have no
-    resolvable module object (or no module-level source file), but their
-    ``co_filename`` is a valid linecache key.
-    """
-    try:
-        filename = inspect.getsourcefile(fn)
-    except TypeError:
-        return None
-    if not filename:
-        return None
-    lines = linecache.getlines(filename)
-    return "".join(lines) if lines else None
-
-
 def _def_nodes(
     module: ast.Module,
 ) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
@@ -243,9 +213,16 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
         )
     target_name = last.name
 
-    fn = _unwrap(anchor)
-    module_source = _recover_module_source(fn)
-    if module_source is None:
+    fn = inspect.unwrap(anchor)  # staticmethod/classmethod -> underlying function
+    # Recover the module source via fn's own filename -- a real path or a
+    # linecache-registered synthetic name (e.g. <synthesis:...>) for REPL/exec/
+    # notebook templates; linecache.getlines reads real files from disk too.
+    try:
+        source_file = inspect.getsourcefile(fn)
+    except TypeError:
+        source_file = None
+    module_source = "".join(linecache.getlines(source_file)) if source_file else ""
+    if not module_source:
         logger.warning("skipping type check: cannot recover source for %r", fn)
         return None
     module_ast = ast.parse(module_source)

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -218,7 +218,7 @@ def _splice_into_source(
     template_def = _find_def_at_lineno(module_ast, fn.__code__.co_firstlineno)
     if template_def is None:
         # The source drifted from what fn was compiled from (e.g. the file was edited after
-        # import). 
+        # import).
         raise RuntimeError(
             f"cannot locate {getattr(fn, '__qualname__', fn)!r} in its module "
             f"source (source drifted since import?)"

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -115,7 +115,7 @@ def exec(
 logger = logging.getLogger(__name__)
 
 
-def _scan_non_nestable(generated: ast.Module) -> None:
+def scan_non_nestable(generated: ast.Module) -> None:
     """Reject constructs legal at module level but illegal once nested in a function.
 
     ``from ... import *`` and ``from __future__ import ...`` are both ``SyntaxError``s
@@ -236,8 +236,6 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
             f"got {type(last).__name__}"
         )
     target_name = last.name
-
-    _scan_non_nestable(generated)
 
     fn = _unwrap(anchor)
     module_source = _recover_module_source(fn)

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -188,27 +188,28 @@ def _region_errors(stdout: str, lo: int, hi: int) -> list[dict[str, Any]]:
     return errors
 
 
-def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
-    """Type-check LLM-generated code by splicing it into the real module source.
+def _splice_into_source(
+    generated: ast.Module, anchor: Any
+) -> tuple[str, int, int] | None:
+    """Splice `generated` into the anchor Template's own function body, in its real
+    module source.
 
-    The generated function — and any helpers it defines alongside — is spliced as
-    the body of the Template's own function, at its real (possibly nested) position
-    in the module, and the whole module is type-checked with mypy. Only diagnostics
-    that fall inside the spliced region are raised, so unrelated pre-existing errors
-    elsewhere in the module never block synthesis. The generated code is thereby
-    checked in its real lexical scope, with no synthesized type stubs.
+    Returns the modified module source and the ``[lo, hi]`` line span of the
+    spliced body within it, or ``None`` when the source or the def site can't be
+    recovered -- so the caller skips rather than guesses (never a silent pass on a
+    real error).
 
-    ``anchor`` is the Template's underlying function, whose module supplies the
-    lexical context. When its source can't be recovered, the check is skipped with
-    a logged reason (never a silent pass on a real error). Raises ``TypeError`` with
-    the mypy report on an in-region failure.
+    The generated function -- and any helpers it defines alongside -- becomes the
+    body of the Template's own function at its real (possibly nested) position, so
+    the generated code is checked in its real lexical scope with no synthesized
+    type stubs.
     """
     if not generated.body:
-        raise TypeError("mypy_type_check: generated module is empty")
+        raise TypeError("splice: generated module is empty")
     last = generated.body[-1]
     if not isinstance(last, ast.FunctionDef | ast.AsyncFunctionDef):
         raise TypeError(
-            f"mypy_type_check: last statement must be a function definition, "
+            f"splice: last statement must be a function definition, "
             f"got {type(last).__name__}"
         )
     target_name = last.name
@@ -264,22 +265,25 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
     spliced = _def_nodes(ast.parse(checked_source))[def_index]
     lo = spliced.body[0].lineno  # first generated statement (body is non-empty)
     hi = spliced.end_lineno or lo
+    return checked_source, lo, hi
 
-    # Type-check the spliced module by writing it to a file and running mypy on
-    # it. Each call gets an isolated temp dir holding both the module and mypy's
-    # cache, for two reasons: (1) `--command`, which the previous implementation
-    # used on a tiny stub, passes the whole source as one argv string and hits an
-    # OS filename-length limit on large modules (`[Errno 36] File name too long`);
-    # (2) parallel decodes (pytest-xdist, concurrent synthesis) must not share
-    # mypy's SQLite cache, which otherwise deadlocks ("database is locked"). A
-    # persistent shared `--cache-dir`/incremental setup, and preserving the
-    # module's sibling-import resolution by writing alongside it, are perf
-    # follow-ups.
+
+def _mypy_check_region(source: str, lo: int, hi: int) -> None:
+    """Run mypy on `source` and raise ``TypeError`` if any error diagnostic falls
+    within ``[lo, hi]``; raise ``RuntimeError`` if mypy itself fails to run.
+
+    Applies mypy to whatever source it's given -- spliced or otherwise -- and
+    reports only the region's errors, so pre-existing errors elsewhere in `source`
+    never block synthesis.
+    """
+    # Run mypy on the source as a temp file (not --command: it hits an argv
+    # length limit on large modules). Each call gets an isolated temp dir + cache
+    # so parallel decodes don't share -- and deadlock on -- mypy's SQLite cache.
     tmpdir = tempfile.mkdtemp(prefix="effectful_typecheck_")
     try:
         tf_path = os.path.join(tmpdir, "_synthesized.py")
         with open(tf_path, "w", encoding="utf-8") as f:
-            f.write(checked_source)
+            f.write(source)
         stdout, stderr, status = mypy_api.run(
             [
                 tf_path,
@@ -298,14 +302,32 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
     # raise `RuntimeError` rather than parse or silently pass.
     if status >= 2:
         raise RuntimeError(
-            f"mypy could not check the spliced module:\n{(stdout or '') + (stderr or '')}"
+            f"mypy could not check the source:\n{(stdout or '') + (stderr or '')}"
         )
     errors = _region_errors(stdout or "", lo, hi)
     if errors:
         report = "\n".join(
             f"{e['line']}: {e['message']}  [{e['code']}]" for e in errors
         )
-        raise TypeError("mypy type check failed:\n" + report + "\n\n" + checked_source)
+        raise TypeError("mypy type check failed:\n" + report + "\n\n" + source)
+
+
+def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
+    """Type-check LLM-generated code by splicing it into the real module source.
+
+    Splices `generated` into the ``anchor`` Template's own function body (in its
+    real module source, via `_splice_into_source`) and checks that spliced source
+    with mypy (via `_mypy_check_region`), so the generated code is checked in its
+    real lexical scope with no synthesized type stubs. Only diagnostics inside the
+    spliced region are raised, so pre-existing errors elsewhere never block
+    synthesis. Skips (logged) when the anchor's source can't be recovered; raises
+    ``TypeError`` on an in-region failure and ``RuntimeError`` if mypy itself fails
+    to run.
+    """
+    spliced = _splice_into_source(generated, anchor)
+    if spliced is None:
+        return None
+    _mypy_check_region(*spliced)
     return None
 
 

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -48,20 +48,6 @@ def parse(source: str, filename: str) -> ast.Module:
 
 
 @defop
-def type_check_anchor() -> Any:
-    """The Template's underlying function, anchoring ``type_check`` to the module
-    the Template is defined in.
-
-    ``None`` (the default) means there is no Template in scope -- the case for
-    tool-argument decoding, which therefore skips the source-anchored type check.
-    ``Template.__apply__`` binds this per call via a handler, so nested/recursive
-    synthesis sees the right anchor (innermost wins); the tool-argument decode
-    rebinds it to ``None``.
-    """
-    return None
-
-
-@defop
 def type_check(generated: ast.Module, anchor: Any) -> None:
     """
     Type check generated code against the lexical context of a Template.

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -270,13 +270,23 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
     ]
 
     # mypy reports line numbers in the coordinates of `checked_source`, so we need
-    # the spliced def's span there. ast.unparse reassigns line numbers but preserves
-    # def order, so the def keeps its index in walk order -- take the def at that
-    # same index in the re-parsed source.
+    # the spliced *body's* span there. ast.unparse reassigns line numbers but
+    # preserves def order, so the def keeps its index in walk order -- take the def
+    # at that same index in the re-parsed source.
+    #
+    # The region is the body (the generated code) only, NOT the def header: the
+    # signature and decorators are the Template author's own pre-existing source,
+    # which we must not attribute to synthesis. This matters for templates whose
+    # module source can't be fully recovered -- notably notebook/REPL cells, which
+    # share a runtime namespace but whose recovered source is a single cell missing
+    # the other cells' imports, so the signature's own annotations (e.g. `Literal`,
+    # `Callable`) look undefined to mypy. Flagging only the body keeps those
+    # spurious signature-line diagnostics out of the gate.
     def_index = _def_nodes(module_ast).index(template_def)
     checked_source = ast.unparse(ast.fix_missing_locations(module_ast))
     spliced = _def_nodes(ast.parse(checked_source))[def_index]
-    lo, hi = spliced.lineno, (spliced.end_lineno or spliced.lineno)
+    lo = spliced.body[0].lineno  # first generated statement (body is non-empty)
+    hi = spliced.end_lineno or lo
 
     # Type-check the spliced module by writing it to a file and running mypy on
     # it. Each call gets an isolated temp dir holding both the module and mypy's
@@ -306,8 +316,7 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
-    # Exit
-    # status >= 2 means mypy itself failed (fatal/usage/internal/syntax) -- a
+    # Exit status >= 2 means mypy itself failed (fatal/usage/internal/syntax) -- a
     # tool failure, not a type error -- and it emits text rather than JSON, so
     # raise `RuntimeError` rather than parse or silently pass.
     if status >= 2:

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -306,11 +306,13 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+    # Check that mypy ran to completion *before* inspecting diagnostics: a type
+    # error (`TypeError`) may only be reported when mypy actually finished. Exit
+    # status >= 2 means mypy itself failed (fatal/usage/internal/syntax) -- a
+    # tool failure, not a type error -- and it emits text rather than JSON, so
+    # raise `RuntimeError` rather than parse or silently pass.
     if status >= 2:
-        # Exit code >= 2 means mypy itself failed (fatal/usage/internal/syntax);
-        # it emits text rather than JSON, so surface it rather than parse or
-        # silently pass.
-        raise TypeError(
+        raise RuntimeError(
             f"mypy could not check the spliced module:\n{(stdout or '') + (stderr or '')}"
         )
     errors = _region_errors(stdout or "", lo, hi)

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -195,9 +195,10 @@ def _splice_into_source(
     module source.
 
     Returns the modified module source and the ``[lo, hi]`` line span of the
-    spliced body within it, or ``None`` when the source or the def site can't be
-    recovered -- so the caller skips rather than guesses (never a silent pass on a
-    real error).
+    spliced body within it, or ``None`` when the anchor's source can't be recovered
+    (the caller skips rather than guesses). Raises ``RuntimeError`` if the source is
+    recovered but the anchor's def can't be located in it (source drift) -- a real
+    error, not a silent pass.
 
     The generated function -- and any helpers it defines alongside -- becomes the
     body of the Template's own function at its real (possibly nested) position, so
@@ -230,11 +231,12 @@ def _splice_into_source(
 
     template_def = _find_def_at_lineno(module_ast, fn.__code__.co_firstlineno)
     if template_def is None:
-        logger.warning(
-            "skipping type check: cannot locate %r in its module source",
-            getattr(fn, "__qualname__", fn),
+        # The source drifted from what fn was compiled from (e.g. the file was edited after
+        # import). 
+        raise RuntimeError(
+            f"cannot locate {getattr(fn, '__qualname__', fn)!r} in its module "
+            f"source (source drifted since import?)"
         )
-        return None
 
     # Splice in place: replace the body with the generated body and bind the
     # target against the (source) return annotation via `return`. Decorators are

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -306,8 +306,7 @@ def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
-    # Check that mypy ran to completion *before* inspecting diagnostics: a type
-    # error (`TypeError`) may only be reported when mypy actually finished. Exit
+    # Exit
     # status >= 2 means mypy itself failed (fatal/usage/internal/syntax) -- a
     # tool failure, not a type error -- and it emits text rather than JSON, so
     # raise `RuntimeError` rather than parse or silently pass.

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -156,9 +156,7 @@ def _find_def_at_lineno(
     return None
 
 
-def _region_errors(
-    stdout: str, lo: int | None, hi: int | None
-) -> list[dict[str, Any]]:
+def _region_errors(stdout: str, lo: int | None, hi: int | None) -> list[dict[str, Any]]:
     """mypy ``--output=json`` diagnostics of severity ``error`` whose reported
     line falls within ``[lo, hi]`` -- the spliced region. An open bound (``None``)
     is unbounded on that side, so ``lo=hi=None`` reports every error.

--- a/effectful/handlers/llm/evaluation.py
+++ b/effectful/handlers/llm/evaluation.py
@@ -4,21 +4,20 @@ import code
 import codeop
 import collections.abc
 import contextlib
-import copy
 import inspect
 import io
-import keyword
 import linecache
-import random
-import string
+import logging
+import os
+import re
+import shutil
 import sys
-import types
+import tempfile
 import typing
-from collections.abc import Mapping, MutableMapping
+from collections.abc import MutableMapping
 from types import CodeType
-from typing import Any, TypeAliasType
+from typing import Any
 
-import autoflake
 from mypy import api as mypy_api
 from RestrictedPython import (
     Eval,
@@ -30,9 +29,7 @@ from RestrictedPython import (
 from RestrictedPython.PrintCollector import PrintCollector
 
 from effectful.handlers.llm.template import Tool
-from effectful.internals.unification import nested_type
 from effectful.ops.syntax import ObjectInterpretation, defop, implements
-from effectful.ops.types import Operation
 
 
 @defop
@@ -51,23 +48,33 @@ def parse(source: str, filename: str) -> ast.Module:
 
 
 @defop
-def type_check(
-    module: ast.Module,
-    ctx: typing.Mapping[str, Any],
-    expected_params: list[type] | None,
-    expected_return: type,
-) -> None:
+def type_check_anchor() -> Any:
+    """The Template's underlying function, anchoring ``type_check`` to the module
+    the Template is defined in.
+
+    ``None`` (the default) means there is no Template in scope -- the case for
+    tool-argument decoding, which therefore skips the source-anchored type check.
+    ``Template.__apply__`` binds this per call via a handler, so nested/recursive
+    synthesis sees the right anchor (innermost wins); the tool-argument decode
+    rebinds it to ``None``.
     """
-    Type check a parsed module against an expected signature and lexical context.
+    return None
 
-    module: The parsed Python source code module to type check.
-    ctx: The lexical context under which the file should be type checked
-    expected_params, expected_return: The expected signature of the last function in the module.
 
-    Returns None, raises TypeError on typechecking failure.
+@defop
+def type_check(generated: ast.Module, anchor: Any) -> None:
+    """
+    Type check generated code against the lexical context of a Template.
+
+    generated: The parsed module of LLM-generated code; its last top-level
+        function definition is the synthesized target, preceded by any helpers.
+    anchor: The Template's underlying function, whose module source supplies the
+        lexical context the generated code is checked against.
+
+    Returns None, raises TypeError on an in-region typechecking failure.
     """
     raise NotImplementedError(
-        "An eval provider must be installed in order to parse code."
+        "An eval provider must be installed in order to type check code."
     )
 
 
@@ -105,584 +112,206 @@ def exec(
     )
 
 
-# Type checking implementation
-def type_to_ast(typ: Any) -> ast.expr:
-    """Convert a Python type to an AST expression.
+logger = logging.getLogger(__name__)
 
-    Takes a type (e.g. from nested_type(value).value) and converts to AST.
+
+def _scan_non_nestable(generated: ast.Module) -> None:
+    """Reject constructs legal at module level but illegal once nested in a function.
+
+    ``from ... import *`` and ``from __future__ import ...`` are both ``SyntaxError``s
+    inside a function body, but mypy *accepts* a nested star import silently, so the
+    splice would slip an illegal construct past the type check and fail later at
+    ``compile``/``exec``. Detect them explicitly and raise before splicing.
     """
-    # Handle None type (both None value and NoneType)
-    if typ is None or typ is type(None):
-        return ast.Constant(value=None)
-
-    # Handle typing.Any (via its metaclass _AnyMeta)
-    if isinstance(typ, type(typing.Any)):
-        return ast.Attribute(
-            value=ast.Name(id="typing", ctx=ast.Load()), attr="Any", ctx=ast.Load()
-        )
-
-    # Handle function type -> Callable (before builtins check since FunctionType is in builtins)
-    if typ is types.FunctionType:
-        return ast.Attribute(
-            value=ast.Attribute(
-                value=ast.Name(id="collections", ctx=ast.Load()),
-                attr="abc",
-                ctx=ast.Load(),
-            ),
-            attr="Callable",
-            ctx=ast.Load(),
-        )
-
-    # Handle basic builtin types
-    if isinstance(typ, type) and typ.__module__ == "builtins":
-        return ast.Name(id=typ.__name__, ctx=ast.Load())
-
-    # Handle runtime-only types (__main__ or <locals> in qualname)
-    # These can't be imported, so we just use the simple name
-    if isinstance(typ, type) and (
-        typ.__module__ == "__main__" or "<locals>" in typ.__qualname__
-    ):
-        return ast.Name(id=typ.__name__, ctx=ast.Load())
-
-    # Handle types from other modules (e.g., collections.abc.Callable)
-    if isinstance(typ, type) and typ.__module__:
-        parts = typ.__module__.split(".")
-        node: ast.expr = ast.Name(id=parts[0], ctx=ast.Load())
-        for part in parts[1:]:
-            node = ast.Attribute(value=node, attr=part, ctx=ast.Load())
-        return ast.Attribute(value=node, attr=typ.__name__, ctx=ast.Load())
-
-    # Handle typing special forms (Union, Optional, etc.)
-    if isinstance(typ, typing._SpecialForm):
-        return ast.Attribute(
-            value=ast.Name(id="typing", ctx=ast.Load()),
-            attr=typ._name,  # type: ignore[attr-defined]
-            ctx=ast.Load(),
-        )
-
-    # Handle TypeVars, ParamSpecs, TypeVarTuples
-    if isinstance(typ, typing.TypeVar | typing.ParamSpec | typing.TypeVarTuple):
-        return ast.Name(id=typ.__name__, ctx=ast.Load())
-
-    # Handle TypeAliasType (PEP 695 type aliases)
-    if isinstance(typ, TypeAliasType):
-        return ast.Name(id=typ.__name__, ctx=ast.Load())
-
-    # Handle union types (int | str)
-    if isinstance(typ, types.UnionType):
-        args = typing.get_args(typ)
-        result = type_to_ast(args[0])
-        for arg in args[1:]:
-            result = ast.BinOp(left=result, op=ast.BitOr(), right=type_to_ast(arg))
-        return result
-
-    # Handle typing.Annotated: use the first argument (the actual type) for typecheck stubs
-    origin = typing.get_origin(typ)
-    if origin is typing.Annotated:
-        args = typing.get_args(typ)
-        if args:
-            return type_to_ast(args[0])
-        raise TypeError("type_to_ast: Annotated must have at least one type argument")
-
-    # Handle generic aliases (e.g., Callable[[int], str], list[int])
-    origin = typing.get_origin(typ)
-    if origin is not None:
-        args = typing.get_args(typ)
-        origin_ast = type_to_ast(origin)
-
-        if not args:
-            return origin_ast
-
-        # Handle Callable-like types: Callable[[arg_types], return_type]
-        # Also handles Operation subclasses which have the same structure
-        is_callable_like = isinstance(origin, type) and issubclass(  # noqa: UP038
-            origin,
-            (collections.abc.Callable, Operation),  # type: ignore[arg-type]
-        )
-        if is_callable_like:
-            if len(args) != 2:
+    for stmt in generated.body:
+        if isinstance(stmt, ast.ImportFrom):
+            if stmt.module == "__future__":
                 raise TypeError(
-                    f"type_to_ast: Callable-like type {typ} must have exactly 2 args, got {len(args)}"
+                    "generated code uses `from __future__ import ...`, which is "
+                    "illegal once spliced into a function body"
                 )
-            param_types, return_type = args
-            # Handle varargs: Callable[..., T] or ParamSpec: Callable[P, T]
-            params_ast: ast.expr
-            if param_types is ...:
-                params_ast = ast.Constant(value=...)
-            elif isinstance(param_types, typing.ParamSpec):
-                params_ast = type_to_ast(param_types)
-            elif isinstance(param_types, list | tuple):
-                params_ast = ast.List(
-                    elts=[type_to_ast(p) for p in param_types], ctx=ast.Load()
-                )
-            else:
+            if any(alias.name == "*" for alias in stmt.names):
                 raise TypeError(
-                    f"type_to_ast: Callable param_types must be list, tuple, ParamSpec, or ..., got {type(param_types)}"
+                    "generated code uses a star import (`from ... import *`), which "
+                    "is illegal once spliced into a function body"
                 )
-            return ast.Subscript(
-                value=origin_ast,
-                slice=ast.Tuple(
-                    elts=[params_ast, type_to_ast(return_type)], ctx=ast.Load()
-                ),
-                ctx=ast.Load(),
-            )
-
-        # Handle single type argument
-        if len(args) == 1:
-            return ast.Subscript(
-                value=origin_ast, slice=type_to_ast(args[0]), ctx=ast.Load()
-            )
-
-        # Handle multiple type arguments
-        return ast.Subscript(
-            value=origin_ast,
-            slice=ast.Tuple(elts=[type_to_ast(arg) for arg in args], ctx=ast.Load()),
-            ctx=ast.Load(),
-        )
-
-    raise TypeError(f"type_to_ast: unhandled type {typ}")
 
 
-# globals always present in python runtime, so we should not stub, or import for
-SKIPPED_GLOBALS = (
-    "__builtins__",
-    "__annotations__",
-    "__doc__",
-    "__file__",
-    "__loader__",
-    "__name__",
-    "__package__",
-    "__spec__",
-    "_frozen_importlib",
-)
+def _unwrap(fn: Any) -> Any:
+    """Unwrap a ``staticmethod``/``classmethod`` to its underlying function."""
+    return fn.__func__ if isinstance(fn, staticmethod | classmethod) else fn
 
 
-def collect_imports(ctx: Mapping[str, Any]) -> list[ast.stmt]:
-    """Collect module imports and symbol imports from context.
+def _recover_module_source(fn: Any) -> str | None:
+    """Recover the full source of the module that lexically contains ``fn``.
 
-    - Modules in context (e.g. ``import math``) produce ``import math``.
-    - Symbols from a module that is not in context (e.g. ``from typing import Any``
-      gives context ``{"Any": typing.Any}`` but no ``typing`` module) produce
-      ``from <module> import <name>`` or ``from <module> import <name> as <alias>``.
+    Reads the real file when one exists, else the ``linecache``-registered source
+    (REPL/``exec``-defined templates, e.g. ``<synthesis:...>`` filenames). Returns
+    ``None`` when neither is available, so the caller can skip rather than guess.
+    ``inspect.getsourcefile`` and ``os.path.isfile`` are both given the *unwrapped*
+    function.
     """
-    # (module_name, asname_in_context) for plain imports; asname is None when same as module_name
-    # Reject any sys.modules key whose dot-separated segments are not all
-    # valid Python identifiers — covers mypyc-internal UUID-prefixed names
-    # (``4c842c94c09923bae9e4__mypyc``), CI tool entries with hyphens or
-    # mid-name digits, and the like. ``_pytest.fixtures``-style internal
-    # modules pass and stay imported (#674).
-    modules: set[tuple[str, str | None]] = set(
-        (k, None)
-        for k in sys.modules.keys()
-        if k not in SKIPPED_GLOBALS and all(seg.isidentifier() for seg in k.split("."))
-    )
-    # module -> list of (name_in_module, name_in_context) for from-imports
-    symbol_imports: dict[str, list[tuple[str, str]]] = {}
-
-    for name_in_ctx, value in ctx.items():
-        if name_in_ctx.startswith("@") or name_in_ctx in SKIPPED_GLOBALS:
-            # pytest adds @pytest_ar, @py_builtins, etc into the context, we skip
-            continue
-
-        if isinstance(value, types.ModuleType):
-            mod_name = value.__name__
-            asname = name_in_ctx if name_in_ctx != mod_name else None
-            modules.add((mod_name, asname))
-            continue
-        module = getattr(value, "__module__", None)
-        if module in (None, "", "__main__", "builtins"):
-            continue
-        if not isinstance(module, str):
-            continue
-        if isinstance(value, type) and _is_runtime_only_type(value):
-            continue
-        # module not in runtime context
-        if not sys.modules.get(module):
-            continue
-        name_in_module = getattr(value, "__name__", name_in_ctx)
-        if not hasattr(sys.modules[module], name_in_module):
-            continue
-        modules.add((module, None))
-        symbol_imports.setdefault(module, []).append((name_in_module, name_in_ctx))
-
-    stmts: list[ast.stmt] = []
-    # Module imports: list of (module_name, asname_in_context)
-    module_pairs = sorted((m, asname or "") for m, asname in modules)
-    if module_pairs:
-        stmts.append(
-            ast.Import(
-                names=[
-                    ast.alias(name=m, asname=asname or None)
-                    for m, asname in module_pairs
-                ]
-            )
-        )
-    for module in sorted(symbol_imports):
-        names = [
-            ast.alias(
-                name=name_in_module,
-                asname=name_in_ctx if name_in_ctx != name_in_module else None,
-            )
-            for name_in_module, name_in_ctx in sorted(
-                symbol_imports[module], key=lambda t: (t[0], t[1])
-            )
-        ]
-        stmts.append(ast.ImportFrom(module=module, names=names, level=0))
-    return stmts
-
-
-def collect_variable_declarations(ctx: Mapping[str, Any]) -> list[ast.stmt]:
-    """Generate variable declarations with type annotations from context.
-
-    For each variable, calls nested_type(value).value to get the type,
-    then type_to_ast to convert to AST.
-    """
-    nodes: list[ast.stmt] = []
-
-    for name, value in sorted(ctx.items()):
-        if name in SKIPPED_GLOBALS:
-            continue
-        # Skip modules (handled by collect_imports)
-        if isinstance(value, types.ModuleType):
-            continue
-
-        # Skip types (classes) - they don't need variable declarations
-        if isinstance(value, type):
-            continue
-
-        # skip values that can be imported from
-        # somewhere, mypy can just use the imports
-        if (
-            hasattr(value, "__qualname__")
-            and hasattr(value, "__module__")
-            and "<locals>" not in value.__qualname__
-            and value.__module__ != "__main__"
-        ):
-            continue
-
+    try:
+        filename = inspect.getsourcefile(fn)
+    except TypeError:
+        return None
+    if not filename:
+        return None
+    if os.path.isfile(filename):
         try:
-            inferred_type = nested_type(value).value
-            type_ast = type_to_ast(inferred_type)
-        except (TypeError, AttributeError):
-            # Use Any for values we can't infer
-            type_ast = type_to_ast(typing.Any)
-
-        ann_assign = ast.AnnAssign(
-            target=ast.Name(id=name, ctx=ast.Store()),
-            annotation=type_ast,
-            value=None,
-            simple=1,
-        )
-        nodes.append(ann_assign)
-
-    return nodes
+            with open(filename, encoding="utf-8") as f:
+                return f.read()
+        except OSError:
+            return None
+    lines = linecache.getlines(filename)
+    return "".join(lines) if lines else None
 
 
-def _is_runtime_only_type(typ: type) -> bool:
-    """Check if a type is runtime-only (can't be imported)."""
-    return typ.__module__ == "__main__" or "<locals>" in typ.__qualname__
-
-
-def signature_to_ast(name: str, sig: inspect.Signature) -> ast.FunctionDef:
-    """Convert an inspect.Signature to an AST function definition stub."""
-    # Build arguments
-    args_list: list[ast.arg] = []
-    for param_name, param in sig.parameters.items():
-        annotation: ast.expr | None = None
-        if param.annotation is not inspect.Parameter.empty:
-            try:
-                annotation = type_to_ast(param.annotation)
-            except TypeError:
-                annotation = type_to_ast(typing.Any)
-        args_list.append(ast.arg(arg=param_name, annotation=annotation))
-
-    # Build return annotation
-    returns: ast.expr | None = None
-    if (
-        sig.return_annotation is not inspect.Signature.empty and name != "__init__"
-    ):  # mypy complains that __init__ must not return anything
-        try:
-            returns = type_to_ast(sig.return_annotation)
-        except TypeError:
-            returns = type_to_ast(typing.Any)
-
-    node = ast.FunctionDef(
-        name=name,
-        args=ast.arguments(
-            posonlyargs=[],
-            args=args_list,
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[],
-        ),
-        body=[
-            ast.Raise(
-                exc=ast.Call(
-                    func=ast.Name(id="NotImplementedError", ctx=ast.Load()),
-                    args=[],
-                    keywords=[],
-                ),
-                cause=None,
-            )
-        ],
-        decorator_list=[],
-        returns=returns,
-        type_params=[],
-    )
-    return ast.fix_missing_locations(node)
-
-
-def collect_runtime_type_stubs(ctx: Mapping[str, Any]) -> list[ast.stmt]:
-    """Generate class stubs for runtime-only types.
-
-    For types defined at runtime (in __main__ or local scopes), generates
-    class definitions with proper inheritance, typed attributes, and method stubs.
-    """
-    nodes: list[ast.stmt] = []
-
-    for name, value in sorted(ctx.items()):
-        # Only process types (classes)
-        if not isinstance(value, type):
-            continue
-
-        # Only process runtime-only types
-        if not _is_runtime_only_type(value):
-            continue
-
-        # Build base classes (use __orig_bases__ to preserve generic params)
-        bases: list[ast.expr] = []
-        orig_bases = getattr(value, "__orig_bases__", value.__bases__)
-        for base in orig_bases:
-            if base is object:
-                continue
-            try:
-                bases.append(type_to_ast(base))
-            except TypeError:
-                pass
-
-        # Build class body
-        body: list[ast.stmt] = []
-
-        # Add typed attributes from __annotations__
-        annotations = getattr(value, "__annotations__", {})
-        for attr_name, attr_type in annotations.items():
-            try:
-                type_ast = type_to_ast(attr_type)
-            except TypeError:
-                type_ast = type_to_ast(typing.Any)
-            body.append(
-                ast.AnnAssign(
-                    target=ast.Name(id=attr_name, ctx=ast.Store()),
-                    annotation=type_ast,
-                    value=None,
-                    simple=1,
-                )
-            )
-
-        # Add method stubs
-        for method_name in dir(value):
-            attr = getattr(value, method_name, None)
-            if attr is None:
-                continue
-            if not isinstance(attr, types.FunctionType):
-                continue
-            try:
-                sig = inspect.signature(attr)
-            except (ValueError, TypeError):
-                continue
-            method_ast = signature_to_ast(method_name, sig)
-            body.append(method_ast)
-
-        # Use ellipsis if body is empty
-        if not body:
-            body = [ast.Expr(value=ast.Constant(value=...))]
-
-        class_def = ast.ClassDef(
-            name=name,
-            bases=bases,
-            keywords=[],
-            body=body,
-            decorator_list=[],
-            type_params=[],
-        )
-        nodes.append(class_def)
-
-    return nodes
-
-
-def _generate_unique_name(existing_names: set[str]) -> str:
-    """Generate a random valid Python identifier that is not in existing_names.
-
-    Produces names like ``_synth_a3f7b2`` that are valid identifiers,
-    not Python keywords, and not in the given set of existing names.
-    """
-    while True:
-        suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
-        candidate = f"_synth_{suffix}"
-        if (
-            candidate not in existing_names
-            and candidate.isidentifier()
-            and not keyword.iskeyword(candidate)
-        ):
-            return candidate
-
-
-class _RenameTransformer(ast.NodeTransformer):
-    """Rename function definitions and their references in a module AST.
-
-    Given a mapping ``{old_name: new_name}``, renames:
-    - ``FunctionDef.name`` for matching definitions
-    - ``ast.Name.id`` references throughout the entire AST
-
-    The rename is applied uniformly because it only targets module-level
-    function definitions that collide with context variable declarations.
-    Local assignments inside function bodies are in their own scope and
-    cannot cause the mypy ``[no-redef]`` error, so they need no special
-    handling.
-    """
-
-    def __init__(self, rename_map: dict[str, str]):
-        self.rename_map = rename_map
-
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
-        if node.name in self.rename_map:
-            node.name = self.rename_map[node.name]
-        self.generic_visit(node)
-        return node
-
-    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
-
-    def visit_Name(self, node: ast.Name) -> ast.Name:
-        if node.id in self.rename_map:
-            node.id = self.rename_map[node.id]
-        return node
-
-
-def mypy_type_check(
+def _def_nodes(
     module: ast.Module,
-    ctx: typing.Mapping[str, Any],
-    expected_params: list[type] | None,
-    expected_return: type,
-) -> None:
-    """Type-check a module with mypy against expected signature and context.
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """All function definitions in ``module``, in a stable order that an
+    ``ast.unparse`` -> ``ast.parse`` round-trip preserves (so a def keeps its
+    index across it)."""
+    return [
+        n
+        for n in ast.walk(module)
+        if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)
+    ]
 
-    Builds a stub module from ctx (imports, runtime type stubs, variable declarations),
-    appends the module body, then a postlude that assigns the last function to a
-    variable annotated with Callable[expected_params, expected_return]. Runs mypy
-    on the combined source; raises TypeError with the mypy report on failure.
 
-    If the synthesized function name clashes with a name already in the context,
-    the function is renamed to a unique random identifier for type-checking only.
+def _find_def_at_lineno(
+    module: ast.Module, lineno: int
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Locate the function definition whose definition site is ``lineno``.
+
+    Matches ``fn.__code__.co_firstlineno`` -- the first decorator line, or the
+    ``def`` line when undecorated -- which identifies the def directly and
+    unambiguously (no name matching, and nesting-agnostic). Returns None only if
+    no def starts there: a dynamically generated ``fn`` with no source def, or
+    source that has drifted since import.
     """
-    if not module.body:
-        raise TypeError("mypy_type_check: module.body is empty")
-    last = module.body[-1]
-    if not isinstance(last, ast.FunctionDef):
+    for node in _def_nodes(module):
+        start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+        if start == lineno:
+            return node
+    return None
+
+
+# mypy diagnostics under --no-pretty: ``file:line: error: ...`` or ``file:line:col: ...``.
+_MYPY_LINE_RE = re.compile(r"^.+?:(\d+):(?:\d+:)?\s+(?:error|note):")
+
+
+def _region_diagnostics(report: str, lo: int, hi: int) -> list[str]:
+    """Diagnostic lines whose reported line number falls within ``[lo, hi]``."""
+    region: list[str] = []
+    for line in report.splitlines():
+        m = _MYPY_LINE_RE.match(line)
+        if m and lo <= int(m.group(1)) <= hi:
+            region.append(line)
+    return region
+
+
+def mypy_type_check(generated: ast.Module, anchor: Any) -> None:
+    """Type-check LLM-generated code by splicing it into the real module source.
+
+    The generated function — and any helpers it defines alongside — is spliced as
+    the body of the Template's own function, at its real (possibly nested) position
+    in the module, and the whole module is type-checked with mypy. Only diagnostics
+    that fall inside the spliced region are raised, so unrelated pre-existing errors
+    elsewhere in the module never block synthesis. The generated code is thereby
+    checked in its real lexical scope, with no synthesized type stubs.
+
+    ``anchor`` is the Template's underlying function, whose module supplies the
+    lexical context. When its source can't be recovered, the check is skipped with
+    a logged reason (never a silent pass on a real error). Raises ``TypeError`` with
+    the mypy report on an in-region failure.
+    """
+    if not generated.body:
+        raise TypeError("mypy_type_check: generated module is empty")
+    last = generated.body[-1]
+    if not isinstance(last, ast.FunctionDef | ast.AsyncFunctionDef):
         raise TypeError(
             f"mypy_type_check: last statement must be a function definition, "
             f"got {type(last).__name__}"
         )
-    func_name = last.name
+    target_name = last.name
 
-    imports = collect_imports(ctx)
-    # Ensure annotations in the postlude can be resolved (e.g. collections.abc.Callable, typing)
-    baseline_imports: list[ast.stmt] = [
-        ast.Import(names=[ast.alias(name="collections", asname=None)]),
-        ast.Import(names=[ast.alias(name="collections.abc", asname=None)]),
-        ast.Import(names=[ast.alias(name="typing", asname=None)]),
-        ast.Import(names=[ast.alias(name="types", asname=None)]),
+    _scan_non_nestable(generated)
+
+    fn = _unwrap(anchor)
+    module_source = _recover_module_source(fn)
+    if module_source is None:
+        logger.warning("skipping type check: cannot recover source for %r", fn)
+        return None
+    module_ast = ast.parse(module_source)
+
+    template_def = _find_def_at_lineno(module_ast, fn.__code__.co_firstlineno)
+    if template_def is None:
+        logger.warning(
+            "skipping type check: cannot locate %r in its module source",
+            getattr(fn, "__qualname__", fn),
+        )
+        return None
+
+    # Splice in place: replace the body with the generated body and bind the
+    # target against the (source) return annotation via `return`. Decorators are
+    # left untouched -- mypy checks a function's body against its declared return
+    # type regardless of decorators (even an unresolvable / `Any` one), and the
+    # decorator application itself doesn't spuriously fail, so touching the
+    # surrounding source as little as possible keeps the splice robust.
+    template_def.body = [
+        *generated.body,
+        ast.Return(ast.Name(target_name, ast.Load())),
     ]
-    stubs = collect_runtime_type_stubs(ctx)
-    variables = collect_variable_declarations(ctx)
 
-    # Collect names already declared in the type-checking preamble
-    # (variable declarations and class stubs) that could collide with
-    # function definitions in the synthesized module.
-    declared_names = {
-        stmt.target.id
-        for stmt in variables
-        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
-    } | {stmt.name for stmt in stubs if isinstance(stmt, ast.ClassDef)}
+    # mypy reports line numbers in the coordinates of `checked_source`, so we need
+    # the spliced def's span there. ast.unparse reassigns line numbers but preserves
+    # def order, so the def keeps its index in walk order -- take the def at that
+    # same index in the re-parsed source.
+    def_index = _def_nodes(module_ast).index(template_def)
+    checked_source = ast.unparse(ast.fix_missing_locations(module_ast))
+    spliced = _def_nodes(ast.parse(checked_source))[def_index]
+    lo, hi = spliced.lineno, (spliced.end_lineno or spliced.lineno)
 
-    # Find all function names in the synthesized module that collide
-    synthesized_func_names = {
-        stmt.name
-        for stmt in module.body
-        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
-    }
-    colliding_names = synthesized_func_names & declared_names
-
-    if colliding_names:
-        # Build a rename map for every colliding function name
-        all_reserved = declared_names | synthesized_func_names
-        rename_map: dict[str, str] = {}
-        for name in colliding_names:
-            unique = _generate_unique_name(all_reserved)
-            rename_map[name] = unique
-            all_reserved.add(unique)
-
-        # Deep-copy the module body so we don't mutate the caller's AST,
-        # then rename definitions and all references to them.
-        module_body = copy.deepcopy(list(module.body))
-        stub_module_body = ast.Module(body=module_body, type_ignores=[])
-        _RenameTransformer(rename_map).visit(stub_module_body)
-        module_body = stub_module_body.body
-        tc_func_name = rename_map.get(func_name, func_name)
-    else:
-        module_body = list(module.body)
-        tc_func_name = func_name
-
-    param_types = expected_params
-    expected_callable_type: type = typing.cast(
-        type,
-        collections.abc.Callable[param_types, expected_return]
-        if expected_params is not None
-        else collections.abc.Callable[..., expected_return],
-    )
-
-    expected_callable_ast = type_to_ast(expected_callable_type)
-    postlude = ast.AnnAssign(
-        target=ast.Name(id="_synthesized_check", ctx=ast.Store()),
-        annotation=expected_callable_ast,
-        value=ast.Name(id=tc_func_name, ctx=ast.Load()),
-        simple=1,
-    )
-    full_body = (
-        baseline_imports
-        + list(imports)
-        + list(stubs)
-        + list(variables)
-        + module_body
-        + [postlude]
-    )
-    stub_module = ast.Module(body=full_body, type_ignores=[])
-    source = ast.unparse(ast.fix_missing_locations(stub_module))
-    # Drop unused imports/vars
-
-    source = autoflake.fix_code(
-        source,
-        additional_imports=None,
-        expand_star_imports=True,
-        remove_all_unused_imports=True,
-        remove_duplicate_keys=True,
-        remove_unused_variables=True,
-    )
-
-    stdout, stderr, status = mypy_api.run(
-        [
-            "--command",
-            source,
-            "--no-error-summary",
-            "--no-pretty",
-            "--ignore-missing-imports",
-            "--disable-error-code=import-untyped",
-        ]
-    )
-    if status != 0:
-        report = (stdout or "") + (stderr or "")
-        raise TypeError(f"mypy type check failed:\n{report}\n{source}")
+    # Type-check the spliced module by writing it to a file and running mypy on
+    # it. Each call gets an isolated temp dir holding both the module and mypy's
+    # cache, for two reasons: (1) `--command`, which the previous implementation
+    # used on a tiny stub, passes the whole source as one argv string and hits an
+    # OS filename-length limit on large modules (`[Errno 36] File name too long`);
+    # (2) parallel decodes (pytest-xdist, concurrent synthesis) must not share
+    # mypy's SQLite cache, which otherwise deadlocks ("database is locked"). A
+    # persistent shared `--cache-dir`/incremental setup, and preserving the
+    # module's sibling-import resolution by writing alongside it, are perf
+    # follow-ups.
+    tmpdir = tempfile.mkdtemp(prefix="effectful_typecheck_")
+    try:
+        tf_path = os.path.join(tmpdir, "_synthesized.py")
+        with open(tf_path, "w", encoding="utf-8") as f:
+            f.write(checked_source)
+        stdout, stderr, status = mypy_api.run(
+            [
+                tf_path,
+                "--cache-dir",
+                os.path.join(tmpdir, "cache"),
+                "--no-error-summary",
+                "--no-pretty",
+                "--ignore-missing-imports",
+                "--disable-error-code=import-untyped",
+            ]
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    report = (stdout or "") + (stderr or "")
+    region = _region_diagnostics(report, lo, hi)
+    if any(" error:" in line for line in region):
+        raise TypeError(
+            "mypy type check failed:\n" + "\n".join(region) + "\n\n" + checked_source
+        )
+    if status >= 2:
+        # Exit code >= 2 means mypy itself failed (fatal/usage/internal error),
+        # not that it found type errors -- surface it rather than silently pass.
+        raise TypeError(f"mypy could not check the spliced module:\n{report}")
     return None
 
 
@@ -694,14 +323,8 @@ class UnsafeEvalProvider(ObjectInterpretation):
     by shelling out to python *without* any further checks. Only use for testing."""
 
     @implements(type_check)
-    def type_check(
-        self,
-        module: ast.Module,
-        ctx: typing.Mapping[str, Any],
-        expected_params: list[type] | None,
-        expected_return: type,
-    ) -> None:
-        mypy_type_check(module, ctx, expected_params, expected_return)
+    def type_check(self, generated: ast.Module, anchor: Any) -> None:
+        mypy_type_check(generated, anchor)
 
     @implements(parse)
     def parse(self, source: str, filename: str) -> ast.Module:
@@ -764,14 +387,8 @@ class RestrictedEvalProvider(ObjectInterpretation):
         self.policy = policy
 
     @implements(type_check)
-    def type_check(
-        self,
-        module: ast.Module,
-        ctx: typing.Mapping[str, Any],
-        expected_params: list[type] | None,
-        expected_return: type,
-    ) -> None:
-        mypy_type_check(module, ctx, expected_params, expected_return)
+    def type_check(self, generated: ast.Module, anchor: Any) -> None:
+        mypy_type_check(generated, anchor)
 
     @implements(parse)
     def parse(self, source: str, filename: str) -> ast.Module:

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method.json
@@ -1,0 +1,46 @@
+{
+  "id": "chatcmpl-E0LaSVEUC2ZqhqMHgjqnpWXy2T04E",
+  "created": 1783751688,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_844ddd95ff",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "{\"value\":{\"module_code\":\"def add(a: int, b: int) -> int:\\n    return a + b\\n\\nadd\"}}",
+        "role": "assistant",
+        "tool_calls": null,
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 35,
+    "prompt_tokens": 1042,
+    "total_tokens": 1077,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 1024,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method_1.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method_1.json
@@ -1,0 +1,46 @@
+{
+  "id": "chatcmpl-E0LaTbVhwjfIDqSAAnoHdsX0xfIwB",
+  "created": 1783751689,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_844ddd95ff",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "{\"value\":{\"module_code\":\"def add(a: int, b: int) -> int:\\n    return a + b\\n\\n# The function to add two integers together.\\n\\nadd\"}}",
+        "role": "assistant",
+        "tool_calls": null,
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 46,
+    "prompt_tokens": 1185,
+    "total_tokens": 1231,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 1024,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method_2.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method_2.json
@@ -1,0 +1,46 @@
+{
+  "id": "chatcmpl-E0LaV5HNI13s28McFpmEOstJIjaEl",
+  "created": 1783751691,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_844ddd95ff",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "{\"value\":{\"module_code\":\"def add(a: int, b: int) -> int:\\n    return a + b\\n\\nadd\"}}",
+        "role": "assistant",
+        "tool_calls": null,
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 35,
+    "prompt_tokens": 1338,
+    "total_tokens": 1373,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 1152,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method_3.json
+++ b/tests/fixtures/tests_test_handlers_llm_provider.py__TestCallableSynthesis__test_synthesize_via_bound_method_3.json
@@ -1,0 +1,46 @@
+{
+  "id": "chatcmpl-E0LaW9F2j54FZM0foXO29TSbly2zU",
+  "created": 1783751692,
+  "model": "gpt-4o-mini-2024-07-18",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_844ddd95ff",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "{\"value\":{\"module_code\":\"def add(a: int, b: int) -> int:\\n    return a + b\"} }",
+        "role": "assistant",
+        "tool_calls": null,
+        "function_call": null,
+        "provider_specific_fields": {
+          "refusal": null
+        },
+        "annotations": []
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "usage": {
+    "completion_tokens": 33,
+    "prompt_tokens": 1481,
+    "total_tokens": 1514,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    },
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 1280,
+      "text_tokens": null,
+      "image_tokens": null,
+      "video_tokens": null
+    }
+  },
+  "service_tier": "default"
+}

--- a/tests/test_handlers_llm_encoding.py
+++ b/tests/test_handlers_llm_encoding.py
@@ -22,6 +22,7 @@ from PIL import Image
 
 from effectful.handlers.llm.encoding import (
     CONTENT_BLOCK_TYPES,
+    TYPE_CHECK_ANCHOR_KEY,
     DecodedToolCall,
     Encodable,
     SynthesizedFunction,
@@ -30,7 +31,6 @@ from effectful.handlers.llm.encoding import (
 from effectful.handlers.llm.evaluation import (
     RestrictedEvalProvider,
     UnsafeEvalProvider,
-    type_check_anchor,
 )
 from effectful.handlers.llm.template import Tool
 from effectful.internals.unification import nested_type
@@ -821,8 +821,10 @@ def test_callable_decode_rejects_invalid(
     ty, ctx, source, exc_type, anchor, eval_provider
 ):
     with pytest.raises(exc_type):
-        with handler(eval_provider), handler({type_check_anchor: lambda: anchor}):
-            pydantic.TypeAdapter(Encodable[ty]).validate_python(source, context=ctx)
+        with handler(eval_provider):
+            pydantic.TypeAdapter(Encodable[ty]).validate_python(
+                source, context={**ctx, TYPE_CHECK_ANCHOR_KEY: anchor}
+            )
 
 
 def test_callable_encode_non_callable():

--- a/tests/test_handlers_llm_encoding.py
+++ b/tests/test_handlers_llm_encoding.py
@@ -30,6 +30,7 @@ from effectful.handlers.llm.encoding import (
 from effectful.handlers.llm.evaluation import (
     RestrictedEvalProvider,
     UnsafeEvalProvider,
+    type_check_anchor,
 )
 from effectful.handlers.llm.template import Tool
 from effectful.internals.unification import nested_type
@@ -765,13 +766,24 @@ def test_callable_full_pipeline_behavioral(
     assert decoded(*args) == expected
 
 
-# Callable error cases: (type, ctx, source, exc_type, match)
+# A Template-style anchor whose return type is the Callable being decoded.
+# Decoding only runs the (source-anchored) type check when an anchor is in scope
+# (bound by Template.__apply__); the result path has one, the argument path does
+# not. The return-type case needs the body checked against the expected signature,
+# so it provides an anchor; the structural cases (param count, missing/last-stmt)
+# are caught without one.
+def _int_pair_anchor() -> Callable[[int, int], int]:
+    raise NotImplementedError
+
+
+# Callable error cases: (type, ctx, source, exc_type, anchor)
 CALLABLE_ERROR_CASES = [
     pytest.param(
         Callable[..., int],
         {},
         SynthesizedFunction(module_code="x = 42"),
         ValueError,
+        None,
         id="non-function-last-stmt",
     ),
     pytest.param(
@@ -779,6 +791,7 @@ CALLABLE_ERROR_CASES = [
         {},
         SynthesizedFunction(module_code="def add(a: int) -> int:\n    return a"),
         ValueError,
+        None,
         id="wrong-param-count",
     ),
     pytest.param(
@@ -788,6 +801,7 @@ CALLABLE_ERROR_CASES = [
             module_code="def add(a: int, b: int) -> str:\n    return str(a + b)"
         ),
         TypeError,
+        _int_pair_anchor,
         id="wrong-return-type",
     ),
     pytest.param(
@@ -795,16 +809,19 @@ CALLABLE_ERROR_CASES = [
         {},
         SynthesizedFunction(module_code="def add(a: int, b: int):\n    return a + b"),
         ValueError,
+        None,
         id="missing-return-annotation",
     ),
 ]
 
 
-@pytest.mark.parametrize("ty,ctx,source,exc_type", CALLABLE_ERROR_CASES)
+@pytest.mark.parametrize("ty,ctx,source,exc_type,anchor", CALLABLE_ERROR_CASES)
 @pytest.mark.parametrize("eval_provider", EVAL_PROVIDERS)
-def test_callable_decode_rejects_invalid(ty, ctx, source, exc_type, eval_provider):
+def test_callable_decode_rejects_invalid(
+    ty, ctx, source, exc_type, anchor, eval_provider
+):
     with pytest.raises(exc_type):
-        with handler(eval_provider):
+        with handler(eval_provider), handler({type_check_anchor: lambda: anchor}):
             pydantic.TypeAdapter(Encodable[ty]).validate_python(source, context=ctx)
 
 

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -21,6 +21,7 @@ from effectful.handlers.llm.evaluation import (
     RestrictedEvalProvider,
     UnsafeEvalProvider,
     mypy_type_check,
+    scan_non_nestable,
     type_check_anchor,
 )
 from effectful.handlers.llm.evaluation import compile as compile_op
@@ -131,16 +132,20 @@ def test_unannotated_container_is_not_a_false_positive():
 
 
 def test_star_import_raises():
-    assert _raises(
-        "from os import *\ndef g(s: str) -> int:\n    return 0\n", _count_char
-    )
+    with pytest.raises(TypeError):
+        scan_non_nestable(
+            ast.parse("from os import *\ndef g(s: str) -> int:\n    return 0\n")
+        )
 
 
 def test_future_import_raises():
-    assert _raises(
-        "from __future__ import annotations\ndef g(s: str) -> int:\n    return 0\n",
-        _count_char,
-    )
+    with pytest.raises(TypeError):
+        scan_non_nestable(
+            ast.parse(
+                "from __future__ import annotations\n"
+                "def g(s: str) -> int:\n    return 0\n"
+            )
+        )
 
 
 def test_annotation_collision_with_context_type_raises():
@@ -306,6 +311,38 @@ def test_decode_without_anchor_skips_typecheck():
         fn = ta.validate_python(
             SynthesizedFunction(
                 module_code="def count_a(s: str) -> str:\n    return s"
+            ),
+            context={},
+        )
+        assert callable(fn)
+
+
+def test_decode_with_anchor_rejects_non_nestable():
+    # The non-nestable scan is a decode-time precondition of the splice: with an
+    # anchor, a star import (illegal once nested in the Template body) is rejected
+    # before type checking.
+    with (
+        handler(UnsafeEvalProvider()),
+        handler({type_check_anchor: lambda: _count_char}),
+    ):
+        ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
+        with pytest.raises(Exception):
+            ta.validate_python(
+                SynthesizedFunction(
+                    module_code="from os import *\ndef count_a(s: str) -> int:\n    return 0"
+                ),
+                context={},
+            )
+
+
+def test_decode_without_anchor_allows_non_nestable():
+    # No anchor -> no splice -> the scan is skipped, and the star import is legal at
+    # the module level where the code is exec'd. So it decodes and runs fine.
+    with handler(UnsafeEvalProvider()):
+        ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
+        fn = ta.validate_python(
+            SynthesizedFunction(
+                module_code="from os import *\ndef count_a(s: str) -> int:\n    return 0"
             ),
             context={},
         )

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -3,16 +3,13 @@
 import ast
 import builtins
 import contextlib
-import inspect
+import importlib.util
 import io
 import sys
-import textwrap
 import types
-import typing
 from collections import ChainMap
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass
-from typing import Annotated, Any, TypedDict
+from collections.abc import Callable
+from typing import Any
 
 import pydantic
 import pytest
@@ -23,1428 +20,296 @@ from effectful.handlers.llm.evaluation import (
     ReplSession,
     RestrictedEvalProvider,
     UnsafeEvalProvider,
-    collect_imports,
-    collect_runtime_type_stubs,
-    collect_variable_declarations,
     mypy_type_check,
-    type_to_ast,
+    type_check_anchor,
 )
 from effectful.handlers.llm.evaluation import compile as compile_op
 from effectful.handlers.llm.evaluation import exec as exec_op
 from effectful.handlers.llm.evaluation import parse as parse_op
-from effectful.internals.unification import nested_type
 from effectful.ops.semantics import handler
-from effectful.ops.syntax import defop
-from effectful.ops.types import NotHandled
 
+# ============================================================================
+# Splice-based type checking (mypy_type_check)
+#
+# The type checker splices LLM-generated code into the real source of the
+# Template's module -- at the template function's own (possibly nested)
+# position -- and runs mypy on the whole module, raising only on diagnostics
+# inside the spliced region. These tests exercise that contract against real
+# anchor functions.
+# ============================================================================
 
-def get_context() -> Mapping[str, Any]:
-    """Get the lexical context at the callsite.
 
-    Returns a ChainMap containing locals and globals from the calling context.
-    """
-    frame = inspect.currentframe()
-    assert frame is not None
-    frame = frame.f_back
-    assert frame is not None
+# Module-level "Template" anchors. Their bodies are placeholders; the type
+# checker replaces them with the generated code. ``count_a`` deliberately shares
+# a name with the function the model is asked to synthesize (issue #542).
+count_a: Callable[[str], int] = lambda s: 0  # noqa: E731
 
-    # Check if we're in a class definition by looking for __qualname__
-    qualname = frame.f_locals.get("__qualname__")
-    n_frames = 1
-    if qualname is not None:
-        name_components = qualname.split(".")
-        for name in reversed(name_components):
-            if name == "<locals>":
-                break
-            n_frames += 1
 
-    contexts = []
-    for offset in range(n_frames):
-        assert frame is not None
-        locals_proxy: types.MappingProxyType[str, Any] = types.MappingProxyType(
-            frame.f_locals
-        )
-        globals_proxy: types.MappingProxyType[str, Any] = types.MappingProxyType(
-            frame.f_globals
-        )
-        contexts.append(locals_proxy)
-        frame = frame.f_back
+class _Ctx:
+    x: int = 0
 
-    contexts.append(globals_proxy)
-    context: Mapping[str, Any] = {
-        k: v
-        for context in contexts
-        for k, v in context.items()
-        if not (
-            (
-                isinstance(v, types.ModuleType)
-                and v.__name__.startswith("tests.test_handlers_llm_evaluation")
-            )
-            or (
-                hasattr(v, "__module__")
-                and (
-                    v.__module__.startswith("tests.test_handlers_llm_evaluation")
-                    or v.__module__.startswith("_pytest")
-                )
-                and inspect.isclass(v)
-                and k.startswith("Test")
-            )
-            or k == "self"
-            or k == "__loader__"
-        )
-    }
-    return context
 
+def _count_char(char: str) -> Callable[[str], int]:
+    raise NotImplementedError
 
-class TestTypeToAstBasicTypes:
-    """Test type_to_ast with basic Python types."""
 
-    @pytest.mark.parametrize(
-        "typ,expected",
-        [
-            (int, "int"),
-            (str, "str"),
-            (float, "float"),
-            (bool, "bool"),
-            (type(None), "None"),
-        ],
-    )
-    def test_basic_types(self, typ, expected):
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == expected
+def _takes_ctx() -> Callable[[_Ctx], int]:
+    raise NotImplementedError
 
 
-class TestTypeToAstTypingTypes:
-    """Test type_to_ast with typing module types."""
+def _loose() -> Callable[..., object]:
+    raise NotImplementedError
 
-    def test_typing_any(self):
-        import typing
 
-        result = type_to_ast(typing.Any)
-        assert ast.unparse(result) == "typing.Any"
+def _make_counter(helper_const: int) -> Callable[[int], int]:
+    def templ(a: int) -> Callable[[int], int]:
+        raise NotImplementedError
 
+    return templ  # type: ignore[return-value]
 
-class TestCollectImports:
-    """Test collect_imports function."""
 
-    def test_collects_module_imports(self):
-        """Test that modules in context are collected as imports."""
-        import math
-        import os
-
-        ctx = {"math": math, "os": os, "x": 42}
-        result = collect_imports(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        assert any("math" in s and "import" in s for s in unparsed)
-        assert any("os" in s and "import" in s for s in unparsed)
-
-    def test_private_module_is_imported(self):
-        """``_``-prefixed modules in ``sys.modules`` are imported alongside
-        public ones (#674).  Without this, emitted stubs that reference
-        types from internal modules — e.g. pytest's ``request`` fixture
-        whose type is ``_pytest.fixtures.TopRequest`` — crash
-        ``mypy_type_check`` with ``Name '_pytest' is not defined``."""
-        import _pytest.fixtures  # noqa: F401
-
-        result = collect_imports({})
-        modules = {
-            alias.name
-            for stmt in result
-            if isinstance(stmt, ast.Import)
-            for alias in stmt.names
-        }
-        assert "_pytest" in modules
-        assert "_pytest.fixtures" in modules
-
-
-class TestCollectImportsStress:
-    """Stress test collect_imports with get_context: imports, aliases, external symbols."""
-
-    def test_from_import_symbol_no_module_in_context(self):
-        """Context has symbol (e.g. Any) but no module (typing); we still emit from-import."""
-        from typing import Any  # noqa: F401 - captured by get_context
-
-        ctx = get_context()
-        result = collect_imports(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        assert unparsed[-1].startswith("from typing import") and "Any" in unparsed[-1]
-
-    def test_plain_import_via_get_context(self):
-        """Plain imports (import math) show up in import statements."""
-        import math  # noqa: F401 - captured by get_context
-
-        ctx = get_context()
-        result = collect_imports(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        assert any(s.startswith("import ") and " math, " in s for s in unparsed)
-
-    def test_import_alias_via_get_context(self):
-        """Import aliases (import os as myos) show up as import os as myos."""
-        import os as myos  # noqa: F401 - captured by get_context
-
-        ctx = get_context()
-        result = collect_imports(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        assert any("os as myos" in s for s in unparsed)
-
-    def test_from_import_alias(self):
-        """from typing import List as L: mapping has L, we emit from typing import List as L."""
-        from typing import List as L  # noqa: F401, UP035 - captured by get_context
-
-        ctx = get_context()
-        assert "L" in ctx
-        result = collect_imports(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        assert any("List as L" in s for s in unparsed)
-
-    def test_mixed_imports_and_symbols(self):
-        """Mixed: from typing import Any, import math, import collections as coll."""
-        import collections as coll  # noqa: F401
-        import math  # noqa: F401
-        from typing import Any  # noqa: F401
-
-        ctx = get_context()
-        result = collect_imports(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        assert any(s.startswith("from") and "Any" in s for s in unparsed), unparsed
-        assert any("math" in s and "import" in s for s in unparsed), unparsed
-        assert any("collections" in s and "coll" in s for s in unparsed), unparsed
-
-
-class TestCollectVariableDeclarations:
-    """Test collect_variable_declarations end-to-end."""
-
-    def test_basic_context(self):
-        ctx = {"x": 42, "y": "hello"}
-        result = collect_variable_declarations(ctx)
-        # Should produce type-annotated variable declarations
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        assert "x: int" in unparsed
-        assert "y: str" in unparsed
-
-
-class TestTypeToAstFunctionTypes:
-    """Test type_to_ast with function types."""
-
-    def test_function_type_becomes_callable(self):
-        """types.FunctionType should become Callable (mypy-compatible)."""
-        result = type_to_ast(types.FunctionType)
-        assert ast.unparse(result) == "collections.abc.Callable"
-
-
-class TestTypeToAstGenericTypes:
-    """Test type_to_ast with generic types."""
-
-    def test_callable_with_args(self):
-        """Callable[[int], str] should be rendered correctly."""
-        import collections.abc
-
-        typ = collections.abc.Callable[[int], str]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.Callable[[int], str]"
-
-    def test_callable_varargs(self):
-        """Callable[..., str] (varargs) should be rendered correctly."""
-        import collections.abc
-
-        typ = collections.abc.Callable[..., str]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.Callable[..., str]"
-
-    def test_callable_multiple_args(self):
-        """Callable[[int, str], bool] should be rendered correctly."""
-        import collections.abc
-
-        typ = collections.abc.Callable[[int, str], bool]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.Callable[[int, str], bool]"
-
-    def test_callable_no_args(self):
-        """Callable[[], int] (no args) should be rendered correctly."""
-        import collections.abc
-
-        typ = collections.abc.Callable[[], int]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.Callable[[], int]"
-
-    def test_mutable_sequence_int(self):
-        """MutableSequence[int] from nested_type([1,2,3])."""
-        typ = nested_type([1, 2, 3]).value
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.MutableSequence[int]"
-
-    def test_mutable_mapping_str_int(self):
-        """MutableMapping[str, int] from nested_type({'a': 1})."""
-        typ = nested_type({"a": 1}).value
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.MutableMapping[str, int]"
-
-    def test_mutable_set_int(self):
-        """MutableSet[int] from nested_type({1, 2, 3})."""
-        typ = nested_type({1, 2, 3}).value
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.MutableSet[int]"
-
-
-class TestTypeToAstUnionTypes:
-    """Test type_to_ast with union types."""
-
-    def test_union_int_str(self):
-        """int | str union type."""
-        typ = int | str
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "int | str"
-
-    def test_union_with_none(self):
-        """int | None (Optional[int])."""
-        typ = int | None
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "int | None"
-
-
-class TestTypeToAstTypingAnnotations:
-    """Test type_to_ast with common typing module annotations."""
-
-    def test_optional_int(self):
-        """typing.Optional[int] renders as typing.Union[int, None]."""
-        import typing
-
-        typ = typing.Optional[int]  # noqa: UP045 - intentionally testing old syntax
-        result = type_to_ast(typ)
-        # Python 3.14 unified typing.Union with types.UnionType (PEP 604),
-        # so typing.Optional[int] now renders with | syntax.
-        expected = (
-            "int | None" if sys.version_info >= (3, 14) else "typing.Union[int, None]"
-        )
-        assert ast.unparse(result) == expected
-
-    def test_typing_dict(self):
-        """typing.Dict[str, int]."""
-        import typing
-
-        typ = typing.Dict[str, int]  # noqa: UP006 - intentionally testing old syntax
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "dict[str, int]"
-
-    def test_typing_list(self):
-        """typing.List[int]."""
-        import typing
-
-        typ = typing.List[int]  # noqa: UP006 - intentionally testing old syntax
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "list[int]"
-
-    def test_typing_set(self):
-        """typing.Set[int]."""
-        import typing
-
-        typ = typing.Set[int]  # noqa: UP006 - intentionally testing old syntax
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "set[int]"
-
-    def test_typing_mapping(self):
-        """typing.Mapping[str, int]."""
-        import typing
-
-        typ = typing.Mapping[str, int]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.Mapping[str, int]"
-
-    def test_typing_sequence(self):
-        """typing.Sequence[int]."""
-        import typing
-
-        typ = typing.Sequence[int]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "collections.abc.Sequence[int]"
-
-
-class TestTypeToAstAnnotated:
-    """Test type_to_ast with typing.Annotated (strips to inner type for typecheck stubs)."""
-
-    def test_annotated_strips_to_inner_type(self):
-        """Annotated[int, "meta"] renders as int."""
-        typ = Annotated[int, "meta"]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "int"
-
-    def test_annotated_with_multiple_metadata(self):
-        """Annotated[str, "a", "b"] strips to str."""
-        typ = Annotated[str, "a", "b"]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "str"
-
-    def test_annotated_generic(self):
-        """Annotated[list[int], "tag"] strips to list[int]."""
-        typ = Annotated[list[int], "tag"]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "list[int]"
-
-
-class TestTypeToAstBuiltinAnnotations:
-    """Test type_to_ast with builtin generic annotations (Python 3.9+)."""
-
-    def test_builtin_list(self):
-        """list[int] builtin annotation."""
-        typ = list[int]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "list[int]"
-
-    def test_builtin_dict(self):
-        """dict[str, int] builtin annotation."""
-        typ = dict[str, int]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "dict[str, int]"
-
-    def test_builtin_set(self):
-        """set[int] builtin annotation."""
-        typ = set[int]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "set[int]"
-
-    def test_builtin_tuple(self):
-        """tuple[int, str] builtin annotation."""
-        typ = tuple[int, str]
-        result = type_to_ast(typ)
-        assert ast.unparse(result) == "tuple[int, str]"
-
-
-class TestGetContextStress:
-    """Stress test with get_context - exercises real lexical contexts."""
-
-    def test_get_context_with_local_variables(self):
-        """Test that we can handle variables from get_context."""
-        x = 42  # noqa: F841 - intentionally captured by get_context
-        y = "hello"  # noqa: F841 - intentionally captured by get_context
-        z = [1, 2, 3]  # noqa: F841 - intentionally captured by get_context
-        ctx = get_context()
-        result = collect_variable_declarations(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        print("\n".join(unparsed))
-        assert "x: int" in unparsed
-        assert "y: str" in unparsed
-
-    def test_functions_with_annotations(self):
-        """Test that annotated functions use Callable[[...], ...] from __annotations__."""
-
-        def annotated_func(x: int) -> str:
-            return str(x)
-
-        ctx = get_context()
-        result = collect_variable_declarations(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        # annotated_func should have Callable[[int], str]
-        assert "annotated_func: collections.abc.Callable[[int], str]" in unparsed
-
-    def test_functions_without_annotations(self):
-        """Test that unannotated functions get Callable type."""
-
-        def unannotated_func(x):
-            return x
-
-        ctx = get_context()
-        result = collect_variable_declarations(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        # unannotated_func should get Callable type
-        assert "unannotated_func: collections.abc.Callable" in unparsed
-
-    def test_operations_in_context(self):
-        """Test that Operations get correct type annotations."""
-
-        @defop
-        def my_op(x: int) -> str:  # noqa: F841 - captured by get_context
-            raise NotHandled
-
-        ctx = get_context()
-        result = collect_variable_declarations(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        # Operation should have exact annotation
-        assert "my_op: effectful.ops.types.Operation[[int], str]" in unparsed
-
-    def test_custom_exception_in_context(self):
-        """Test that custom exceptions get correct type annotations without __main__."""
-
-        class MyError(Exception):  # noqa: F841 - captured by get_context
-            pass
-
-        err = MyError("test")  # noqa: F841 - captured by get_context
-        ctx = get_context()
-        result = collect_variable_declarations(ctx)
-        unparsed = [ast.unparse(stmt) for stmt in result]
-        print("\n".join(unparsed))
-        # The exception instance should have the exception class type without __main__
-        assert "err: MyError" in unparsed
-
-
-class TestTypeToAstOperations:
-    """Test type_to_ast with effectful Operation types."""
-
-    def test_operation_type(self):
-        """Operation type from nested_type."""
-
-        @defop
-        def my_op(x: int) -> str:
-            raise NotHandled
-
-        typ = nested_type(my_op).value
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # Check exact structure
-        assert unparsed == "effectful.ops.types.Operation[[int], str]"
-
-
-class TestTypeToAstPolymorphicTypes:
-    """Test type_to_ast with polymorphic (generic) types."""
-
-    def test_callable_with_typevar(self):
-        """Callable with TypeVar: Callable[[T], T]."""
-        import typing
-
-        T = typing.TypeVar("T")  # noqa: PLC0132
-        typ = typing.Callable[[T], T]
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # Check exact structure: collections.abc.Callable[[T], T]
-        assert unparsed == "collections.abc.Callable[[T], T]"
-
-    def test_callable_with_bounded_typevar(self):
-        """Callable with bounded TypeVar: Callable[[T], T] where T: int."""
-        import typing
-
-        T_bounded = typing.TypeVar("T_bounded", bound=int)  # noqa: PLC0132
-        typ = typing.Callable[[T_bounded], T_bounded]
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # Bounded TypeVar still uses its name
-        assert unparsed == "collections.abc.Callable[[T_bounded], T_bounded]"
-
-    def test_operation_with_typevar(self):
-        """Operation with TypeVar: Operation[[T], T]."""
-
-        @defop
-        def identity[T](x: T) -> T:
-            raise NotHandled
-
-        typ = nested_type(identity).value
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # Check exact structure
-        assert unparsed == "effectful.ops.types.Operation[[T], T]"
-
-    def test_operation_with_bounded_typevar_312_syntax(self):
-        """Operation with bounded TypeVar using Python 3.12+ [T: int] syntax."""
-
-        @defop
-        def bounded_op[T: int](x: T) -> T:
-            raise NotHandled
-
-        typ = nested_type(bounded_op).value
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # Check that the bounded TypeVar is preserved
-        assert unparsed == "effectful.ops.types.Operation[[T], T]"
-
-    def test_generic_class(self):
-        """Generic class: list[T]."""
-        import typing
-
-        T = typing.TypeVar("T")  # noqa: PLC0132
-        typ = list[T]
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # Check exact structure
-        assert unparsed == "list[T]"
-
-    def test_callable_with_paramspec(self):
-        """Callable with ParamSpec: Callable[P, int]."""
-        import typing
-
-        P = typing.ParamSpec("P")  # noqa: PLC0132
-        typ = typing.Callable[P, int]
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # ParamSpec is rendered by name
-        assert unparsed == "collections.abc.Callable[P, int]"
-
-    def test_tuple_with_typevartuple(self):
-        """tuple with TypeVarTuple: tuple[*Ts]."""
-
-        Ts = typing.TypeVarTuple("Ts")  # noqa: PLC0132
-        typ = tuple[*Ts]
-        result = type_to_ast(typ)
-        unparsed = ast.unparse(result)
-        # TypeVarTuple with Unpack
-        assert "tuple" in unparsed
-        assert "Ts" in unparsed
-
-
-class TestCollectRuntimeTypeStubs:
-    """Test collect_runtime_type_stubs for generating class stubs."""
-
-    def test_exception_subclass_stub(self):
-        """Test that runtime exception classes get proper stubs with inheritance."""
-
-        class MyError(Exception):
-            pass
-
-        ctx = {"MyError": MyError}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class MyError(Exception):" in unparsed
-
-    def test_class_with_callable_method(self):
-        """Test that classes with callable methods get typed stubs."""
-
-        class MyClass:
-            def my_method(self, x: int) -> str:
-                return str(x)
-
-        ctx = {"MyClass": MyClass}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class MyClass:" in unparsed
-        assert "def my_method(self, x: int) -> str:" in unparsed
-
-    def test_class_with_typed_attribute(self):
-        """Test that classes with __annotations__ get typed stubs."""
-
-        class MyClass:
-            x: int
-            y: str
-
-        ctx = {"MyClass": MyClass}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class MyClass:" in unparsed
-        assert "x: int" in unparsed
-        assert "y: str" in unparsed
-
-    def test_exception_chain_inheritance(self):
-        """Test exception with multiple levels of inheritance."""
-
-        class BaseError(Exception):
-            pass
-
-        class SpecificError(BaseError):
-            pass
-
-        ctx = {"BaseError": BaseError, "SpecificError": SpecificError}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class BaseError(Exception):" in unparsed
-        assert "class SpecificError(BaseError):" in unparsed
-
-    def test_exception_with_attributes(self):
-        """Test exception class with typed attributes."""
-
-        class ValidationError(Exception):
-            field: str
-            message: str
-
-        ctx = {"ValidationError": ValidationError}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class ValidationError(Exception):" in unparsed
-        assert "field: str" in unparsed
-        assert "message: str" in unparsed
-
-    def test_exception_with_init(self):
-        """Test exception class with __init__ method."""
-
-        class CustomError(Exception):
-            def __init__(self, code: int, message: str) -> None:
-                super().__init__(message)
-                self.code = code
-
-        ctx = {"CustomError": CustomError}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class CustomError(Exception):" in unparsed
-        assert "def __init__(self, code: int, message: str):" in unparsed
-
-    def test_dataclass_like_with_fields(self):
-        """Test class with multiple typed fields like a dataclass."""
-
-        class Person:
-            name: str
-            age: int
-            email: str | None
-
-        ctx = {"Person": Person}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class Person:" in unparsed
-        assert "name: str" in unparsed
-        assert "age: int" in unparsed
-        assert "email: str | None" in unparsed
-
-    def test_method_with_generic_types(self):
-        """Test method with generic type annotations."""
-
-        class Container:
-            def get_items(self) -> list[str]:
-                return []
-
-            def set_mapping(self, data: dict[str, int]) -> None:
-                pass
-
-        ctx = {"Container": Container}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "def get_items(self) -> list[str]:" in unparsed
-        assert "def set_mapping(self, data: dict[str, int]) -> None:" in unparsed
-
-    def test_field_with_generic_types(self):
-        """Test fields with generic type annotations."""
-
-        class DataStore:
-            items: list[int]
-            cache: dict[str, Any]
-
-        ctx = {"DataStore": DataStore}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "items: list[int]" in unparsed
-        assert "cache: dict[str, typing.Any]" in unparsed
-
-    def test_generic_superclass(self):
-        """Test class inheriting from generic type."""
-
-        class StringList(list[str]):
-            pass
-
-        ctx = {"StringList": StringList}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class StringList(list[str]):" in unparsed
-
-    def test_generic_class_with_type_params(self):
-        """Test generic class with its own type parameters: class Foo[T](list[T])."""
-
-        class Container[T](list[T]):
-            def get_first(self) -> T:
-                return self[0]
-
-        ctx = {"Container": Container}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        print(unparsed)
-        # Should include generic base class
-        assert "class Container(list[T], typing.Generic[T]):" in unparsed, unparsed
-        assert "def get_first(self) -> T:" in unparsed
-
-    def test_multiple_inheritance(self):
-        """Test class with multiple base classes."""
-
-        class Mixin:
-            pass
-
-        class Base:
-            pass
-
-        class Combined(Base, Mixin):
-            pass
-
-        ctx = {"Base": Base, "Mixin": Mixin, "Combined": Combined}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class Base:" in unparsed
-        assert "class Mixin:" in unparsed
-        assert "class Combined(Base, Mixin):" in unparsed
-
-    def test_method_with_optional_params(self):
-        """Test method with optional/default parameters."""
-
-        class Config:
-            def setup(self, name: str, debug: bool = False) -> None:
-                pass
-
-        ctx = {"Config": Config}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "def setup(self, name: str, debug: bool) -> None:" in unparsed
-
-    def test_class_with_classmethod_and_staticmethod(self):
-        """Test class with classmethod and staticmethod (should not appear as regular methods)."""
-
-        class Factory:
-            @classmethod
-            def create(cls) -> "Factory":
-                return cls()
-
-            @staticmethod
-            def validate(x: int) -> bool:
-                return x > 0
-
-            def instance_method(self) -> str:
-                return "hello"
-
-        ctx = {"Factory": Factory}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        # instance_method should be present
-        assert "def instance_method(self) -> str:" in unparsed
-
-    def test_method_with_callable_param(self):
-        """Test method with Callable parameter type."""
-
-        class Handler:
-            def register(self, callback: Callable[[int], str]) -> None:
-                pass
-
-        ctx = {"Handler": Handler}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert (
-            "def register(self, callback: collections.abc.Callable[[int], str]) -> None:"
-            in unparsed
-        )
-
-    def test_nested_generic_types(self):
-        """Test deeply nested generic types."""
-
-        class NestedData:
-            matrix: list[list[int]]
-            lookup: dict[str, list[tuple[int, str]]]
-
-        ctx = {"NestedData": NestedData}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "matrix: list[list[int]]" in unparsed
-        assert "lookup: dict[str, list[tuple[int, str]]]" in unparsed
-
-    def test_union_types_in_method(self):
-        """Test method with union type annotations."""
-
-        class Parser:
-            def parse(self, data: str | bytes) -> int | None:
-                return None
-
-        ctx = {"Parser": Parser}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "def parse(self, data: str | bytes) -> int | None:" in unparsed
-
-    def test_dataclasses(self):
-        """Test method with dataclasses annotations."""
-
-        @dataclass
-        class Point:
-            x: int
-            y: int
-
-        ctx = {"Point": Point}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class Point:\n    x: int\n    y: int" in unparsed
-
-    def test_typed_dicts(self):
-        """Test method subclassing typed dict."""
-
-        class TypedPoint(TypedDict):
-            x: int
-            y: int
-
-        ctx = {"TypedPoint": TypedPoint}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert "class TypedPoint:\n    x: int\n    y: int" in unparsed
-
-    def test_pydantic_base_models(self):
-        """Test method subclassing pydantic base models."""
-
-        class BasePoint(pydantic.BaseModel):
-            x: int
-            y: int
-
-        ctx = {"Point": BasePoint}
-        result = collect_runtime_type_stubs(ctx)
-        unparsed = "\n".join(ast.unparse(stmt) for stmt in result)
-        assert (
-            "class Point(pydantic.main.BaseModel):\n    x: int\n    y: int" in unparsed
-        )
-
-
-class TestTypeAliases:
-    """Test type_to_ast with type aliases."""
-
-    def test_simple_type_alias(self):
-        """Test simple type alias."""
-
-        type IntList = list[int]
-        result = type_to_ast(IntList)
-        unparsed = ast.unparse(result)
-        assert unparsed == "IntList"
-
-    def test_generic_type_alias(self):
-        """Test generic type alias with TypeVar using Python 3.12+ syntax."""
-        type MyList[T] = list[T]  # noqa: PLC0132 - T is defined by the type syntax
-        result = type_to_ast(MyList)
-        unparsed = ast.unparse(result)
-        assert unparsed == "MyList"
-
-
-@pytest.mark.xdist_group("mypy")
-class TestMypyTypeCheckE2E:
-    """End-to-end stress tests for mypy_type_check with get_context and ast.parse. Never empty context."""
-
-    def test_simple_function_with_get_context(self):
-        """One function; ctx from get_context(); typecheck passes."""
-        _ = 1  # noqa: F841 - in context
-        source = "def f(x: int, s: str) -> bool:\n    return len(s) > x"
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [int, str], bool)
-
-    def test_private_module_qualified_type_in_context(self):
-        """Regression for #674: a ctx value whose runtime type lives in
-        a ``_``-prefixed module must not crash ``mypy_type_check`` with
-        ``Name '_pytest' is not defined``.  Uses a pytest fixture-request
-        instance because that is the path that surfaced the bug."""
-        import _pytest.fixtures
-
-        # Build a `request`-shaped instance.  We cannot easily instantiate
-        # `TopRequest` properly outside pytest, but `__new__` gives us a
-        # value whose `type(...).__module__` is `_pytest.fixtures`, which
-        # is what triggers the qualname emission in
-        # `collect_variable_declarations`.
-        fake_request = _pytest.fixtures.TopRequest.__new__(_pytest.fixtures.TopRequest)
-        ctx = {"request": fake_request}
-        source = "def f() -> int:\n    return 0"
-        module = ast.parse(source)
-        # Must not raise.
-        mypy_type_check(module, ctx, None, int)
-
-    def test_simple_function_no_params_with_get_context(self):
-        """Function with no params, returns int; get_context()."""
-        _ = 1  # noqa: F841
-        source = "def g() -> int:\n    return 42"
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), None, int)
-
-    def test_module_with_multiple_statements_then_function(self):
-        """Module has assignments then the function we check; get_context()."""
-        _ = 1  # noqa: F841
-        source = """
-a = 1
-b = "x"
-def h(n: int) -> str:
-    return str(n)
-"""
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [int], str)
-
-    def test_with_get_context_and_typed_values(self):
-        """Use get_context(); function signature matches expected; passes."""
-        x = 42  # noqa: F841
-        s = "hello"  # noqa: F841
-
-        ctx = get_context()
-        source = "def add_one(n: int) -> int:\n    return n + 1"
-        module = ast.parse(source)
-        mypy_type_check(module, ctx, [int], int)
-
-    def test_nested_function_module_last_is_outer(self):
-        """Module body has def outer with nested def inner; we check outer; get_context()."""
-        _ = 1  # noqa: F841
-        source = """
-def outer(x: int) -> str:
-    def inner(y: int) -> int:
-        return y + 1
-    return str(inner(x))
-"""
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [int], str)
-
-    def test_local_class_in_context_and_module(self):
-        """Runtime-only class in ctx; module has class + function using it; stubs generated."""
-
-        class LocalKlass:
-            def method(self) -> int:
-                return 0
-
-        source = """
-def use_it(obj: LocalKlass) -> int:
-    return obj.method()
-"""
-        module = ast.parse(source)
-        ctx = ChainMap({"LocalKlass": LocalKlass}, get_context())
-        mypy_type_check(module, ctx, [LocalKlass], int)
-
-    def test_decorated_function(self):
-        """Function has a decorator; last stmt is still the function; get_context()."""
-        _ = 1  # noqa: F841
-        source = """
-def dec(f):
-    return f
-@dec
-def decorated(x: int) -> bool:
-    return x > 0
-"""
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [int], bool)
-
-    def test_module_uses_typing_from_context(self):
-        """Context provides List from get_context; module uses list[int]; typecheck passes."""
-
-        _ = list  # noqa: F841 - in context
-        source = """
-def sum_list(nums: list[int]) -> int:
-    return sum(nums)
-"""
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [list], int)
-
-    def test_typecheck_passes_with_fully_annotated_function(self):
-        """Typechecking passes when the module has full type annotations (params + return) matching expected."""
-        _ = 1  # noqa: F841
-        source = """
-def add(x: int, y: int) -> int:
-    return x + y
-"""
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [int, int], int)
-
-    def test_typecheck_passes_with_annotated_generics(self):
-        """Typechecking passes when the function uses generic annotations (list, dict) in params."""
-        _ = list  # noqa: F841
-        _ = dict  # noqa: F841
-        source = """
-def process(nums: list[int], mapping: dict[str, int]) -> int:
-    return len(nums) + len(mapping)
-"""
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [list, dict], int)
-
-    def test_typecheck_passes_when_module_uses_typing_annotated(self):
-        """Typechecking passes when the function uses typing.Annotated in params and return."""
-        from typing import Annotated  # noqa: F401 - in context for get_context
-
-        source = """
-def f(x: Annotated[int, "positive"], y: Annotated[str, "name"]) -> Annotated[bool, "ok"]:
-    return len(y) > x
-"""
-        module = ast.parse(source)
-        mypy_type_check(module, get_context(), [int, str], bool)
-
-    def test_typecheck_passes_with_expected_annotated(self):
-        """Typechecking passes when expected params/return use Annotated (stripped for stub)."""
-        _ = 1  # noqa: F841
-        source = "def g(x: int) -> int:\n    return x"
-        module = ast.parse(source)
-        mypy_type_check(
-            module,
-            get_context(),
-            [Annotated[int, "value"]],
-            Annotated[int, "result"],
-        )
-
-    def test_typecheck_symbol_in_annotated_metadata_does_not_crash_mypy(self):
-        """A symbol (type/class) in Annotated metadata is resolved from context and does not crash mypy."""
-
-        class Tag:
-            """Metadata marker class in context."""
-
-        source = """
-def f(x: Annotated[int, Tag]) -> int:
-    return x
-"""
-        module = ast.parse(source)
-        ctx = get_context()
-        mypy_type_check(module, ctx, [int], int)
-
-
-@pytest.mark.xdist_group("mypy")
-class TestMypyTypeCheckFailures:
-    """Failure cases: mypy_type_check must raise TypeError with mypy report. All use get_context()."""
-
-    def test_wrong_return_type_raises(self):
-        """Function returns int but expected return is str; mypy fails."""
-        _ = 1  # noqa: F841
-        source = "def f(x: int) -> str:\n    return x"
-        module = ast.parse(source)
-        with pytest.raises(TypeError) as exc_info:
-            mypy_type_check(module, get_context(), [int], str)
-        assert (
-            "mypy" in str(exc_info.value).lower()
-            or "error" in str(exc_info.value).lower()
-        )
-
-    def test_wrong_param_count_raises(self):
-        """Expected (int, str) but function takes (int); fails."""
-        _ = 1  # noqa: F841
-        source = "def g(x: int) -> bool:\n    return True"
-        module = ast.parse(source)
-        with pytest.raises(TypeError) as exc_info:
-            mypy_type_check(module, get_context(), [int, str], bool)
-        assert exc_info.type is TypeError
-
-    def test_incompatible_param_type_raises(self):
-        """Function annotates param as str, we expect int; mismatch."""
-        _ = 1  # noqa: F841
-        source = "def h(s: str) -> int:\n    return len(s)"
-        module = ast.parse(source)
-        with pytest.raises(TypeError):
-            mypy_type_check(module, get_context(), [int], int)
-
-    def test_empty_module_raises(self):
-        """Empty module.body raises TypeError before mypy."""
-        _ = 1  # noqa: F841
-        module = ast.Module(body=[], type_ignores=[])
-        with pytest.raises(TypeError, match="empty"):
-            mypy_type_check(module, get_context(), None, int)
-
-    def test_last_statement_not_function_raises(self):
-        """Last stmt is an expression, not a function def."""
-        _ = 1  # noqa: F841
-        source = "x = 1"
-        module = ast.parse(source)
-        with pytest.raises(TypeError, match="function"):
-            mypy_type_check(module, get_context(), [], int)
-
-    def test_assign_then_expr_no_function_raises(self):
-        """Module has only assignments/expressions; no function def."""
-        _ = 1  # noqa: F841
-        source = "a = 1\na + 1"
-        module = ast.parse(source)
-        with pytest.raises(TypeError, match="function"):
-            mypy_type_check(module, get_context(), [], int)
-
-    def test_failure_dataclass_wrong_return(self):
-        """Dataclass in context; function returns wrong type; get_context()."""
-
-        @dataclass
-        class Box:
-            value: int
-
-        source = """
-def bad(b: Box) -> Box:
-    return b.value
-"""
-        module = ast.parse(source)
-        ctx = ChainMap({"Box": Box}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [Box], Box)
-
-    def test_failure_dataclass_wrong_param_type(self):
-        """Dataclass; expected param int, function takes Box; get_context()."""
-
-        @dataclass
-        class Box:
-            value: int
-
-        source = "def use(b: Box) -> int:\n    return b.value"
-        module = ast.parse(source)
-        ctx = ChainMap({"Box": Box}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [int], int)
-
-    def test_failure_plain_class_wrong_return(self):
-        """Plain class in context; function returns wrong type; get_context()."""
-
-        class Node:
-            def __init__(self, x: int) -> None:
-                self.x = x
-
-        source = "def make() -> Node:\n    return 42"
-        module = ast.parse(source)
-        ctx = ChainMap({"Node": Node}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [], Node)
-
-    def test_failure_plain_class_param_mismatch(self):
-        """Plain class; expected (Node, Node), function takes (Node); get_context()."""
-
-        class Node:
-            pass
-
-        source = "def add(a: Node) -> Node:\n    return a"
-        module = ast.parse(source)
-        ctx = ChainMap({"Node": Node}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [Node, Node], Node)
-
-    def test_failure_local_class_wrong_return(self):
-        """Runtime local class; function annotated to return class but returns int; get_context()."""
-
-        class LocalKlass:
-            pass
-
-        source = """
-class LocalKlass:
-    pass
-def f() -> LocalKlass:
-    return 1
-"""
-        module = ast.parse(source)
-        ctx = ChainMap({"LocalKlass": LocalKlass}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [], LocalKlass)
-
-    def test_failure_runtime_local_class_param_wrong_type(self):
-        """Runtime local class; we expect (int,), function takes (LocalKlass,); get_context()."""
-
-        class LocalKlass:
-            pass
-
-        source = """
-class LocalKlass:
-    pass
-def g(obj: LocalKlass) -> int:
-    return 0
-"""
-        module = ast.parse(source)
-        ctx = ChainMap({"LocalKlass": LocalKlass}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [int], int)
-
-    def test_failure_nested_function_outer_wrong_return(self):
-        """Nested function: outer declared -> str but returns int; get_context()."""
-        _ = 1  # noqa: F841
-        source = """
-def outer(x: int) -> str:
-    def inner() -> int:
-        return 1
-    return inner()
-"""
-        module = ast.parse(source)
-        with pytest.raises(TypeError):
-            mypy_type_check(module, get_context(), [int], str)
-
-    def test_failure_nested_function_expected_wrong_param_count(self):
-        """Nested: we expect (int, str), outer takes (int); get_context()."""
-        _ = 1  # noqa: F841
-        source = """
-def outer(x: int) -> bool:
-    def inner() -> bool:
+def _raises(generated_src: str, anchor: Any) -> bool:
+    try:
+        mypy_type_check(ast.parse(generated_src), anchor)
+        return False
+    except TypeError:
         return True
-    return inner()
-"""
-        module = ast.parse(source)
-        with pytest.raises(TypeError):
-            mypy_type_check(module, get_context(), [int, str], bool)
-
-    def test_failure_typeddict_wrong_return(self):
-        """TypedDict in context; function returns wrong type; get_context()."""
-
-        class Point(TypedDict):
-            x: int
-            y: int
-
-        source = "def origin() -> Point:\n    return 0"
-        module = ast.parse(source)
-        ctx = ChainMap({"Point": Point}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [], Point)
-
-    def test_failure_typeddict_param_mismatch(self):
-        """TypedDict; we expect (Point, int), function takes (Point,); get_context()."""
-
-        class Point(TypedDict):
-            x: int
-            y: int
-
-        source = "def get_x(p: Point) -> int:\n    return p['x']"
-        module = ast.parse(source)
-        ctx = ChainMap({"Point": Point}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [Point, int], int)
-
-    def test_failure_pydantic_model_wrong_return(self):
-        """Pydantic BaseModel in context; function returns wrong type; get_context()."""
-
-        class Item(pydantic.BaseModel):
-            name: str
-
-        source = "def make() -> Item:\n    return 1"
-        module = ast.parse(source)
-        ctx = ChainMap({"Item": Item}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [], Item)
-
-    def test_failure_pydantic_model_param_wrong(self):
-        """Pydantic model; we expect (str,), function takes (Item,); get_context()."""
-
-        class Item(pydantic.BaseModel):
-            name: str
-
-        source = "def get_name(i: Item) -> str:\n    return i.name"
-        module = ast.parse(source)
-        ctx = ChainMap({"Item": Item}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [str], str)
-
-    def test_failure_custom_class_wrong_return(self):
-        """Custom class; function declares return type but returns other; get_context()."""
-
-        class Custom:
-            def run(self) -> int:
-                return 0
-
-        source = "def get_custom() -> Custom:\n    return 1"
-        module = ast.parse(source)
-        ctx = ChainMap({"Custom": Custom}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [], Custom)
-
-    def test_failure_custom_class_param_expected_mismatch(self):
-        """Custom class; expected (Custom, str), function (Custom,) -> str; get_context()."""
-
-        class Custom:
-            pass
-
-        source = "def greet(c: Custom) -> str:\n    return 'hi'"
-        module = ast.parse(source)
-        ctx = ChainMap({"Custom": Custom}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [Custom, str], str)
-
-    def test_failure_callable_wrong_return(self):
-        """Callable type: we expect Callable[[int], str], function returns Callable[[int], int]; get_context()."""
-        _ = 1  # noqa: F841
-        source = "def f() -> Callable[[int], int]:\n    return lambda x: x"
-        module = ast.parse(source)
-        with pytest.raises(TypeError):
-            mypy_type_check(module, get_context(), [], Callable[[int], str])
-
-    def test_failure_optional_return_wrong(self):
-        """Optional/union: function returns int, we expect str | None; get_context()."""
-        _ = 1  # noqa: F841
-        source = "def f(x: int) -> int:\n    return x"
-        module = ast.parse(source)
-        with pytest.raises(TypeError):
-            mypy_type_check(module, get_context(), [int], str | None)
-
-    def test_failure_exception_class_wrong_base(self):
-        """Custom exception class; function returns int but expected return MyErr; get_context()."""
-
-        class MyErr(Exception):
-            pass
-
-        source = "def raise_it() -> MyErr:\n    return 1"
-        module = ast.parse(source)
-        ctx = ChainMap({"MyErr": MyErr}, get_context())
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [], MyErr)
 
 
-@pytest.mark.xdist_group("mypy")
-class TestMypyTypeCheckNameCollision:
-    """Tests that mypy_type_check renames synthesized functions whose names
-    collide with variable declarations or class stubs from the context."""
+def _import_fixture(tmp_path, source: str, modname: str):
+    p = tmp_path / f"{modname}.py"
+    p.write_text(source)
+    spec = importlib.util.spec_from_file_location(modname, str(p))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
 
-    def test_single_function_collides_with_variable(self):
-        """Function name matches a variable in context; should still pass type-check."""
-        count_char = lambda s: s.count("a")  # noqa: E731, F841
 
-        source = textwrap.dedent("""\
-            def count_char(s: str) -> int:
-                return s.count('a')
-        """)
-        module = ast.parse(source)
-        ctx = get_context()
-        # Should NOT raise — the collision is handled by renaming
-        mypy_type_check(module, ctx, [str], int)
+def _anchor_from_source(tmp_path, source: str, attr: str, modname: str) -> Any:
+    return getattr(_import_fixture(tmp_path, source, modname), attr)
 
-    def test_colliding_function_still_detects_type_errors(self):
-        """Even after renaming, real type errors are still caught."""
-        count_char = lambda s: s.count("a")  # noqa: E731, F841
 
-        source = textwrap.dedent("""\
-            def count_char(s: str) -> int:
-                return s  # wrong return type
-        """)
-        module = ast.parse(source)
-        ctx = get_context()
-        with pytest.raises(TypeError):
-            mypy_type_check(module, ctx, [str], int)
+def test_good_function_typechecks():
+    assert not _raises(
+        "def count_a(s: str) -> int:\n    return s.count('a')\n", _count_char
+    )
 
-    def test_no_collision_passes_normally(self):
-        """No name collision — normal type-check should work as before."""
-        x = 42  # noqa: F841
 
-        source = textwrap.dedent("""\
-            def some_unique_func(s: str) -> int:
-                return len(s)
-        """)
-        module = ast.parse(source)
-        ctx = get_context()
-        mypy_type_check(module, ctx, [str], int)
+def test_wrong_return_type_raises():
+    assert _raises("def count_a(s: str) -> str:\n    return s\n", _count_char)
 
-    def test_multiple_functions_one_collides(self):
-        """Module has helper + main function; only main collides with context."""
-        process = "some_value"  # noqa: F841
 
-        source = textwrap.dedent("""\
-            def helper(x: int) -> str:
-                return str(x)
-            def process(items: list[int]) -> list[str]:
-                return [helper(i) for i in items]
-        """)
-        module = ast.parse(source)
-        ctx = get_context()
-        mypy_type_check(module, ctx, [list[int]], list[str])
+def test_synthesized_name_collides_with_context_var_issue_542():
+    # The synthesized ``count_a`` collides with the module-level ``count_a``
+    # binding. Nested as a local it *shadows* it (no ``[no-redef]``), where the
+    # old flat-stub mechanism raised and had to rename around the collision.
+    assert not _raises(
+        "def count_a(s: str) -> int:\n    return s.count('a')\n", _count_char
+    )
 
-    def test_multiple_functions_both_collide(self):
-        """Both helper and main function names collide with context variables."""
-        helper = lambda: None  # noqa: E731, F841
-        compute = 123  # noqa: F841
 
-        source = textwrap.dedent("""\
-            def helper(x: int) -> str:
-                return str(x)
-            def compute(n: int) -> str:
-                return helper(n)
-        """)
-        module = ast.parse(source)
-        ctx = get_context()
-        mypy_type_check(module, ctx, [int], str)
+def test_helpers_alongside_target_are_checked():
+    src = (
+        "def helper(y: int) -> int:\n    return y * 2\n"
+        "def count_a(s: str) -> int:\n    return helper(len(s))\n"
+    )
+    assert not _raises(src, _count_char)
 
-    def test_collision_with_class_stub(self):
-        """Function name collides with a runtime class stub in context."""
 
-        class MyModel:
-            value: int
+def test_closure_template_sees_enclosing_local():
+    anchor = _make_counter(5)  # nested ``templ``, whose factory binds helper_const
+    assert not _raises("def f(z: int) -> int:\n    return z + helper_const\n", anchor)
 
-        # Also define a function named MyModel in synthesized code
-        source = textwrap.dedent("""\
-            def MyModel(x: int) -> int:
-                return x * 2
-        """)
-        module = ast.parse(source)
-        ctx = ChainMap({"MyModel": MyModel}, get_context())
-        mypy_type_check(module, ctx, [int], int)
 
-    def test_collision_does_not_mutate_original_ast(self):
-        """Renaming should not modify the original module AST."""
-        count_char = lambda s: s.count("a")  # noqa: E731, F841
+def test_unannotated_container_is_not_a_false_positive():
+    # Heterogeneous list via ``append`` runs fine; with ``--check-untyped-defs``
+    # off mypy skips the unannotated body, so it must not be rejected.
+    src = "def cf(z):\n    acc = []\n    acc.append(1)\n    acc.append('x')\n    return acc\n"
+    assert not _raises(src, _loose)
 
-        source = textwrap.dedent("""\
-            def count_char(s: str) -> int:
-                return s.count('a')
-        """)
-        module = ast.parse(source)
-        original_name = module.body[-1].name
 
-        ctx = get_context()
-        mypy_type_check(module, ctx, [str], int)
+def test_star_import_raises():
+    assert _raises(
+        "from os import *\ndef g(s: str) -> int:\n    return 0\n", _count_char
+    )
 
-        # Original AST must be untouched
-        assert module.body[-1].name == original_name
 
-    def test_helper_reference_updated_after_rename(self):
-        """When a helper function is renamed, calls to it inside other
-        functions are also updated so mypy still sees valid code."""
-        validate = True  # noqa: F841 — collides with helper name
+def test_future_import_raises():
+    assert _raises(
+        "from __future__ import annotations\ndef g(s: str) -> int:\n    return 0\n",
+        _count_char,
+    )
 
-        source = textwrap.dedent("""\
-            def validate(x: int) -> bool:
-                return x > 0
-            def run(x: int) -> bool:
-                return validate(x)
-        """)
-        module = ast.parse(source)
-        ctx = get_context()
-        mypy_type_check(module, ctx, [int], bool)
+
+def test_annotation_collision_with_context_type_raises():
+    # A helper named like the context type ``_Ctx`` and used as a body annotation
+    # is shadowed -> rejected (fail-closed; matches runtime, where the helper
+    # wins). The old rename pass rejected this identically; not a regression.
+    src = "def _Ctx(q):\n    return q\ndef f(z: _Ctx) -> int:\n    return z.x\n"
+    assert _raises(src, _takes_ctx)
+
+
+def test_unrecoverable_source_skips():
+    # An ``exec``-defined function has no recoverable source -> skip, never raise.
+    ns: dict[str, Any] = {}
+    exec("def t(c: str):\n    raise NotImplementedError", ns)
+    assert not _raises(
+        "def count_a(s: str) -> int:\n    return s.count('a')\n", ns["t"]
+    )
+
+
+def test_empty_module_raises():
+    assert _raises("", _count_char)
+
+
+def test_last_statement_not_function_raises():
+    assert _raises("x = 1\n", _count_char)
+
+
+def test_gate_unrelated_module_error_does_not_block(tmp_path):
+    # The anchor's module contains an UNRELATED type error; a correct synthesis
+    # must still pass, because region-scoping ignores out-of-region diagnostics.
+    source = (
+        "from collections.abc import Callable\n\n\n"
+        "def unrelated() -> int:\n    return 'boom'\n\n\n"
+        "def templ(char: str) -> Callable[[str], int]:\n    raise NotImplementedError\n"
+    )
+    anchor = _anchor_from_source(tmp_path, source, "templ", "splice_gate_fixture")
+    assert not _raises("def count_a(s: str) -> int:\n    return s.count('a')\n", anchor)
+
+
+def test_method_templates_all_flavors(tmp_path):
+    # staticmethod/classmethod/instance templates all type-check: the splice leaves
+    # decorators untouched, so the method kind (self/cls semantics) is preserved and
+    # mypy never spuriously demands a missing ``self``. ``template.__default__`` is
+    # the static/classmethod *wrapper* (or the plain function for an instance
+    # method), exactly as ``Template.define`` stores it.
+    source = (
+        "from collections.abc import Callable\n\n\n"
+        "class C:\n"
+        "    @staticmethod\n"
+        "    def sm(char: str) -> Callable[[str], int]:\n"
+        "        raise NotImplementedError\n\n"
+        "    @classmethod\n"
+        "    def cm(cls, char: str) -> Callable[[str], int]:\n"
+        "        raise NotImplementedError\n\n"
+        "    def im(self, char: str) -> Callable[[str], int]:\n"
+        "        raise NotImplementedError\n"
+    )
+    cls = _import_fixture(tmp_path, source, "splice_method_fixture").C
+    good = "def count_a(s: str) -> int:\n    return s.count('a')\n"
+    bad = "def count_a(s: str) -> str:\n    return s\n"
+    for name in ("sm", "cm", "im"):
+        anchor = cls.__dict__[name]  # the wrapper for static/classmethod
+        assert not _raises(good, anchor), f"{name}: correct body should pass"
+        assert _raises(bad, anchor), f"{name}: wrong return type should raise"
+
+
+def test_context_enum_and_dataclass_are_checked(tmp_path):
+    # The PR's headline value (issue #576): an Enum / dataclass in the template's
+    # module is reachable through its real import, where the old quotation
+    # mechanism mishandled such types. A correct generated function passes; a
+    # misuse is still caught -- all without synthesizing any type stub.
+    source = (
+        "import dataclasses\n"
+        "import enum\n"
+        "from collections.abc import Callable\n\n\n"
+        "class Color(enum.Enum):\n"
+        "    RED = 1\n"
+        "    GREEN = 2\n\n\n"
+        "@dataclasses.dataclass\n"
+        "class Point:\n"
+        "    x: int\n"
+        "    y: int\n\n\n"
+        "def templ() -> Callable[[Color, Point], int]:\n"
+        "    raise NotImplementedError\n"
+    )
+    anchor = _anchor_from_source(tmp_path, source, "templ", "splice_enum_fixture")
+    good = (
+        "def f(c: Color, p: Point) -> int:\n    return p.x if c is Color.RED else p.y\n"
+    )
+    bad = "def f(c: Color, p: Point) -> int:\n    return p.nonexistent\n"
+    assert not _raises(good, anchor)
+    assert _raises(bad, anchor)
+
+
+def test_generated_reference_to_unsourced_name_raises():
+    # A name present only at runtime (injected into the env, absent from the
+    # template's source) is unrecoverable -> mypy [name-defined] in-region ->
+    # raise. The fail-closed case-3 / injected-name narrowing.
+    assert _raises(
+        "def count_a(s: str) -> int:\n    return _definitely_not_in_scope(s)\n",
+        _count_char,
+    )
+
+
+def test_linecache_backed_template_is_checked():
+    # REPL/``exec``-defined templates have no file; their source lives in
+    # ``linecache`` (the #690 path). Recovery must read it, so the check runs.
+    import linecache
+
+    fname = "<synthesis:splice-linecache-test>"
+    src = (
+        "from collections.abc import Callable\n\n\n"
+        "def templ(char: str) -> Callable[[str], int]:\n"
+        "    raise NotImplementedError\n"
+    )
+    linecache.cache[fname] = (len(src), None, src.splitlines(keepends=True), fname)
+    ns: dict[str, Any] = {}
+    exec(compile(src, fname, "exec"), ns)
+    anchor = ns["templ"]  # __code__.co_filename == fname; source only in linecache
+    assert not _raises("def count_a(s: str) -> int:\n    return s.count('a')\n", anchor)
+    assert _raises("def count_a(s: str) -> str:\n    return s\n", anchor)
+
+
+# --- End-to-end: decode through ``Encodable[Callable]`` with the anchor in
+# the (result) decode context. The argument path has no anchor and is skipped.
+
+
+def test_decode_with_anchor_typechecks_and_runs():
+    with (
+        handler(UnsafeEvalProvider()),
+        handler({type_check_anchor: lambda: _count_char}),
+    ):
+        ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
+        fn = ta.validate_python(
+            SynthesizedFunction(
+                module_code="def count_a(s: str) -> int:\n    return s.count('a')"
+            ),
+            context={},
+        )
+        assert fn("banana") == 3
+
+
+def test_decode_with_anchor_rejects_bad_code():
+    with (
+        handler(UnsafeEvalProvider()),
+        handler({type_check_anchor: lambda: _count_char}),
+    ):
+        ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
+        with pytest.raises(Exception):
+            ta.validate_python(
+                SynthesizedFunction(
+                    module_code="def count_a(s: str) -> str:\n    return s"
+                ),
+                context={},
+            )
+
+
+def test_decode_without_anchor_skips_typecheck():
+    # Argument-path decoding carries no anchor -> the type check is skipped, so
+    # even ill-typed code decodes (it is out of scope for this stage).
+    with handler(UnsafeEvalProvider()):
+        ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
+        fn = ta.validate_python(
+            SynthesizedFunction(
+                module_code="def count_a(s: str) -> str:\n    return s"
+            ),
+            context={},
+        )
+        assert callable(fn)
 
 
 # ============================================================================

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -24,8 +24,9 @@ from effectful.handlers.llm.evaluation import (
     ReplSession,
     RestrictedEvalProvider,
     UnsafeEvalProvider,
-    mypy_type_check,
     scan_non_nestable,
+    splice_into_source,
+    type_check,
 )
 from effectful.handlers.llm.evaluation import compile as compile_op
 from effectful.handlers.llm.evaluation import exec as exec_op
@@ -33,7 +34,7 @@ from effectful.handlers.llm.evaluation import parse as parse_op
 from effectful.ops.semantics import handler
 
 # ============================================================================
-# Splice-based type checking (mypy_type_check)
+# Splice-based type checking (splice_into_source + type_check)
 #
 # The type checker splices LLM-generated code into the real source of the
 # Template's module -- at the template function's own (possibly nested)
@@ -73,8 +74,13 @@ def _make_counter(helper_const: int) -> Callable[[int], int]:
 
 
 def _raises(generated_src: str, anchor: Any) -> bool:
+    # Splice then type-check as separate steps (the decode path's shape), under a
+    # provider so the `type_check` op resolves.
     try:
-        mypy_type_check(ast.parse(generated_src), anchor)
+        with handler(UnsafeEvalProvider()):
+            spliced = splice_into_source(ast.parse(generated_src), anchor)
+            if spliced is not None:
+                type_check(*spliced)
         return False
     except TypeError:
         return True

--- a/tests/test_handlers_llm_evaluation.py
+++ b/tests/test_handlers_llm_evaluation.py
@@ -15,14 +15,17 @@ import pydantic
 import pytest
 from RestrictedPython import RestrictingNodeTransformer
 
-from effectful.handlers.llm.encoding import Encodable, SynthesizedFunction
+from effectful.handlers.llm.encoding import (
+    TYPE_CHECK_ANCHOR_KEY,
+    Encodable,
+    SynthesizedFunction,
+)
 from effectful.handlers.llm.evaluation import (
     ReplSession,
     RestrictedEvalProvider,
     UnsafeEvalProvider,
     mypy_type_check,
     scan_non_nestable,
-    type_check_anchor,
 )
 from effectful.handlers.llm.evaluation import compile as compile_op
 from effectful.handlers.llm.evaluation import exec as exec_op
@@ -274,32 +277,26 @@ def test_linecache_backed_template_is_checked():
 
 
 def test_decode_with_anchor_typechecks_and_runs():
-    with (
-        handler(UnsafeEvalProvider()),
-        handler({type_check_anchor: lambda: _count_char}),
-    ):
+    with handler(UnsafeEvalProvider()):
         ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
         fn = ta.validate_python(
             SynthesizedFunction(
                 module_code="def count_a(s: str) -> int:\n    return s.count('a')"
             ),
-            context={},
+            context={TYPE_CHECK_ANCHOR_KEY: _count_char},
         )
         assert fn("banana") == 3
 
 
 def test_decode_with_anchor_rejects_bad_code():
-    with (
-        handler(UnsafeEvalProvider()),
-        handler({type_check_anchor: lambda: _count_char}),
-    ):
+    with handler(UnsafeEvalProvider()):
         ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
         with pytest.raises(Exception):
             ta.validate_python(
                 SynthesizedFunction(
                     module_code="def count_a(s: str) -> str:\n    return s"
                 ),
-                context={},
+                context={TYPE_CHECK_ANCHOR_KEY: _count_char},
             )
 
 
@@ -321,17 +318,14 @@ def test_decode_with_anchor_rejects_non_nestable():
     # The non-nestable scan is a decode-time precondition of the splice: with an
     # anchor, a star import (illegal once nested in the Template body) is rejected
     # before type checking.
-    with (
-        handler(UnsafeEvalProvider()),
-        handler({type_check_anchor: lambda: _count_char}),
-    ):
+    with handler(UnsafeEvalProvider()):
         ta = pydantic.TypeAdapter(Encodable[Callable[[str], int]])
         with pytest.raises(Exception):
             ta.validate_python(
                 SynthesizedFunction(
                     module_code="from os import *\ndef count_a(s: str) -> int:\n    return 0"
                 ),
-                context={},
+                context={TYPE_CHECK_ANCHOR_KEY: _count_char},
             )
 
 

--- a/tests/test_handlers_llm_provider.py
+++ b/tests/test_handlers_llm_provider.py
@@ -1189,6 +1189,20 @@ def synthesize_three_param_func() -> Callable[[int, int, int], int]:
     raise NotHandled
 
 
+class _MethodSynthesizer:
+    """A class whose *method* is a Template returning a Callable, so its synthesis
+    anchor is a bound-method ``__default__`` (eb8680: bound-method Templates)."""
+
+    @Template.define
+    def make_adder(self) -> Callable[[int, int], int]:
+        """Generate a Python function that adds two integers together.
+
+        The function should take two integer parameters and return their sum.
+        Return a code block whose last definition is the function.
+        """
+        raise NotHandled
+
+
 class TestCallableSynthesis:
     """Tests for synthesizing callable functions via LLM."""
 
@@ -1204,6 +1218,23 @@ class TestCallableSynthesis:
             assert callable(add_func)
             assert add_func(2, 3) == 5
             assert add_func(0, 0) == 0
+            assert add_func(-1, 1) == 0
+            assert add_func(100, 200) == 300
+
+    def test_synthesize_via_bound_method(self, request):
+        """A *method* Template synthesizes a callable end-to-end -- exercising the
+        bound-method `__default__` anchor through the real splice type-check
+        (RetryLLMHandler lets the model recover from a malformed first draft)."""
+        with (
+            handler(ReplayLiteLLMProvider(request, model=EFFECTFUL_LLM_MODEL)),
+            handler(RetryLLMHandler(stop=tenacity.stop_after_attempt(4))),
+            handler(UnsafeEvalProvider()),
+            handler(LimitLLMCallsHandler(max_calls=4)),
+        ):
+            add_func = _MethodSynthesizer().make_adder()
+
+            assert callable(add_func)
+            assert add_func(2, 3) == 5
             assert add_func(-1, 1) == 0
             assert add_func(100, 200) == 300
 


### PR DESCRIPTION
Closes #696. Addresses #577, #576.

Currently, for synthesis, we are reconstructing a `Template`'s lexical context as synthetic type stubs. This is brittle and likely unsound.

This PR splices the generated code into the Template module, and type checks the whole file. This come with a few changes


1. `mypy_type_check` now parameterized with `generated` (code) and `anchor` (the Template). The anchor is used to recover its module source, 

Note, in practice there is a few more tweaks: 
-  Mypy runs on the whole module, but only diagnostics inside the spliced span are raised, so an unrelated pre-existing error elsewhere in the module can't fail synthesis. 
- Non-nestable constructs (`from x import *`, `__future__`) are caught by an explicit AST pre-scan, since mypy silently accepts a nested star-import; a fatal mypy error (exit ≥ 2) is surfaced rather than silently passed; unrecoverable source (no file, no `linecache`) is skipped with a logged reason.

2. **Name collisions (#542)** are now handled structurally: the generated def is a function-body local that *shadows* a colliding context name rather than redefining it at module level, so the AST-rename pass is gone. The whole quotation layer is deleted — `type_to_ast`, `signature_to_ast`, `collect_variable_declarations`, `collect_runtime_type_stubs`, `collect_imports`, and `_RenameTransformer`/`_generate_unique_name` (net +510 / −1991).

3. **Behavior change.** Runtime-only / local types, and names with no lexical presence at the splice point, now raise instead of being (partially, fakily) stubbed. The check is sound on annotated generated code; unannotated bodies are checked at their signature only (`--check-untyped-defs` is deliberately off — it rejects runnable heterogeneous-container code).

**Tests.** 
1. Deleted the quotation-internals unit tests; kept the security/REPL tests
2. Added behavior tests asserting raise-or-not (not mypy text): #542 collision shadowing, the gate (unrelated module error doesn't block a correct synthesis), closures (enclosing locals in scope), method/static/class templates, `Enum` + dataclass context (#576), injected-name, non-nestable, `linecache`-backed recovery (the #690 path), annotation-collision, and end-to-end decode through `Encodable[Callable]`. `mypy effectful/handlers/llm/` clean, `ruff` clean, full LLM suite green.
