### PR TITLE
Add tests for `syntactic_eq` and fix bugs

### DIFF
--- a/effectful/handlers/torch.py
+++ b/effectful/handlers/torch.py
@@ -724,4 +724,8 @@ def vmap(func, *args, **kwargs):
 
 @syntactic_eq.register
 def _(x: torch.Tensor, other) -> bool:
-    return isinstance(other, torch.Tensor) and bool((x == other).all())
+    return (
+        isinstance(other, torch.Tensor)
+        and x.shape == other.shape
+        and bool((x == other).all())
+    )

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -781,17 +781,47 @@ next_ = _IteratorTerm.__next__
 def syntactic_eq(
     __dispatch: Callable[[type], Callable[[Any, Any], bool]], x, other
 ) -> bool:
-    """Syntactic equality, ignoring the interpretation of the terms.
+    """Compare values structurally, without interpreting any terms they contain.
 
-    :param x: A term.
-    :param other: Another term.
-    :returns: ``True`` if the terms are syntactically equal and ``False`` otherwise.
+    Two :class:`Term` objects are syntactically equal when they use the same
+    (identity-compared) operation, have recursively equal positional arguments in
+    the same order, and have recursively equal keyword arguments. Keyword insertion
+    order is ignored.
+
+    Dataclass instances and named tuples are compared recursively by field and must
+    have the same concrete type. Other mappings are compared recursively by key and
+    value without regard to mapping type or iteration order. Other sequences are
+    compared recursively in order without requiring the same sequence type; strings
+    and bytes are treated as atomic values. Values not covered by one of these cases
+    use their ordinary Python ``==`` behavior.
+
+    Registered backend values follow the same structural intent. In particular,
+    JAX arrays and PyTorch tensors compare by shape and values; dtype is not part of
+    syntactic equality, and NaNs compare unequal as they do with ordinary ``==``.
+
+    No operation defaults or installed interpretations are invoked during the
+    comparison.
+
+    >>> x = defop(int, name="x")
+    >>> syntactic_eq(x() + 1, x() + 1)
+    True
+    >>> y = defop(int, name="y")
+    >>> syntactic_eq(x() + 1, y() + 1)
+    False
+    >>> syntactic_eq({"items": [x(), 2]}, {"items": (x(), 2)})
+    True
+
+    :param x: A value, possibly containing terms.
+    :param other: Another value.
+    :returns: ``True`` if the values are syntactically equal and ``False`` otherwise.
     """
     if (
         dataclasses.is_dataclass(x)
         and not isinstance(x, type)
+        and not isinstance(x, Term)
         and dataclasses.is_dataclass(other)
         and not isinstance(other, type)
+        and not isinstance(other, Term)
     ):
         return type(x) == type(other) and syntactic_eq(
             {field.name: getattr(x, field.name) for field in dataclasses.fields(x)},
@@ -830,13 +860,21 @@ def _(x: collections.abc.Mapping, other) -> bool:
 
 @syntactic_eq.register
 def _(x: collections.abc.Sequence, other) -> bool:
-    if (
+    x_fields = getattr(x, "_fields", ())
+    other_fields = getattr(other, "_fields", ())
+    x_is_namedtuple = (
         isinstance(x, tuple)
         and hasattr(x, "_fields")
-        and all(hasattr(x, f) for f in x._fields)
-    ):
+        and all(hasattr(x, f) for f in x_fields)
+    )
+    other_is_namedtuple = (
+        isinstance(other, tuple)
+        and hasattr(other, "_fields")
+        and all(hasattr(other, f) for f in other_fields)
+    )
+    if x_is_namedtuple or other_is_namedtuple:
         return type(other) == type(x) and all(
-            syntactic_eq(getattr(x, f), getattr(other, f)) for f in x._fields
+            syntactic_eq(getattr(x, f), getattr(other, f)) for f in x_fields
         )
     else:
         return (

--- a/tests/test_handlers_jax.py
+++ b/tests/test_handlers_jax.py
@@ -370,12 +370,23 @@ def test_jax_array():
 
 
 def test_array_eq():
-    x = defop(jax.Array)()
-    y = jnp.array([1, 2, 3])
-    assert syntactic_eq(x + y, x + y)
+    integer = jnp.array([[1, 2], [3, 4]])
+    equal = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    unequal = jnp.array([[1, 2], [3, 5]])
 
-    z = jnp.array([1, 2, 3, 4])
-    assert not syntactic_eq(x + y, x + z)
+    assert syntactic_eq(integer, equal)
+    assert syntactic_eq(equal, integer)
+    assert not syntactic_eq(integer, unequal)
+    assert not syntactic_eq(integer, jnp.array([1, 2, 3, 4]))
+    assert not syntactic_eq(jnp.empty((0,)), jnp.empty((0, 2)))
+    assert not syntactic_eq(integer, [[1, 2], [3, 4]])
+    assert not syntactic_eq(jnp.array([float("nan")]), jnp.array([float("nan")]))
+    assert syntactic_eq({"array": integer}, {"array": equal})
+
+    x = defop(jax.Array)()
+    assert syntactic_eq(x + integer, x + equal)
+    assert not syntactic_eq(x + integer, x + unequal)
+    assert not syntactic_eq(x + integer, x + jnp.array([1, 2, 3, 4]))
 
 
 def test_jax_rotation():

--- a/tests/test_handlers_torch.py
+++ b/tests/test_handlers_torch.py
@@ -633,6 +633,20 @@ def test_tensor_iter():
 
 
 def test_tensor_eq():
+    integer = torch.tensor([[1, 2], [3, 4]])
+    equal = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    unequal = torch.tensor([[1, 2], [3, 5]])
+
+    assert syntactic_eq(integer, equal)
+    assert syntactic_eq(equal, integer)
+    assert not syntactic_eq(integer, unequal)
+    assert not syntactic_eq(integer, torch.tensor([1, 2, 3, 4]))
+    assert not syntactic_eq(torch.empty(0), torch.empty(0, 2))
+    assert not syntactic_eq(integer, [[1, 2], [3, 4]])
+    assert not syntactic_eq(torch.tensor([torch.nan]), torch.tensor([torch.nan]))
+    assert syntactic_eq({"tensor": integer}, {"tensor": equal})
+
     x = defop(torch.Tensor)()
-    y = torch.tensor([1, 2, 3])
-    assert syntactic_eq(x + y, x + y)
+    assert syntactic_eq(x + integer, x + equal)
+    assert not syntactic_eq(x + integer, x + unequal)
+    assert not syntactic_eq(x + integer, x + torch.tensor([1, 2, 3, 4]))

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -958,22 +958,6 @@ def test_syntactic_eq_term_and_nonterm_is_symmetric(concrete) -> None:
     assert not syntactic_eq(concrete, term)
 
 
-def test_syntactic_eq_does_not_interpret_terms() -> None:
-    calls = 0
-
-    @defop
-    def counted() -> int:
-        nonlocal calls
-        calls += 1
-        raise NotHandled
-
-    term = counted() + 1
-    calls_after_construction = calls
-    with handler({counted: lambda: pytest.fail("syntactic_eq interpreted a term")}):
-        assert syntactic_eq(term, term)
-    assert calls == calls_after_construction
-
-
 def test_syntactic_eq_dataclasses() -> None:
     @dataclasses.dataclass
     class Inner:

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -875,17 +875,184 @@ def test_evaluate_2():
         assert evaluate(t) == 3
 
 
-def test_syntactic_eq() -> None:
-    l = defop(list[int])()
-    assert syntactic_eq("test", "test")
-    assert syntactic_eq([1, 2, 3], [1, 2, 3])
-    assert syntactic_eq(set([1, 2, 3]), set([1, 2, 3]))
-    assert syntactic_eq({"a": 1, "b": 2}, {"b": 2, "a": 1})
-    assert syntactic_eq(l, l)
-    assert not syntactic_eq(1, defop(int)())
-    assert not syntactic_eq(defop(int)(), 1)
-    assert not syntactic_eq([], l)
-    assert not syntactic_eq(1, [])
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        (None, None, True),
+        ("test", "test", True),
+        ("test", "other", False),
+        (b"test", b"test", True),
+        (b"test", b"other", False),
+        (1, 1, True),
+        (1, 2, False),
+        ({1, 2, 3}, {3, 2, 1}, True),
+        ({1, 2}, {1, 3}, False),
+    ],
+)
+def test_syntactic_eq_atomic_values(left, right, expected: bool) -> None:
+    assert syntactic_eq(left, right) is expected
+
+
+def test_syntactic_eq_fallback_objects() -> None:
+    value = object()
+    assert syntactic_eq(value, value)
+    assert not syntactic_eq(object(), object())
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ([], (), True),
+        ([1, 2, 3], (1, 2, 3), True),
+        ([1, [2, 3]], (1, (2, 3)), True),
+        ([1, 2], [1, 2, 3], False),
+        ([1, 2], [2, 1], False),
+        ([1, [2]], [1, [3]], False),
+        ([], 1, False),
+    ],
+)
+def test_syntactic_eq_sequences(left, right, expected: bool) -> None:
+    assert syntactic_eq(left, right) is expected
+    assert syntactic_eq(right, left) is expected
+
+
+def test_syntactic_eq_mappings() -> None:
+    x = defop(int, name="x")
+    left = {"a": [1, x()], "b": {"nested": 2}}
+    reordered = collections.UserDict({"b": {"nested": 2}, "a": (1, x())})
+
+    assert syntactic_eq(left, reordered)
+    assert syntactic_eq(reordered, left)
+    assert not syntactic_eq(left, {"a": [1, x()]})
+    assert not syntactic_eq(left, {**left, "extra": 3})
+    assert not syntactic_eq(left, {"a": [1, x()], "b": {"nested": 4}})
+
+
+def test_syntactic_eq_terms() -> None:
+    @defop
+    def variadic(*args: object, **kwargs: object) -> object:
+        raise NotHandled
+
+    @defop
+    def another_variadic(*args: object, **kwargs: object) -> object:
+        raise NotHandled
+
+    x = defop(int, name="x")
+    equal = variadic(x(), [1, {"nested": x()}], left=2, right=[3])
+
+    assert syntactic_eq(equal, variadic(x(), [1, {"nested": x()}], right=[3], left=2))
+    assert not syntactic_eq(
+        equal, another_variadic(x(), [1, {"nested": x()}], left=2, right=[3])
+    )
+    assert not syntactic_eq(variadic(1), variadic(1, 2))
+    assert not syntactic_eq(variadic(1, 2), variadic(2, 1))
+    assert not syntactic_eq(variadic(value=1), variadic(other=1))
+    assert not syntactic_eq(variadic(value=1), variadic(value=2))
+    assert not syntactic_eq(variadic(x()), variadic(defop(int, name="x")()))
+
+
+@pytest.mark.parametrize("concrete", [1, [], {}])
+def test_syntactic_eq_term_and_nonterm_is_symmetric(concrete) -> None:
+    term = defop(int, name="x")()
+    assert not syntactic_eq(term, concrete)
+    assert not syntactic_eq(concrete, term)
+
+
+def test_syntactic_eq_does_not_interpret_terms() -> None:
+    calls = 0
+
+    @defop
+    def counted() -> int:
+        nonlocal calls
+        calls += 1
+        raise NotHandled
+
+    term = counted() + 1
+    calls_after_construction = calls
+    with handler({counted: lambda: pytest.fail("syntactic_eq interpreted a term")}):
+        assert syntactic_eq(term, term)
+    assert calls == calls_after_construction
+
+
+def test_syntactic_eq_dataclasses() -> None:
+    @dataclasses.dataclass
+    class Inner:
+        value: object
+
+    @dataclasses.dataclass
+    class Outer:
+        inner: Inner
+        items: object
+
+    @dataclasses.dataclass
+    class OtherOuter:
+        inner: Inner
+        items: object
+
+    x = defop(int, name="x")
+    left = Outer(Inner(x()), [1, {"value": x()}])
+    equal = Outer(Inner(x()), (1, {"value": x()}))
+
+    assert syntactic_eq(left, equal)
+    assert not syntactic_eq(left, Outer(Inner(x()), [1, {"value": 2}]))
+    assert not syntactic_eq(left, OtherOuter(Inner(x()), [1, {"value": x()}]))
+    as_mapping = {"inner": left.inner, "items": left.items}
+    assert not syntactic_eq(left, as_mapping)
+    assert not syntactic_eq(as_mapping, left)
+    assert syntactic_eq(Outer, Outer)
+    assert not syntactic_eq(Outer, OtherOuter)
+
+
+def test_syntactic_eq_dataclass_terms() -> None:
+    @dataclasses.dataclass
+    class Value:
+        x: int
+
+    @defop
+    def value(x: int) -> Value:
+        raise NotHandled
+
+    assert syntactic_eq(value(1), value(1))
+    assert not syntactic_eq(value(1), value(2))
+
+
+def test_syntactic_eq_named_tuples() -> None:
+    class Pair(typing.NamedTuple):
+        left: object
+        right: object
+
+    class OtherPair(typing.NamedTuple):
+        left: object
+        right: object
+
+    x = defop(int, name="x")
+    pair = Pair(x(), [1, 2])
+
+    assert syntactic_eq(pair, Pair(x(), (1, 2)))
+    assert not syntactic_eq(pair, Pair(x(), [1, 3]))
+    other_pair = OtherPair(x(), [1, 2])
+    ordinary_tuple = (x(), [1, 2])
+    assert not syntactic_eq(pair, other_pair)
+    assert not syntactic_eq(other_pair, pair)
+    assert not syntactic_eq(pair, ordinary_tuple)
+    assert not syntactic_eq(ordinary_tuple, pair)
+
+
+def test_syntactic_eq_equivalence_laws() -> None:
+    x = defop(int, name="x")
+    triples = [
+        (1, 1, 1),
+        ([1, 2], (1, 2), collections.UserList([1, 2])),
+        ({"x": [x()]}, collections.UserDict({"x": (x(),)}), {"x": [x()]}),
+        (x() + 1, x() + 1, x() + 1),
+    ]
+
+    for left, middle, right in triples:
+        assert syntactic_eq(left, left)
+        assert syntactic_eq(left, middle) == syntactic_eq(middle, left)
+        assert syntactic_eq(left, middle)
+        assert syntactic_eq(middle, right)
+        assert syntactic_eq(left, right)
 
 
 def test_arg_positioning():


### PR DESCRIPTION
Adds new tests for `syntactic_eq` and fixes three bugs:

- #720 
- tuple/namedtuple comparison behavior is now symmetric (if one side is a named tuple, then the other must also be)
- differently-shaped tensors are now unequal