### PR TITLE
Don't route all-scalar monoid ops through jax

### DIFF
--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -68,12 +68,21 @@ for a, b in {
 
 
 def _jax_args(args):
-    """True iff ``args`` is non-empty and every arg is a concrete
-    :class:`jax.typing.ArrayLike` or named tensor.
+    """True iff ``args`` is non-empty, every arg is a concrete
+    :class:`jax.typing.ArrayLike` or named tensor, and at least one of them is
+    an array rather than a Python scalar.
 
+    :class:`jax.typing.ArrayLike` is a union that includes ``bool``, ``int``,
+    ``float`` and ``complex``, so admitting it alone would claim pure-Python
+    scalar arithmetic. These handlers extend ``EvaluateIntp`` after the scalar
+    implementations and so take precedence over them, which would silently
+    narrow a Python float to a ``float32`` array and leave downstream rules
+    treating a scalar body as array-valued.
     """
-    return args and all(
-        isinstance(a, jax.typing.ArrayLike) or is_eager_array(a) for a in args
+    return (
+        args
+        and all(isinstance(a, jax.typing.ArrayLike) or is_eager_array(a) for a in args)
+        and any(not isinstance(a, bool | int | float | complex) for a in args)
     )
 
 

--- a/tests/test_handlers_jax_monoid.py
+++ b/tests/test_handlers_jax_monoid.py
@@ -124,6 +124,55 @@ def test_reduce_array_2(monoid, reductor, backend: JaxBackend):
     assert jnp.allclose(actual, expected)
 
 
+SCALAR_PLUS = [
+    pytest.param(Sum, 3.0, id="Sum"),
+    pytest.param(Product, 2.0, id="Product"),
+]
+
+
+@pytest.mark.parametrize("monoid,expected", SCALAR_PLUS)
+def test_plus_scalars_stays_scalar(monoid, expected):
+    """``Monoid.plus`` of plain Python numbers must not become a ``jax.Array``.
+
+    ``jax.typing.ArrayLike`` is a union that includes ``bool``, ``int``,
+    ``float`` and ``complex``, so the jax ``plus`` handlers -- which extend
+    ``EvaluateIntp`` after the scalar implementations and therefore take
+    precedence -- must not claim pure-Python scalar arithmetic.
+    """
+    with handler(NormalizeIntp), handler(EvaluateIntp):
+        actual = monoid.plus(1.0, 2.0)
+
+    assert not isinstance(actual, jax.Array)
+    assert isinstance(actual, float)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "monoid,expected",
+    [pytest.param(Sum, 6.0, id="Sum"), pytest.param(Product, 8.0, id="Product")],
+)
+def test_reduce_scalar_body_stays_scalar(monoid, expected, backend: JaxBackend):
+    """A reduction over a scalar body is likewise plain Python arithmetic."""
+    i = backend.define_vars("i", ret="scalar")
+
+    with handler(NormalizeIntp), handler(EvaluateIntp):
+        actual = monoid.reduce(2.0, {i: range(3)})
+
+    assert not isinstance(actual, jax.Array)
+    assert isinstance(actual, float)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("monoid,expected", SCALAR_PLUS)
+def test_plus_mixed_array_and_scalar_is_array(monoid, expected):
+    """One genuine array is enough: the narrowing must not be over-applied."""
+    with handler(NormalizeIntp), handler(EvaluateIntp):
+        actual = monoid.plus(jnp.asarray([1.0, 1.0]), 2.0)
+
+    assert isinstance(actual, jax.Array)
+    assert jnp.allclose(actual, jnp.asarray([expected, expected]))
+
+
 @pytest.mark.parametrize("monoid,reductor", MONOIDS)
 def test_arange_reduce_indirect(monoid, reductor, backend: JaxBackend):
     """When the range var is used both as a direct index and as a value


### PR DESCRIPTION
## The bug

`_jax_args` in `effectful/handlers/jax/monoid.py` gated the jax `Monoid.plus`
handlers on every argument being a concrete `jax.typing.ArrayLike` or a named
tensor. But `jax.typing.ArrayLike` is a *union* that includes `bool`, `int`,
`float` and `complex`, so the predicate also accepted arguments that were
entirely plain Python numbers.

## Why it was silent

The jax handlers (`SumPlusJax`, `ProductPlusJax`, `MinPlusJax`, `MaxPlusJax`,
`LogSumExpPlusJax`, ...) extend `EvaluateIntp` *after* the generic scalar
implementations, so they take precedence. Whenever their guard matched they
never `fwd()`ed to the scalar rules, and pure-Python arithmetic was routed
through `jnp.add` / `jnp.multiply` / etc. The result was numerically correct,
so nothing blew up -- but a Python `float` came back as a weakly-typed
`float32` `jax.Array`, which leaves downstream rules treating a scalar body as
array-valued.

This affected `plus` directly and `reduce` transitively:

```python
with handler(NormalizeIntp), handler(EvaluateIntp):
    Sum.plus(1.0, 2.0)            # Array(3., dtype=float32, weak_type=True)
    Sum.reduce(2.0, {i: range(3)}) # Array(6., dtype=float32, weak_type=True)
```

## The fix

Require at least one argument that is *not* a `bool | int | float | complex`,
i.e. at least one genuine array, before the jax handlers claim the operation.

## The regression test

Three parametrized tests in `tests/test_handlers_jax_monoid.py`, covering both
`Sum` and `Product`:

- `test_plus_scalars_stays_scalar` -- `monoid.plus(1.0, 2.0)` under
  `NormalizeIntp` + `EvaluateIntp` returns a plain `float`, not a `jax.Array`.
- `test_reduce_scalar_body_stays_scalar` -- `monoid.reduce(2.0, {i: range(3)})`
  likewise stays a plain `float`.
- `test_plus_mixed_array_and_scalar_is_array` -- the fix is not over-applied:
  `monoid.plus(jnp.asarray([1.0, 1.0]), 2.0)` still returns a `jax.Array` with
  the right values, since one genuine array is enough to claim the op.

The first two fail on `staging-weighted` (`assert not isinstance(actual, jax.Array)`
-> `Array(3., dtype=float32, weak_type=True)`); the third passes both before and
after, which is the point -- it pins the boundary.

## Testing

`tests/test_handlers_jax_monoid.py`, `tests/test_handlers_jax.py` and
`tests/test_ops_monoid.py`: 592 passed. Full `tests/` sweep excluding the
network-dependent `tests/test_handlers_llm_*.py`: 18323 passed, 2 skipped,
2078 xfailed. `ruff check` and `ruff format` clean; `mypy` reports one
pre-existing error in this file (`monoid.py:391`, present unchanged on
`staging-weighted` at line 382).

Split out of #724 for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)