### PR TITLE
Fix quadratic term construction under nested binders

### DIFF
--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -306,6 +306,25 @@ class _TypeofIntp(PureInterpretation):
 _TYPEOF_INTP = _TypeofIntp()
 
 
+def _seed_typeof(expr: Expr, full_type: Any) -> None:
+    """Record a term's already-computed type analysis in its cache.
+
+    :func:`~effectful.ops.syntax.defdata` computes the type of every term it
+    builds in order to pick a constructor. Storing that result here means a
+    parent's :func:`_typeof` on a freshly built child is a cache hit rather
+    than a fresh traversal of the whole subterm -- without which term
+    construction is quadratic in subterm size, and compounds multiplicatively
+    through nested binders.
+    """
+    from effectful.internals.unification import Box
+
+    if not isinstance(expr, Term):
+        return
+    cache = _term_cache(expr)
+    if cache is not None:
+        cache[_TYPEOF_INTP] = Box(full_type)
+
+
 def _typeof(term: Expr):
     """Evaluate the cached type analysis without unwrapping its result."""
     return evaluate(term, intp=_TYPEOF_INTP)

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -306,25 +306,6 @@ class _TypeofIntp(PureInterpretation):
 _TYPEOF_INTP = _TypeofIntp()
 
 
-def _seed_typeof(expr: Expr, full_type: Any) -> None:
-    """Record a term's already-computed type analysis in its cache.
-
-    :func:`~effectful.ops.syntax.defdata` computes the type of every term it
-    builds in order to pick a constructor. Storing that result here means a
-    parent's :func:`_typeof` on a freshly built child is a cache hit rather
-    than a fresh traversal of the whole subterm -- without which term
-    construction is quadratic in subterm size, and compounds multiplicatively
-    through nested binders.
-    """
-    from effectful.internals.unification import Box
-
-    if not isinstance(expr, Term):
-        return
-    cache = _term_cache(expr)
-    if cache is not None:
-        cache[_TYPEOF_INTP] = Box(full_type)
-
-
 def _typeof(term: Expr):
     """Evaluate the cached type analysis without unwrapping its result."""
     return evaluate(term, intp=_TYPEOF_INTP)

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -491,7 +491,13 @@ def defdata[T](
     it is reconstructed as a :class:`_CallableTerm`, which implements the :func:`__call__` method.
     """
     from effectful.internals.runtime import interpreter
-    from effectful.ops.semantics import _simple_type, _typeof, apply, evaluate
+    from effectful.ops.semantics import (
+        _seed_typeof,
+        _simple_type,
+        _typeof,
+        apply,
+        evaluate,
+    )
 
     # If this operation binds variables, we need to rename them in the
     # appropriate parts of the child term.
@@ -514,8 +520,23 @@ def defdata[T](
         # Note: coproduct cannot be used to compose these interpretations
         # because evaluate will only do operation replacement when the handler
         # is operation typed, which coproduct does not satisfy.
-        with interpreter({apply: defdata} | renaming_ctx):
+        #
+        # Rebuild with ``_reconstruct`` rather than ``defdata``: the subterm was
+        # already renamed when it was first built, so re-entering ``defdata``
+        # here would recompute binders and rename each child again at every
+        # level, re-traversing the subtree once per level of nesting.
+        with interpreter({apply: _reconstruct} | renaming_ctx):
             return evaluate(expr)
+
+    def _reconstruct(op, *args, **kwargs):
+        """Rebuild one node, reusing its children's cached type analysis."""
+        typed = tuple(_typeof(a) for a in args)
+        typed_kw = {k: _typeof(v) for k, v in kwargs.items()}
+        node_type = op.__type_rule__(*typed, **typed_kw)
+        node_dispatch = _simple_type(node_type)
+        node = __dispatch(node_dispatch)(node_dispatch, op, *args, **kwargs)
+        _seed_typeof(node, node_type)
+        return node
 
     renamed_args = op.__signature__.bind(*args, **kwargs)
     renamed_args.apply_defaults()
@@ -534,7 +555,9 @@ def defdata[T](
     typed_kwargs = {k: _typeof(v) for k, v in kwargs_.items()}
     full_type = op.__type_rule__(*typed_args, **typed_kwargs)
     dispatch_type = _simple_type(full_type)
-    return __dispatch(dispatch_type)(dispatch_type, op, *args_, **kwargs_)
+    result = __dispatch(dispatch_type)(dispatch_type, op, *args_, **kwargs_)
+    _seed_typeof(result, full_type)
+    return result
 
 
 def _construct_dataclass_term[T](

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -432,6 +432,26 @@ def deffn[T, A, B](
     raise NotHandled
 
 
+def _build_term[T](
+    __dispatch: Callable[[type], Callable[..., Expr[T]]],
+    op: Operation[..., T],
+    *args,
+    **kwargs,
+) -> Expr[T]:
+    """Build a single node from arguments whose bound variables are already renamed.
+
+    This is :func:`defdata` without the renaming step: it computes the node's
+    type from the types of its arguments and dispatches on that type to pick a
+    constructor.
+    """
+    from effectful.ops.semantics import _simple_type, _typeof
+
+    typed_args = tuple(_typeof(arg) for arg in args)
+    typed_kwargs = {k: _typeof(v) for k, v in kwargs.items()}
+    dispatch_type = _simple_type(op.__type_rule__(*typed_args, **typed_kwargs))
+    return __dispatch(dispatch_type)(dispatch_type, op, *args, **kwargs)
+
+
 @_CustomSingleDispatchCallable
 def defdata[T](
     __dispatch: Callable[[type], Callable[..., Expr[T]]],
@@ -491,13 +511,7 @@ def defdata[T](
     it is reconstructed as a :class:`_CallableTerm`, which implements the :func:`__call__` method.
     """
     from effectful.internals.runtime import interpreter
-    from effectful.ops.semantics import (
-        _seed_typeof,
-        _simple_type,
-        _typeof,
-        apply,
-        evaluate,
-    )
+    from effectful.ops.semantics import apply, evaluate
 
     # If this operation binds variables, we need to rename them in the
     # appropriate parts of the child term.
@@ -521,22 +535,13 @@ def defdata[T](
         # because evaluate will only do operation replacement when the handler
         # is operation typed, which coproduct does not satisfy.
         #
-        # Rebuild with ``_reconstruct`` rather than ``defdata``: the subterm was
+        # Rebuild with ``_build_term`` rather than ``defdata``: the subterm was
         # already renamed when it was first built, so re-entering ``defdata``
         # here would recompute binders and rename each child again at every
         # level, re-traversing the subtree once per level of nesting.
-        with interpreter({apply: _reconstruct} | renaming_ctx):
+        rebuild = functools.partial(_build_term, __dispatch)
+        with interpreter({apply: rebuild} | renaming_ctx):
             return evaluate(expr)
-
-    def _reconstruct(op, *args, **kwargs):
-        """Rebuild one node, reusing its children's cached type analysis."""
-        typed = tuple(_typeof(a) for a in args)
-        typed_kw = {k: _typeof(v) for k, v in kwargs.items()}
-        node_type = op.__type_rule__(*typed, **typed_kw)
-        node_dispatch = _simple_type(node_type)
-        node = __dispatch(node_dispatch)(node_dispatch, op, *args, **kwargs)
-        _seed_typeof(node, node_type)
-        return node
 
     renamed_args = op.__signature__.bind(*args, **kwargs)
     renamed_args.apply_defaults()
@@ -550,14 +555,7 @@ def defdata[T](
         for (k, v) in renamed_args.kwargs.items()
     }
 
-    # Build the final term using the cached type analysis of its children.
-    typed_args = tuple(_typeof(arg) for arg in args_)
-    typed_kwargs = {k: _typeof(v) for k, v in kwargs_.items()}
-    full_type = op.__type_rule__(*typed_args, **typed_kwargs)
-    dispatch_type = _simple_type(full_type)
-    result = __dispatch(dispatch_type)(dispatch_type, op, *args_, **kwargs_)
-    _seed_typeof(result, full_type)
-    return result
+    return _build_term(__dispatch, op, *args_, **kwargs_)
 
 
 def _construct_dataclass_term[T](

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -1457,3 +1457,45 @@ def test_bench_term_construction(benchmark):
 
     result = benchmark(_make_benchmark_term, 25)
     assert isinstance(result, Term)
+
+
+def test_bench_nested_binder_construction(benchmark):
+    """Benchmark term construction under *nested* binders.
+
+    Constructing an operation that binds a variable renames that variable
+    throughout the body, which rebuilds the body. Nesting binders means each
+    level rebuilds everything beneath it, so a rebuild that is not single-pass
+    compounds multiplicatively with depth rather than adding to it.
+
+    ``test_bench_term_construction`` builds a binder-free term, so it never
+    reaches this path -- it is fast even when nested construction is
+    exponential in depth.
+    """
+
+    @defop
+    def _benchmark_let[S, T, A](
+        var: Annotated[Operation[[], S], Scoped[A]],
+        val: S,
+        body: Annotated[T, Scoped[A]],
+    ) -> T:
+        raise NotHandled
+
+    @defop
+    def _benchmark_add(x: int, y: int) -> int:
+        raise NotHandled
+
+    def _make_nested_term(depth: int) -> Term[int]:
+        """A term of ``depth`` nested binders, each used in the body below it."""
+        if depth < 1:
+            raise ValueError("depth must be positive")
+
+        body: Expr[int] = 0
+        for index in range(depth):
+            var = defop(int, name=f"_benchmark_var_{index}")
+            body = _benchmark_let(var, 1, _benchmark_add(var(), body))
+
+        assert isinstance(body, Term)
+        return body
+
+    result = benchmark(_make_nested_term, 10)
+    assert isinstance(result, Term)


### PR DESCRIPTION
## The regression

#716 ("Add cached interpretations and use for `typeof`") made `defdata` compute the
full type analysis of every term it builds, in order to pick the right term
constructor. That interacts badly with binders: when an operation binds variables,
`defdata` renames them throughout the body, which rebuilds the body by re-entering
`defdata` via `apply`. Re-entering `defdata` recomputes binders and renames each
child *again* at every level, so nesting binders re-traverses the subtree once per
level of nesting.

## The changes

- **`effectful/ops/syntax.py`**: `evaluate_with_renaming` now rebuilds nodes with
  `_build_term` instead of re-entering `defdata`. The subterm was already renamed
  when it was first built, so the rebuild only needs to re-dispatch each node, not
  redo binder analysis and renaming.
- `_build_term` is `defdata` minus the renaming step, and is shared: `defdata`
  itself ends with `return _build_term(__dispatch, op, *args_, **kwargs_)`, and the
  rebuild installs `functools.partial(_build_term, __dispatch)` as the `apply` rule.

The change does not alter any observable result.

## Benchmark

`tests/test_ops_syntax.py::test_bench_nested_binder_construction` builds a term
of 10 nested `let`-style binders, each variable used in the body below it. The
existing `test_bench_term_construction` builds a *binder-free* term, so it never
reaches this path and stays fast even when nested construction blows up.

Measured on this branch vs. the same test with the `effectful/` change reverted
(mean of pytest-benchmark rounds):

| benchmark | before | after |
| --- | --- | --- |
| `test_bench_nested_binder_construction` | 572.8 ms | 17.2 ms (**33x**) |
| `test_bench_term_construction` | 3.39 ms | 3.50 ms (unchanged) |

An earlier revision of this PR also seeded `defdata`'s already-computed type
analysis into the per-term evaluation cache, which bought a further ~1.8x on
nested construction and ~1.5x on binder-free construction. That was dropped at
review: it reached past `_evaluate_term`, which owns that cache, and it is a
constant factor rather than the asymptotic fix (with and without, nested
construction is quadratic in depth, at a flat ~1.8x ratio from depth 10 to 40).

## Testing

Full test suite: 18749 passed, 1 skipped, 2108 xfailed. `mypy` and `ruff` clean
on the changed files.

Split out of #724 for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
