### PR TITLE
Pin litellm off the wheel-less 1.92.0 (fixes CI on Python 3.14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ numpyro = [
   "jax<0.10"
 ]
 llm = [
-  "litellm",
+  # 1.92.0 ships no wheel, so it builds from sdist; on Python 3.14 that build pulls
+  # pyo3-ffi 0.23.5, which doesn't support 3.14, so `uv sync` fails the whole matrix.
+  "litellm!=1.92.0",
   "tenacity",
   "mypy",
   "autoflake",


### PR DESCRIPTION
The Python 3.14 matrix job can't install the latest litellm `1.92.0`, so all CIs should fail on all branches.

litellm 1.92.0 publishes no wheel, so `uv` builds it from sdist. On 3.14, that build compiles `pyo3-ffi 0.23.5`, which doesn't support 3.14, so `uv sync` fails at install; fail-fast then cancels the rest of the matrix, so every job goes red before a test runs.

I exclude 1.92.0, so a wheel'd release resolves. Kept the pin in pyproject (not committing uv.lock).