### PR TITLE
Detect non-parameterizable Collection subclasses

### DIFF
--- a/effectful/internals/unification.py
+++ b/effectful/internals/unification.py
@@ -1079,17 +1079,24 @@ def _(value: collections.abc.Mapping):
 
 @nested_type.register
 def _(value: collections.abc.Collection):
-    if len(value) == 0:
-        return Box(type(value))
-    elif len(value) == 1:
+    typ = canonicalize(type(value))
+    if not (
+        isinstance(typ, type) and hasattr(typ, "__class_getitem__")
+    ):  # not a parameterizable type
+        return Box(typ)
+
+    l = len(value)
+    if l == 0:
+        return Box(typ)
+    elif l == 1:
         vtyp = nested_type(next(iter(value))).value
-        return Box(canonicalize(type(value))[vtyp])  # type: ignore
+        return Box(typ[vtyp])  # type: ignore
     else:
         valtyp = functools.reduce(operator.or_, [nested_type(x).value for x in value])
         if isinstance(valtyp, UnionType):
-            return Box(type(value))
+            return Box(typ)
         else:
-            return Box(canonicalize(type(value))[valtyp])  # type: ignore
+            return Box(typ[valtyp])  # type: ignore
 
 
 @nested_type.register

--- a/effectful/internals/unification.py
+++ b/effectful/internals/unification.py
@@ -911,11 +911,11 @@ def nested_type(value) -> Box[TypeExpression]:
 
         # Empty collections return their base type
         >>> nested_type([]).value
-        <class 'list'>
+        <class 'collections.abc.MutableSequence'>
         >>> nested_type({}).value
         <class 'dict'>
         >>> nested_type(set()).value
-        <class 'set'>
+        <class 'collections.abc.MutableSet'>
 
         # Sequences become Sequence[element_type]
         >>> nested_type([1, 2, 3]).value

--- a/tests/test_internals_unification.py
+++ b/tests/test_internals_unification.py
@@ -5,6 +5,8 @@ import inspect
 import typing
 from typing import Literal
 
+import jax
+import jax.numpy as jnp
 import pytest
 
 from effectful.internals.unification import (
@@ -781,6 +783,9 @@ def test_infer_return_type_failure(
         # Other built-in types
         (range(5), type(range(5))),
         (slice(1, 10), type(slice(1, 10))),
+        # jax arrays
+        (jnp.array(0.0), jax.Array),
+        (jnp.array([1, 2, 3]), jax.Array),
     ],
 )
 def test_nested_type(value, expected):


### PR DESCRIPTION
As of jax 0.10, jax arrays are instances of `collections.abc.Collection`. However, they don't implement `len` in all cases (scalar arrays). This breaks the logic in `nested_type` (#705). This PR sidesteps the issue by detecting non-parameterizable generic types in the `Collection` case and refusing to introspect the value in the non-parameterized case.

Unfortunately, this is probably only the first issue with `jax.Array` and singledispatch. Any singledispatch that registers a `Collection` case will need to handle jax arrays as well. We can't just override the `Collection` case in singledispatch functions by registering `jax.Array` because `jax.Array` doesn't take precedence---both are abstract base classes, and singledispatch falls back to registration order when deciding between them.