### PR TITLE
Make `__signature__` a cached property

### DIFF
--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -83,7 +83,7 @@ class Operation[**Q, V]:
         self.__default__ = default
         self.__name__ = name or default.__name__
 
-    @property
+    @functools.cached_property
     def __signature__(self):
         # Resolve forward references (e.g. -> "MyClass") using the
         # default function's __globals__.  This handles module-level

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -80,11 +80,19 @@ class Operation[**Q, V]:
 
     def __init__(self, default: Callable[Q, V], name: str | None = None):
         functools.update_wrapper(self, default)
+        # update_wrapper copies the wrapped callable's __dict__. Do not retain a
+        # signature cached by another Operation, since `default` may now be a
+        # bound version of that operation.
+        self.__dict__.pop("_signature", None)
         self.__default__ = default
         self.__name__ = name or default.__name__
 
-    @functools.cached_property
+    @property
     def __signature__(self):
+        return self._signature
+
+    @functools.cached_property
+    def _signature(self):
         # Resolve forward references (e.g. -> "MyClass") using the
         # default function's __globals__.  This handles module-level
         # forward refs; local forward refs will raise NameError.

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -25,7 +25,7 @@ from effectful.ops.syntax import (
     syntactic_eq,
     trace,
 )
-from effectful.ops.types import NotHandled, Operation, Term
+from effectful.ops.types import Expr, NotHandled, Operation, Term
 
 logger = logging.getLogger(__name__)
 
@@ -1263,3 +1263,46 @@ def test_defop_forward_ref_mutual_recursion():
     exp_term = tangent.exp()
     assert isinstance(exp_term, Term)
     assert typeof(exp_term) is _Coordinate
+
+
+def test_bench_term_construction(benchmark):
+    """Benchmark polymorphic type checking during term construction."""
+
+    @defop
+    def _benchmark_identity[T](value: T) -> T:
+        raise NotHandled
+
+    @defop
+    def _benchmark_keep_left[T, U](value: T, metadata: U) -> T:
+        raise NotHandled
+
+    @defop
+    def _benchmark_lookup[K, V](values: Mapping[K, V], key: K) -> V:
+        raise NotHandled
+
+    @defop
+    def _benchmark_first[T](values: collections.abc.Sequence[T]) -> T:
+        raise NotHandled
+
+    _BENCHMARK_OPERATIONS: tuple[Callable[[Expr[int], int], Expr[int]], ...] = (
+        lambda value, _: _benchmark_identity(value),
+        lambda value, index: _benchmark_keep_left(value, ("node", index)),
+        lambda value, _: _benchmark_lookup({"value": value}, "value"),
+        lambda value, _: _benchmark_first([value]),
+    )
+
+    def _make_benchmark_term(size: int) -> Term[int]:
+        """Construct a linear term containing exactly ``size`` applications."""
+        if size < 1:
+            raise ValueError("term size must be positive")
+
+        value: Expr[int] = 0
+        for index in range(size):
+            operation = _BENCHMARK_OPERATIONS[index % len(_BENCHMARK_OPERATIONS)]
+            value = operation(value, index)
+
+        assert isinstance(value, Term)
+        return value
+
+    result = benchmark(_make_benchmark_term, 25)
+    assert isinstance(result, Term)


### PR DESCRIPTION
Before:

```
----------------------------------------------------- benchmark: 1 tests -----------------------------------------------------
Name (time in ms)                     Min       Max      Mean   StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------
test_bench_term_construction     106.4417  171.0169  114.0333  21.3720  107.0401  0.6609       1;1  8.7694       9           1
------------------------------------------------------------------------------------------------------------------------------
```

After:

```
---------------------------------------------------- benchmark: 1 tests ----------------------------------------------------
Name (time in ms)                    Min       Max     Mean   StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------
test_bench_term_construction     60.1234  127.2249  65.1138  16.5825  60.9053  0.8398       1;2  15.3577      16           1
----------------------------------------------------------------------------------------------------------------------------
```