### PR TITLE
Change pytest-xdist flag in CI from 'auto' to 'logical'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,4 +51,4 @@ jobs:
       - name: Run tests
         env:
           MKL_NUM_THREADS: 1
-        run: uv run pytest ${{ matrix.test-group.paths }} -n auto
+        run: uv run pytest ${{ matrix.test-group.paths }} -n logical


### PR DESCRIPTION
Following a similar PR in RoboTL, this PR is an attempt to speed up CI further by parallelizing across logical CPUs