### PR TITLE
Fix the Agent's  Tool Name advertisement

### DIFF
--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -705,6 +705,7 @@ def _serialize_tool(
     response_format = litellm.utils.type_to_response_format_param(sig_model)
     assert response_format is not None
     assert value.__default__.__doc__ is not None
+    # Advertise under the context key, since decode (`_validate_tool`) resolves the call by that name.
     tool_name = value.__name__
     context = info.context
     if isinstance(context, Mapping):

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -705,19 +705,6 @@ def _serialize_tool(
     response_format = litellm.utils.type_to_response_format_param(sig_model)
     assert response_format is not None
     assert value.__default__.__doc__ is not None
-    # Advertise the tool under the name it is keyed by in the serialization
-    # context, because tool-call decoding resolves the call by that same name
-    # (`_validate_tool`); advertising value.__name__ ("remember") would make an
-    # Agent method tool (collected as "self__remember") undecodable.
-    #
-    # The context is a name->tool mapping whose shape depends on the caller, so
-    # both the identity scan and the `__name__` default are load-bearing:
-    #   * a single {k: t} when advertising one tool (`call_assistant`);
-    #   * the full lexical env when a tool is reached while serializing a
-    #     prompt-field object (e.g. a Tool inside a list/dataclass field passed
-    #     to `call_user`), so the scan finds *this* tool's key among many; and
-    #   * empty/absent for standalone serialization, where the plain __name__ is
-    #     correct (a non-method tool is keyed by its own __name__ anyway).
     tool_name = value.__name__
     context = info.context
     if isinstance(context, Mapping):

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -705,10 +705,18 @@ def _serialize_tool(
     response_format = litellm.utils.type_to_response_format_param(sig_model)
     assert response_format is not None
     assert value.__default__.__doc__ is not None
-    # Advertise the tool under the same name it is keyed by in the tool
-    # context (e.g. an Agent method tool is collected as "self__remember").
-    # Tool-call decoding looks the name up in that context, so advertising
-    # value.__name__ ("remember") would make every method tool undecodable.
+    # Advertise the tool under the name it is keyed by in the serialization
+    # context, because tool-call decoding resolves the call by that same name
+    # (`_validate_tool`); advertising value.__name__ ("remember") would make an
+    # Agent method tool (collected as "self__remember") undecodable.
+    #
+    # The context is a name->tool mapping whose shape depends on the caller, so
+    # both the identity scan and the `__name__` default are load-bearing:
+    #   * a single {k: t} when advertising one tool (`call_assistant`);
+    #   * the full lexical env when a tool is embedded in a prompt field, so the
+    #     scan is needed to find *this* tool's key among many; and
+    #   * empty/absent for standalone serialization, where the plain __name__ is
+    #     correct (a non-method tool is keyed by its own __name__ anyway).
     tool_name = value.__name__
     context = info.context
     if isinstance(context, Mapping):

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -713,8 +713,9 @@ def _serialize_tool(
     # The context is a name->tool mapping whose shape depends on the caller, so
     # both the identity scan and the `__name__` default are load-bearing:
     #   * a single {k: t} when advertising one tool (`call_assistant`);
-    #   * the full lexical env when a tool is embedded in a prompt field, so the
-    #     scan is needed to find *this* tool's key among many; and
+    #   * the full lexical env when a tool is reached while serializing a
+    #     prompt-field object (e.g. a Tool inside a list/dataclass field passed
+    #     to `call_user`), so the scan finds *this* tool's key among many; and
     #   * empty/absent for standalone serialization, where the plain __name__ is
     #     correct (a non-method tool is keyed by its own __name__ anyway).
     tool_name = value.__name__

--- a/effectful/handlers/llm/encoding.py
+++ b/effectful/handlers/llm/encoding.py
@@ -690,7 +690,9 @@ def _validate_tool(
         raise NotImplementedError(f"Unknown tool: {value['function']['name']}") from e
 
 
-def _serialize_tool(value: Tool) -> ChatCompletionToolParam:
+def _serialize_tool(
+    value: Tool, info: pydantic.SerializationInfo
+) -> ChatCompletionToolParam:
     fields: dict[str, Any] = {
         name: TypeToPydanticType().evaluate(param.annotation)
         for name, param in inspect.signature(value).parameters.items()
@@ -703,11 +705,22 @@ def _serialize_tool(value: Tool) -> ChatCompletionToolParam:
     response_format = litellm.utils.type_to_response_format_param(sig_model)
     assert response_format is not None
     assert value.__default__.__doc__ is not None
+    # Advertise the tool under the same name it is keyed by in the tool
+    # context (e.g. an Agent method tool is collected as "self__remember").
+    # Tool-call decoding looks the name up in that context, so advertising
+    # value.__name__ ("remember") would make every method tool undecodable.
+    tool_name = value.__name__
+    context = info.context
+    if isinstance(context, Mapping):
+        for key, tool in context.items():
+            if tool is value:
+                tool_name = key
+                break
     return pydantic.TypeAdapter(ChatCompletionToolParam).validate_python(
         {
             "type": "function",
             "function": {
-                "name": value.__name__,
+                "name": tool_name,
                 "description": textwrap.dedent(value.__default__.__doc__),
                 "parameters": response_format["json_schema"]["schema"],
                 "strict": True,

--- a/tests/test_handlers_llm_template.py
+++ b/tests/test_handlers_llm_template.py
@@ -5,6 +5,7 @@ import dataclasses
 import inspect
 from dataclasses import dataclass
 
+import pydantic
 import pytest
 from litellm import ModelResponse
 
@@ -14,8 +15,10 @@ from effectful.handlers.llm.completions import (
     LiteLLMProvider,
     RetryLLMHandler,
     call_user,
+    collect_tools,
     completion,
 )
+from effectful.handlers.llm.encoding import DecodedToolCall, Encodable
 from effectful.ops.semantics import handler
 from effectful.ops.syntax import ObjectInterpretation, implements
 from effectful.ops.types import NotHandled
@@ -239,6 +242,37 @@ class _DesignerAgent(Agent):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_agent_method_tool_advertised_name_matches_decode_key():
+    """An Agent method tool is collected under a qualified key ("self__nested_tool") that
+    differs from its own `__name__` ("nested_tool"). It must be *advertised* to the LLM
+    under that key, because tool-call decoding resolves the call by the advertised name --
+    otherwise every method tool is undecodable. This is the serialize->advertise->decode
+    round-trip, no LLM required."""
+    agent = _DesignerAgent()
+    tools = dict(collect_tools({"self": agent}))
+    key = "self__nested_tool"
+    tool = tools[key]
+    assert tool.__name__ == "nested_tool"  # own name differs from the context key
+
+    # Serialize exactly as `call_assistant` advertises it: single-entry {key: tool} context.
+    spec = pydantic.TypeAdapter(Encodable[type(tool)]).dump_python(
+        tool, mode="json", context={key: tool}
+    )
+    advertised = spec["function"]["name"]
+    assert advertised == key  # advertised under the context key, not __name__
+
+    # A tool call using the advertised name decodes back to the same tool object.
+    raw_tool_call = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": advertised, "arguments": '{"payload": "x"}'},
+    }
+    decoded = pydantic.TypeAdapter(Encodable[DecodedToolCall]).validate_python(
+        raw_tool_call, context=tools
+    )
+    assert decoded.tool is tool
 
 
 class TestAgentHistoryAccumulation:
@@ -1539,15 +1573,11 @@ import typing
 from pathlib import Path
 from types import CodeType
 
-import pydantic
-
 from effectful.handlers.llm.completions import (
     LexicalReaders,
     PythonRepl,
     _LexicalVariableTool,
-    collect_tools,
 )
-from effectful.handlers.llm.encoding import Encodable
 from effectful.handlers.llm.evaluation import UnsafeEvalProvider
 
 


### PR DESCRIPTION
`_serialize_tool` currently advertise bare/non namespace name, for example, `remember` instead of `self__remember`. This cause confusion in models. This PR fixes it.

Also added corresponding test.