### PR TITLE
Monoid.reduce(b, {}) == b

### DIFF
--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -363,9 +363,7 @@ class ReduceArrayScan(ObjectInterpretation):
                 jax_getitem(scan_val, (index,)), And.plus(*tail_mask_elems)
             )
             tail_streams = {k: v for (k, v) in streams.items() if k != stream_op}
-            if tail_streams:
-                return monoid.reduce(tail_body, tail_streams)
-            return tail_body
+            return monoid.reduce(tail_body, tail_streams)
 
         mask_elems = _conjuncts(mask)
         for i, elem in enumerate(mask_elems):
@@ -508,8 +506,8 @@ class ReduceSumProductContraction(ObjectInterpretation):
 
         # create leading reduction dimensions
         index = tuple(k() for k in streams)
-        pos_lhs = Sum.reduce(Sum.delta(index, lhs), streams)
-        pos_rhs = Sum.reduce(Sum.delta(index, rhs), streams)
+        pos_lhs = Sum.reduce(Sum.delta(index, lhs) if index else lhs, streams)
+        pos_rhs = Sum.reduce(Sum.delta(index, rhs) if index else rhs, streams)
 
         dims = "".join(get_symbol(i) for i in range(len(streams)))
         contraction = jnp.einsum(f"{dims}...,{dims}...->...", pos_lhs, pos_rhs)
@@ -745,7 +743,7 @@ class _EinsumBuilder:
         dims = [(self.out_vars[c], self.sizes[c]) for c in self.out_spec]
 
         reductions = self._build_plate_reductions(self.plate_tree)
-        reduction = Sum.reduce(reductions, streams) if streams else reductions
+        reduction = Sum.reduce(reductions, streams)
         return deffn(
             bind_dims(
                 deffn(reduction, *(self.out_vars[c] for c in self.out_spec))(

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -143,8 +143,8 @@ class Monoid[W]:
         streams: Annotated[Streams, Scoped[A]],
     ) -> Annotated[U, Scoped[B]]:
         """Reduce ``body`` over ``streams``. Handlers supply per-monoid and
-        broadcasting behavior; the default rule only handles the empty-stream
-        case.
+        broadcasting behavior.
+
         """
         raise NotHandled
 
@@ -561,11 +561,20 @@ class PlusConsecutiveDups(ObjectInterpretation):
         return monoid.plus(*(args[i] for i in dedup_args))
 
 
+class ReduceEmpty(ObjectInterpretation):
+    @implements(Monoid.reduce)
+    def _(self, monoid, body, streams):
+        if streams:
+            return fwd()
+
+        return body
+
+
 class ReducePartial(ObjectInterpretation):
     @implements(Monoid.reduce)
     def _(self, monoid, body, streams):
         if not streams:
-            return monoid.identity
+            return fwd()
 
         for stream_key, stream_body, streams_tail in outer_stream(streams):
             if isinstance(stream_body, Term):
@@ -984,8 +993,7 @@ class ReduceDistributeCartesianProduct(ObjectInterpretation):
                 inner_tail_streams = {
                     k: v for (k, v) in inner_streams.items() if k != inner_plate_op
                 }
-                if inner_tail_streams:
-                    subst_body = inner_monoid.reduce(subst_body, inner_tail_streams)
+                subst_body = inner_monoid.reduce(subst_body, inner_tail_streams)
                 combined_factors.append(subst_body)
 
             combined = (
@@ -1013,33 +1021,20 @@ class ReduceDistributeCartesianProduct(ObjectInterpretation):
                 peeled_body = Union.reduce(
                     [as_dict((peeled_idx, union_body))], union_streams
                 )
-                if not peeled_cprod_streams:
-                    peeled_cprod = peeled_body
-                else:
-                    peeled_cprod = CartesianProduct.reduce(
-                        peeled_body, peeled_cprod_streams
-                    )
+                peeled_cprod = CartesianProduct.reduce(
+                    peeled_body, peeled_cprod_streams
+                )
                 inner_reduce_body = monoid.reduce(combined, {stream_key: peeled_cprod})
 
             peeled_reduce = inner_monoid.reduce(
-                inner_reduce_body,
-                {shared_plate_op: plate_range},
+                inner_reduce_body, {shared_plate_op: plate_range}
             )
-
-            result_body = (
-                inner_monoid.plus(peeled_reduce, *row_outer_factors)
-                if row_outer_factors
-                else peeled_reduce
-            )
+            result_body = inner_monoid.plus(peeled_reduce, *row_outer_factors)
 
             # Include any extra sum streams outermost.  In particular, the
             # non-reduce product factors above remain outside the plate fold.
             tail_streams = {k: v for (k, v) in streams.items() if k != stream_key}
-            if tail_streams:
-                result = monoid.reduce(result_body, tail_streams)
-            else:
-                result = result_body
-
+            result = monoid.reduce(result_body, tail_streams)
             return result
 
         return fwd()
@@ -1352,7 +1347,7 @@ class EliminateSingletonStreams(ObjectInterpretation):
         }
         # reduce over no streams is a single (empty) assignment, i.e. the body
         # itself -- not the monoid identity.
-        return monoid.reduce(new_body, new_streams) if new_streams else new_body
+        return monoid.reduce(new_body, new_streams)
 
 
 class WhereHoist(ObjectInterpretation):
@@ -1752,6 +1747,7 @@ NormalizeIntp = _ExtensibleInterpretation().extend(
     MonoidOverSequence(),
     MonoidOverMapping(),
     MonoidOverCallable(),
+    ReduceEmpty(),
     ReduceFusion(),
     ReduceUnion(),
     ReduceSplit(),

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -1,3 +1,4 @@
+import functools
 import math
 import sys
 import typing
@@ -32,6 +33,7 @@ from effectful.ops.monoid import (
     ReduceDependentRangeMask,
     ReduceDisjunctiveDisequalityMask,
     ReduceDistributeCartesianProduct,
+    ReduceEmpty,
     ReduceEqualityMaskRange,
     ReduceFusion,
     ReduceMaskHoist,
@@ -539,7 +541,7 @@ def test_eliminate_singleton_only_stream(monoid, backend: Backend):
     f = backend.define_vars("f", arg_types=(backend.scalar_typ,), ret="scalar")
 
     lhs = monoid.reduce(f(x()), {x: (a(),)})
-    rhs = f(a())
+    rhs = monoid.reduce(f(a()), {})
     backend.check_rewrite(lhs=lhs, rhs=rhs, rule=EliminateSingletonStreams())
 
 
@@ -587,8 +589,8 @@ def test_reduce_no_streams(monoid, backend: Backend):
     a = backend.define_vars("a", ret="scalar")
 
     lhs = monoid.reduce(a(), {})
-    rhs = monoid.identity
-    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=ReducePartial())
+    rhs = a()
+    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=ReduceEmpty())
 
 
 @pytest.mark.parametrize("monoid", ALL_MONOIDS)
@@ -892,6 +894,18 @@ def test_cartesian_union():
         )
 
 
+_LiftingIntp = functools.reduce(
+    coproduct,  # type: ignore
+    (
+        ReduceDistributeCartesianProduct(),
+        ReduceUnion(),
+        EliminateSingletonStreams(),
+        ReduceEmpty(),
+        PlusSingle(),
+    ),
+)
+
+
 @pytest.mark.parametrize("outer,inner", MONOID_PAIRS)
 def test_reduce_lifted_1(outer, inner, backend: Backend):
     a, i = backend.define_vars("a", "i", ret="scalar")
@@ -908,14 +922,7 @@ def test_reduce_lifted_1(outer, inner, backend: Backend):
         },
     )
     rhs = inner.reduce(outer.reduce(f(a()), {a: A_domain()}), {i: range(3)})
-    backend.check_rewrite(
-        lhs=lhs,
-        rhs=rhs,
-        rule=coproduct(
-            ReduceDistributeCartesianProduct(),
-            coproduct(ReduceUnion(), EliminateSingletonStreams()),
-        ),
-    )
+    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=_LiftingIntp)
 
 
 def test_reduce_lifted_aligns_equal_ranges_by_row_position():
@@ -947,7 +954,7 @@ def test_reduce_lifted_aligns_equal_ranges_by_row_position():
         {p: plate},
     )
 
-    norm = handler(ReduceDistributeCartesianProduct())(evaluate)(lhs)
+    norm = handler(_LiftingIntp)(evaluate)(lhs)
     assert syntactic_eq_alpha(norm, rhs)
 
 
@@ -981,75 +988,8 @@ def test_reduce_lifted_unfactors_single_product_factor():
         {b: range(4)},
     )
 
-    norm = handler(ReduceDistributeCartesianProduct())(evaluate)(lhs)
+    norm = handler(_LiftingIntp)(evaluate)(lhs)
     assert syntactic_eq_alpha(norm, rhs)
-
-
-def test_reduce_lifted_sum_of_products_cartesian_body():
-    """A cartesian-product reduction remains visible after SOP expansion."""
-    backend = JaxBackend()
-    a, b, c_v, d_v, e_v, i, j = backend.define_vars(
-        "a", "b", "c_v", "d_v", "e_v", "i", "j", ret="scalar"
-    )
-    d = Operation.define(Mapping[tuple, backend.scalar_typ], name="d")
-    f, f0, f1, f2 = backend.define_vars("f", "f0", "f1", "f2", ret="scalar")
-
-    lhs = Sum.reduce(
-        Product.plus(
-            Product.reduce(
-                Sum.reduce(
-                    f2()[(d()[(i(),)], e_v(), f()[(i(), j())], i(), j())],
-                    {e_v: range(6)},
-                ),
-                {i: range(2), j: range(3)},
-            ),
-            Sum.reduce(
-                Product.plus(
-                    Product.reduce(
-                        Sum.reduce(
-                            f1()[(b(), c_v(), d()[(i(),)], i())],
-                            {c_v: range(4)},
-                        ),
-                        {i: range(2)},
-                    ),
-                    Sum.reduce(f0()[(a(), b())], {a: range(2)}),
-                ),
-                {b: range(3)},
-            ),
-        ),
-        {
-            d: CartesianProduct.reduce(
-                Union.reduce([as_dict(((i(),), d_v()))], {d_v: range(5)}),
-                {i: range(2)},
-            )
-        },
-    )
-
-    norm = handler(ReduceDistributeCartesianProduct())(evaluate)(lhs)
-    assert CartesianProduct.reduce not in fvsof(norm)
-
-    product_streams = []
-
-    def walk(expr):
-        if isinstance(expr, Term):
-            if expr.op is Product.reduce:
-                product_streams.append(expr.args[1])
-            for arg in expr.args:
-                walk(arg)
-            for arg in expr.kwargs.values():
-                walk(arg)
-        elif isinstance(expr, tuple | list):
-            for item in expr:
-                walk(item)
-        elif isinstance(expr, Mapping):
-            for item in expr.values():
-                walk(item)
-
-    walk(norm)
-    assert [stream for streams in product_streams for stream in streams.values()] == [
-        range(2),
-        range(3),
-    ]
 
 
 def test_reduce_lifted_3(backend: Backend):
@@ -1083,7 +1023,7 @@ def test_reduce_lifted_3(backend: Backend):
         ),
         {i: range(2)},
     )
-    norm = handler(ReduceDistributeCartesianProduct())(evaluate)(lhs)
+    norm = handler(_LiftingIntp)(evaluate)(lhs)
     assert syntactic_eq_alpha(norm, rhs)
 
 
@@ -1107,7 +1047,7 @@ def test_reduce_lifted_multi_index(outer, inner, backend: Backend):
         inner.reduce(outer.reduce(f(a()), {a: A_domain()}), {j: range(2)}),
         {i: range(3)},
     )
-    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=ReduceDistributeCartesianProduct())
+    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=_LiftingIntp)
 
 
 @pytest.mark.parametrize("outer,inner", MONOID_PAIRS)
@@ -1145,14 +1085,7 @@ def test_reduce_lifted_2(outer, inner, backend: Backend):
         ),
         {t: T()},
     )
-    backend.check_rewrite(
-        lhs=lhs,
-        rhs=rhs,
-        rule=coproduct(
-            ReduceDistributeCartesianProduct(),
-            coproduct(ReduceUnion(), EliminateSingletonStreams()),
-        ),
-    )
+    backend.check_rewrite(lhs=lhs, rhs=rhs, rule=_LiftingIntp)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Change the semantics of reductions over the empty stream collection. While reductions over empty collections should (and do) still evaluate to identity, reductions over no collections should just be the body.

Also removes a low quality LLM-generated test.