### PR TITLE
Add argmin that can be factored

### DIFF
--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -18,6 +18,7 @@ from effectful.handlers.jax._handlers import is_eager_array
 from effectful.handlers.jax.scipy.special import logsumexp
 from effectful.ops.monoid import (
     And,
+    Body,
     CartesianProduct,
     EvaluateIntp,
     LogSumExp,
@@ -52,23 +53,9 @@ from effectful.ops.types import Expr, Interpretation, Operation, Term
 logger = logging.getLogger(__name__)
 
 
-def _optimum_flatten(optimum: Optimum):
-    keys = None if optimum.assignment is None else tuple(optimum.assignment)
-    values = () if optimum.assignment is None else tuple(optimum.assignment.values())
-    return (optimum.value, *values), keys
-
-
-def _optimum_unflatten(keys, children):
-    value, *assignment_values = children
-    assignment = (
-        None if keys is None else dict(zip(keys, assignment_values, strict=True))
-    )
-    return Optimum(value, assignment)
-
-
 # ``Optimum`` lives in the backend-independent module, but once the JAX backend
 # is imported it should be a valid input/output of ``jax.jit``.
-jax.tree_util.register_pytree_node(Optimum, _optimum_flatten, _optimum_unflatten)
+jax.tree_util.register_dataclass(Optimum)
 
 
 is_equality.register(jnp.equal)
@@ -282,22 +269,16 @@ ARRAY_REDUCTORS[LogSumExp] = logsumexp
 class ReduceOptimum(ObjectInterpretation):
     """Reduce an assignment-carrying JAX score with ``argmin`` or ``argmax``.
 
-    This is deliberately a lowering for the normalized ``Optimum`` body rather
-    than for weighted-stream syntax.  ``ReduceWeightedStream`` turns the latter
-    into this form, so the same kernel handles both spellings.
-
     The initial kernel supports independent ``range`` streams and assignments
     that record stream variables directly.  Those are the normal form produced
     by ``Sum.weighted(..., lambda v: Optimum(0, {x: v}))``.
     """
 
     @implements(Monoid.reduce)
-    def reduce(self, monoid, body, streams):
+    def reduce(self, monoid: Monoid, body: Body, streams: Streams):
         if monoid not in (Min, Max) or not isinstance(body, Optimum):
             return fwd()
         if not issubclass(typeof(body.value), jax.Array):
-            return fwd()
-        if not body.feasible or not isinstance(body.assignment, Mapping):
             return fwd()
         if not streams or not all(
             isinstance(stream, range) for stream in streams.values()
@@ -309,17 +290,12 @@ class ReduceOptimum(ObjectInterpretation):
         # provenance value for an arbitrary assignment expression.
         assignment_vars = {}
         for key, value in body.assignment.items():
-            if not (
-                isinstance(value, Term)
-                and not value.args
-                and not value.kwargs
-                and value.op in streams
-            ):
+            if not (isinstance(value, Term) and value.op in streams):
                 return fwd()
             assignment_vars[key] = value.op
 
         if any(len(stream) == 0 for stream in streams.values()):
-            return Optimum(monoid.identity, None)
+            return monoid.identity
 
         score_fvs = fvsof(body.value)
         used = tuple(k for k in streams if k in score_fvs)

--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -294,7 +294,7 @@ class ReduceOptimum(ObjectInterpretation):
                 return fwd()
             assignment_vars[key] = value.op
 
-        if any(len(stream) == 0 for stream in streams.values()):
+        if any(len(typing.cast(range, stream)) == 0 for stream in streams.values()):
             return monoid.identity
 
         score_fvs = fvsof(body.value)

--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -25,6 +25,7 @@ from effectful.ops.monoid import (
     Min,
     Monoid,
     NormalizeIntp,
+    Optimum,
     Or,
     Product,
     Streams,
@@ -49,6 +50,25 @@ from effectful.ops.syntax import (
 from effectful.ops.types import Expr, Interpretation, Operation, Term
 
 logger = logging.getLogger(__name__)
+
+
+def _optimum_flatten(optimum: Optimum):
+    keys = None if optimum.assignment is None else tuple(optimum.assignment)
+    values = () if optimum.assignment is None else tuple(optimum.assignment.values())
+    return (optimum.value, *values), keys
+
+
+def _optimum_unflatten(keys, children):
+    value, *assignment_values = children
+    assignment = (
+        None if keys is None else dict(zip(keys, assignment_values, strict=True))
+    )
+    return Optimum(value, assignment)
+
+
+# ``Optimum`` lives in the backend-independent module, but once the JAX backend
+# is imported it should be a valid input/output of ``jax.jit``.
+jax.tree_util.register_pytree_node(Optimum, _optimum_flatten, _optimum_unflatten)
 
 
 is_equality.register(jnp.equal)
@@ -257,6 +277,87 @@ for monoid, func in [
     ARRAY_REDUCTORS[monoid] = functools.partial(func, initial=monoid.identity)
 
 ARRAY_REDUCTORS[LogSumExp] = logsumexp
+
+
+class ReduceOptimum(ObjectInterpretation):
+    """Reduce an assignment-carrying JAX score with ``argmin`` or ``argmax``.
+
+    This is deliberately a lowering for the normalized ``Optimum`` body rather
+    than for weighted-stream syntax.  ``ReduceWeightedStream`` turns the latter
+    into this form, so the same kernel handles both spellings.
+
+    The initial kernel supports independent ``range`` streams and assignments
+    that record stream variables directly.  Those are the normal form produced
+    by ``Sum.weighted(..., lambda v: Optimum(0, {x: v}))``.
+    """
+
+    @implements(Monoid.reduce)
+    def reduce(self, monoid, body, streams):
+        if monoid not in (Min, Max) or not isinstance(body, Optimum):
+            return fwd()
+        if not issubclass(typeof(body.value), jax.Array):
+            return fwd()
+        if not body.feasible or not isinstance(body.assignment, Mapping):
+            return fwd()
+        if not streams or not all(
+            isinstance(stream, range) for stream in streams.values()
+        ):
+            return fwd()
+
+        # For now assignments must be direct references to reduction variables.
+        # Keeping this check narrow is preferable to silently returning a wrong
+        # provenance value for an arbitrary assignment expression.
+        assignment_vars = {}
+        for key, value in body.assignment.items():
+            if not (
+                isinstance(value, Term)
+                and not value.args
+                and not value.kwargs
+                and value.op in streams
+            ):
+                return fwd()
+            assignment_vars[key] = value.op
+
+        if any(len(stream) == 0 for stream in streams.values()):
+            return Optimum(monoid.identity, None)
+
+        score_fvs = fvsof(body.value)
+        used = tuple(k for k in streams if k in score_fvs)
+        used_streams = {k: streams[k] for k in used}
+
+        if used:
+            # Materialize one leading positional axis per used stream.  Existing
+            # delta lowering performs vectorized substitution and preserves any
+            # trailing batch dimensions of the score.
+            score = monoid.reduce(
+                monoid.delta(tuple(k() for k in used), body.value), used_streams
+            )
+            if not isinstance(score, jax.Array | jax.core.Tracer):
+                return fwd()
+
+            reduction_shape = tuple(len(typing.cast(range, streams[k])) for k in used)
+            if tuple(score.shape[: len(used)]) != reduction_shape:
+                return fwd()
+
+            flat_size = functools.reduce(lambda a, b: a * b, reduction_shape, 1)
+            flat_score = jnp.reshape(score, (flat_size, *score.shape[len(used) :]))
+            arg_reduce = jnp.argmin if monoid is Min else jnp.argmax
+            flat_index = arg_reduce(flat_score, axis=0)
+            value = jnp.take_along_axis(flat_score, flat_index[None], axis=0)[0]
+            coordinates = jnp.unravel_index(flat_index, reduction_shape)
+            positions = dict(zip(used, coordinates, strict=True))
+        else:
+            # An invariant score ties everywhere; monoid reduction chooses the
+            # first candidate, matching both Python's min/max and JAX argmin/max.
+            value = body.value
+            positions = {}
+
+        assignment = {}
+        for key, variable in assignment_vars.items():
+            stream = typing.cast(range, streams[variable])
+            position = positions.get(variable, 0)
+            assignment[key] = stream.start + stream.step * position
+        return Optimum(value, assignment)
 
 
 class ReduceArray(ObjectInterpretation):
@@ -822,6 +923,7 @@ EvaluateIntp.extend(
     ReduceDeltaSimpleRange(),
     ReduceArrayScan(),
     PlusCastArray(),
+    ReduceOptimum(),
 )
 
 NormalizeIntp.extend(

--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -97,8 +97,10 @@ class PlusCastArray(ObjectInterpretation):
             return issubclass(t, jax.Array | jax.core.Tracer)
 
         # exists array valued and non-array-valued args
-        if any(_is_jax(t) for t in arg_types) and any(
-            not _is_jax(t) for t in arg_types
+        if (
+            any(_is_jax(t) for t in arg_types)
+            and any(not _is_jax(t) for t in arg_types)
+            and all(issubclass(t, jax.typing.ArrayLike) for t in arg_types)
         ):
             return monoid.plus(
                 *(

--- a/effectful/handlers/numpyro.py
+++ b/effectful/handlers/numpyro.py
@@ -1,6 +1,7 @@
 try:
     import numpyro
     import numpyro.distributions as dist
+    import numpyro.optim
 except ImportError:
     raise ImportError("Numpyro is required to use effectful.handlers.numpyro")
 
@@ -16,14 +17,16 @@ from effectful.handlers.jax import bind_dims, jax_getitem, sizesof, unbind_dims
 from effectful.handlers.jax._handlers import _register_jax_op, is_eager_array
 from effectful.ops.monoid import (
     LogSumExp,
+    Min,
     Monoid,
     NormalizeIntp,
+    Optimum,
     Product,
     Stream,
     Streams,
     Sum,
 )
-from effectful.ops.semantics import evaluate, fwd, typeof
+from effectful.ops.semantics import evaluate, fvsof, fwd, handler, typeof
 from effectful.ops.syntax import ObjectInterpretation, defdata, deffn, defop, implements
 from effectful.ops.types import NotHandled, Operation, Term
 
@@ -1194,7 +1197,6 @@ def _embed_independent(d: dist.Independent) -> Term[dist.Independent]:
     return Independent(d.base_dist, d.reinterpreted_batch_ndims)
 
 
-@Operation.define
 def distribution_stream(
     distribution: numpyro.distributions.Distribution,
 ) -> Stream[jax.Array]:
@@ -1235,6 +1237,137 @@ class ReduceEnumerableDistribution(ObjectInterpretation):
             return monoid.reduce(body, new_streams)
 
         return fwd()
+
+
+@Operation.define
+def constraint_stream(
+    constraint: numpyro.distributions.constraints.Constraint, prototype: jax.Array
+) -> Stream[jax.Array]:
+    raise NotHandled
+
+
+class NestConstraintMinReduce(ObjectInterpretation):
+    """Move constraint streams into an inner :data:`~effectful.ops.monoid.Min`.
+
+    This rewrites::
+
+        Min.reduce(body, constraint_streams | other_streams)
+
+    to::
+
+        Min.reduce(Min.reduce(body, constraint_streams), other_streams)
+
+    when both partitions are nonempty. A constraint stream may depend on an
+    outer stream, but an outer stream may not depend on a constraint variable;
+    the latter ordering would move the variable outside its scope and is left
+    for another handler.
+    """
+
+    @implements(Min.reduce)
+    def reduce(self, body, streams):
+        constraint_streams = {
+            key: stream
+            for key, stream in streams.items()
+            if isinstance(stream, Term) and stream.op is constraint_stream
+        }
+        if not constraint_streams or len(constraint_streams) == len(streams):
+            return fwd()
+
+        other_streams = {
+            key: stream
+            for key, stream in streams.items()
+            if key not in constraint_streams
+        }
+        if fvsof(other_streams) & set(constraint_streams):
+            return fwd()
+
+        return Min.reduce(Min.reduce(body, constraint_streams), other_streams)
+
+
+class AdamConstraintMinReduce(ObjectInterpretation):
+    """Minimize an all-continuous constraint-stream bundle with Adam.
+
+    Optimization takes place in unconstrained coordinates using NumPyro's
+    ``biject_to`` transforms. The prototypes carried by
+    :func:`constraint_stream` determine shape and dtype; each constraint's
+    :meth:`~numpyro.distributions.constraints.Constraint.feasible_like` method
+    constructs the constrained initial value.
+    """
+
+    def __init__(
+        self,
+        step_size=1e-2,
+        *,
+        num_steps: int = 1_000,
+        b1: float = 0.9,
+        b2: float = 0.999,
+        eps: float = 1e-8,
+    ):
+        if num_steps < 0:
+            raise ValueError("num_steps must be nonnegative")
+        self.num_steps = num_steps
+        self.optimizer = numpyro.optim.Adam(step_size=step_size, b1=b1, b2=b2, eps=eps)
+
+    @implements(Min.reduce)
+    def reduce(self, body, streams):
+        if not streams or not all(
+            isinstance(stream, Term) and stream.op is constraint_stream
+            for stream in streams.values()
+        ):
+            return fwd()
+
+        constraints = tuple(stream.args[0] for stream in streams.values())
+        if any(constraint.is_discrete for constraint in constraints):
+            return fwd()
+
+        score = body.value if isinstance(body, Optimum) else body
+        stream_keys = tuple(streams)
+
+        transforms = tuple(
+            numpyro.distributions.transforms.biject_to(constraint)
+            for constraint in constraints
+        )
+        prototypes = tuple(stream.args[1] for stream in streams.values())
+        constrained_initial = tuple(
+            constraint.feasible_like(prototype)
+            for constraint, prototype in zip(constraints, prototypes, strict=True)
+        )
+        unconstrained_initial = tuple(
+            transform.inv(value)
+            for transform, value in zip(transforms, constrained_initial, strict=True)
+        )
+
+        def substitute(value, unconstrained):
+            constrained = tuple(
+                transform(x)
+                for transform, x in zip(transforms, unconstrained, strict=True)
+            )
+            substitutions = {
+                key: (lambda value=value: value)
+                for key, value in zip(stream_keys, constrained, strict=True)
+            }
+            with handler(substitutions):
+                return evaluate(value)
+
+        def objective(unconstrained):
+            return substitute(score, unconstrained)
+
+        initial_score = objective(unconstrained_initial)
+        if isinstance(initial_score, Term):
+            return fwd()
+        if jnp.ndim(initial_score) != 0:
+            raise ValueError("Min objective must be scalar")
+
+        state = self.optimizer.init(unconstrained_initial)
+
+        def step(_, state):
+            (_, _), state = self.optimizer.eval_and_stable_update(
+                lambda params: (objective(params), None), state
+            )
+            return state
+
+        state = jax.lax.fori_loop(0, self.num_steps, step, state)
+        return substitute(body, self.optimizer.get_params(state))
 
 
 NormalizeIntp.extend(ReduceEnumerableDistribution())

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -203,65 +203,12 @@ class MonoidWithZero[T](Monoid[T]):
         self.zero = zero
 
 
+@dataclass(frozen=True)
 class Optimum[T]:
     """A value together with an assignment that attains it."""
 
-    __slots__ = ("assignment", "value")
-
-    def __init__(self, value: T, assignment: Mapping[Operation, Any] | None):
-        self.value = value
-        self.assignment = assignment
-
-    @property
-    def feasible(self) -> bool:
-        return self.assignment is not None
-
-    def __eq__(self, other: object) -> bool:
-        return (
-            isinstance(other, Optimum)
-            and self.value == other.value
-            and self.assignment == other.assignment
-        )
-
-    def __repr__(self) -> str:
-        return f"Optimum(value={self.value!r}, assignment={self.assignment!r})"
-
-
-@evaluate.register(Optimum)
-def _evaluate_optimum(expr: Optimum, **kwargs) -> Optimum:
-    """Evaluate an optimum's score and assignment values, preserving variable keys."""
-
-    assignment = (
-        None
-        if expr.assignment is None
-        else {variable: evaluate(value) for variable, value in expr.assignment.items()}
-    )
-    return Optimum(evaluate(expr.value), assignment)
-
-
-class ProductMonoid[L, R](Monoid[tuple[L, R]]):
-    """The componentwise product of two monoids.
-
-    ``ProductMonoid(left, right).plus`` combines the first components with
-    ``left.plus`` and the second components with ``right.plus``.
-    """
-
-    left: Monoid[L]
-    right: Monoid[R]
-
-    def __init__(self, left: Monoid[L], right: Monoid[R], name: str | None = None):
-        self.left = left
-        self.right = right
-        super().__init__(
-            name=name or f"{left.__name__}×{right.__name__}",
-            identity=(left.identity, right.identity),
-        )
-
-        # Product operations inherit these algebraic properties componentwise.
-        if is_commutative(left) and is_commutative(right):
-            is_commutative.register(self)
-        if is_idempotent(left) and is_idempotent(right):
-            is_idempotent.register(self)
+    value: T
+    assignment: Mapping[Operation, Any]
 
 
 Min = Monoid(name="Min", identity=float("inf"))
@@ -1634,20 +1581,6 @@ class LogSumExpPlus(ObjectInterpretation):
         )
 
 
-class ArgMinPlus(ObjectInterpretation):
-    """Scalar score implementation of :data:`ArgMin`."""
-
-    @implements(ArgMin.plus)
-    def plus(self, *args):
-        if not args or not all(isinstance(a, tuple) for a in args):
-            return fwd()
-        if any(isinstance(a[0], Term) for a in args):
-            return fwd()
-        if not all(isinstance(a[0], int | float) for a in args):
-            return fwd()
-        return min(args, key=lambda a: a[0])
-
-
 class MinOptimumPlus(ObjectInterpretation):
     """Lift :data:`Min` to values carrying minimizing assignments."""
 
@@ -1684,20 +1617,6 @@ class MaxOptimumPlus(ObjectInterpretation):
             return fwd()
 
 
-class ArgMaxPlus(ObjectInterpretation):
-    """Scalar score implementation of :data:`ArgMax`."""
-
-    @implements(ArgMax.plus)
-    def plus(self, *args):
-        if not args or not all(isinstance(a, tuple) for a in args):
-            return fwd()
-        if any(isinstance(a[0], Term) for a in args):
-            return fwd()
-        if not all(isinstance(a[0], int | float) for a in args):
-            return fwd()
-        return max(args, key=lambda a: a[0])
-
-
 def _disjoint_merge[K, V](*dicts: Mapping[K, V]) -> Mapping[K, V]:
     merged = {}
     for d in dicts:
@@ -1708,6 +1627,44 @@ def _disjoint_merge[K, V](*dicts: Mapping[K, V]) -> Mapping[K, V]:
                 raise ValueError(f"Duplicate key found: '{key}'")
             merged[key] = value
     return merged
+
+
+class OptimumPlus(ObjectInterpretation):
+    @staticmethod
+    def _optimum_min_max(func, *args):
+        if (
+            not args
+            or not any(isinstance(a, Optimum) for a in args)
+            or any(isinstance(a, Optimum) and isinstance(a.value, Term) for a in args)
+        ):
+            return fwd()
+
+        return func(args, key=lambda a: a.value if isinstance(a, Optimum) else a)
+
+    @implements(Min.plus)
+    def _min_plus(self, *args):
+        return self._optimum_min_max(min, *args)
+
+    @implements(Max.plus)
+    def _max_plus(self, *args):
+        return self._optimum_min_max(max, *args)
+
+    @implements(Sum.plus)
+    def _sum_plus(self, *args):
+        if not args or not any(isinstance(arg, Optimum) for arg in args):
+            return fwd()
+        return Optimum(
+            Sum.plus(*(arg.value if isinstance(arg, Optimum) else arg for arg in args)),
+            _disjoint_merge(
+                *(arg.assignment if isinstance(arg, Optimum) else {} for arg in args)
+            ),
+        )
+
+    @implements(Monoid.plus)
+    def plus(self, monoid, *args):
+        if not args or not any(isinstance(arg, Optimum) for arg in args):
+            return fwd()
+        return monoid.plus(*(a.value if isinstance(a, Optimum) else a for a in args))
 
 
 class AssignmentPlus(ObjectInterpretation):
@@ -1722,25 +1679,6 @@ class AssignmentPlus(ObjectInterpretation):
         if not all(isinstance(arg, Mapping) for arg in args):
             return fwd()
         return _disjoint_merge(*args)
-
-
-class ProductMonoidPlus(ObjectInterpretation):
-    """Componentwise implementation of :class:`ProductMonoid`."""
-
-    @implements(Monoid.plus)
-    def plus(self, monoid, *args):
-        if not isinstance(monoid, ProductMonoid):
-            return fwd()
-        if not args:
-            return monoid.identity
-        if any(isinstance(arg, Term) for arg in args):
-            return fwd()
-        if not all(isinstance(arg, tuple) and len(arg) == 2 for arg in args):
-            return fwd()
-        return (
-            monoid.left.plus(*(arg[0] for arg in args)),
-            monoid.right.plus(*(arg[1] for arg in args)),
-        )
 
 
 class CartesianProductPlus(ObjectInterpretation):
@@ -1846,35 +1784,6 @@ class PlusCastFloat(ObjectInterpretation):
                 for (a, t) in zip(args, typs, strict=True)
             ]
             return monoid.plus(*args)
-        return fwd()
-
-
-class SumOptimumPlus(ObjectInterpretation):
-    """Lift :data:`Sum` to values carrying minimizing assignments."""
-
-    @implements(Sum.plus)
-    def plus(self, *args):
-        if not args or not all(isinstance(arg, Optimum) for arg in args):
-            return fwd()
-        if any(not arg.feasible for arg in args):
-            return Optimum(float("inf"), None)
-        return Optimum(
-            Sum.plus(*(arg.value for arg in args)),
-            _disjoint_merge(*(typing.cast(Mapping, arg.assignment) for arg in args)),
-        )
-
-
-class PlusCastOptimum(ObjectInterpretation):
-    """Promote plain scores when adding an assignment-carrying weight."""
-
-    @implements(Sum.plus)
-    def plus(self, *args):
-        if any(isinstance(arg, Optimum) for arg in args) and any(
-            not isinstance(arg, Optimum) for arg in args
-        ):
-            return Sum.plus(
-                *(arg if isinstance(arg, Optimum) else Optimum(arg, {}) for arg in args)
-            )
         return fwd()
 
 
@@ -2289,20 +2198,13 @@ EvaluateIntp = _ExtensibleInterpretation().extend(
     ReducePartial(),
     DeltaConcrete(),
     SumPlus(),
-    SumOptimumPlus(),
-    PlusCastOptimum(),
     MinPlus(),
-    MinOptimumPlus(),
     MaxPlus(),
-    MaxOptimumPlus(),
     ProductPlus(),
-    AssignmentPlus(),
-    ProductMonoidPlus(),
-    ArgMinPlus(),
-    ArgMaxPlus(),
     CartesianProductPlus(),
     UnionPlus(),
     IntersectionPlus(),
+    OptimumPlus(),
     ReduceWhereToMasks(),
 )
 
@@ -2354,7 +2256,7 @@ NormalizeIntp = _ExtensibleInterpretation().extend(
     PlusOrder(),
     PlusCastFloat(),
     PlusCastIterable(),
-    SumOptimumPlus(),
+    OptimumPlus(),
     PlusCastOptimum(),
     MaskFusion(),
     MaskBool(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -203,6 +203,42 @@ class MonoidWithZero[T](Monoid[T]):
         self.zero = zero
 
 
+class Optimum[T]:
+    """A value together with an assignment that attains it."""
+
+    __slots__ = ("assignment", "value")
+
+    def __init__(self, value: T, assignment: Mapping[Operation, Any] | None):
+        self.value = value
+        self.assignment = assignment
+
+    @property
+    def feasible(self) -> bool:
+        return self.assignment is not None
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, Optimum)
+            and self.value == other.value
+            and self.assignment == other.assignment
+        )
+
+    def __repr__(self) -> str:
+        return f"Optimum(value={self.value!r}, assignment={self.assignment!r})"
+
+
+@evaluate.register(Optimum)
+def _evaluate_optimum(expr: Optimum, **kwargs) -> Optimum:
+    """Evaluate an optimum's score and assignment values, preserving variable keys."""
+
+    assignment = (
+        None
+        if expr.assignment is None
+        else {variable: evaluate(value) for variable, value in expr.assignment.items()}
+    )
+    return Optimum(evaluate(expr.value), assignment)
+
+
 class ProductMonoid[L, R](Monoid[tuple[L, R]]):
     """The componentwise product of two monoids.
 
@@ -1612,6 +1648,24 @@ class ArgMinPlus(ObjectInterpretation):
         return min(args, key=lambda a: a[0])
 
 
+class MinOptimumPlus(ObjectInterpretation):
+    """Lift :data:`Min` to values carrying minimizing assignments."""
+
+    @implements(Min.plus)
+    def plus(self, *args):
+        if not args or not all(isinstance(a, Optimum) for a in args):
+            return fwd()
+        feasible = [a for a in args if a.feasible]
+        if not feasible:
+            return Optimum(Min.identity, None)
+        if any(isinstance(a.value, Term) for a in feasible):
+            return fwd()
+        try:
+            return min(feasible, key=lambda a: a.value)
+        except (TypeError, ValueError):
+            return fwd()
+
+
 class ArgMaxPlus(ObjectInterpretation):
     """Scalar score implementation of :data:`ArgMax`."""
 
@@ -1774,6 +1828,35 @@ class PlusCastFloat(ObjectInterpretation):
                 for (a, t) in zip(args, typs, strict=True)
             ]
             return monoid.plus(*args)
+        return fwd()
+
+
+class SumOptimumPlus(ObjectInterpretation):
+    """Lift :data:`Sum` to values carrying minimizing assignments."""
+
+    @implements(Sum.plus)
+    def plus(self, *args):
+        if not args or not all(isinstance(arg, Optimum) for arg in args):
+            return fwd()
+        if any(not arg.feasible for arg in args):
+            return Optimum(float("inf"), None)
+        return Optimum(
+            Sum.plus(*(arg.value for arg in args)),
+            _disjoint_merge(*(typing.cast(Mapping, arg.assignment) for arg in args)),
+        )
+
+
+class PlusCastOptimum(ObjectInterpretation):
+    """Promote plain scores when adding an assignment-carrying weight."""
+
+    @implements(Sum.plus)
+    def plus(self, *args):
+        if any(isinstance(arg, Optimum) for arg in args) and any(
+            not isinstance(arg, Optimum) for arg in args
+        ):
+            return Sum.plus(
+                *(arg if isinstance(arg, Optimum) else Optimum(arg, {}) for arg in args)
+            )
         return fwd()
 
 
@@ -2188,7 +2271,10 @@ EvaluateIntp = _ExtensibleInterpretation().extend(
     ReducePartial(),
     DeltaConcrete(),
     SumPlus(),
+    SumOptimumPlus(),
+    PlusCastOptimum(),
     MinPlus(),
+    MinOptimumPlus(),
     MaxPlus(),
     ProductPlus(),
     AssignmentPlus(),
@@ -2249,6 +2335,8 @@ NormalizeIntp = _ExtensibleInterpretation().extend(
     PlusOrder(),
     PlusCastFloat(),
     PlusCastIterable(),
+    SumOptimumPlus(),
+    PlusCastOptimum(),
     MaskFusion(),
     MaskBool(),
     WhereHoist(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -203,6 +203,31 @@ class MonoidWithZero[T](Monoid[T]):
         self.zero = zero
 
 
+class ProductMonoid[L, R](Monoid[tuple[L, R]]):
+    """The componentwise product of two monoids.
+
+    ``ProductMonoid(left, right).plus`` combines the first components with
+    ``left.plus`` and the second components with ``right.plus``.
+    """
+
+    left: Monoid[L]
+    right: Monoid[R]
+
+    def __init__(self, left: Monoid[L], right: Monoid[R], name: str | None = None):
+        self.left = left
+        self.right = right
+        super().__init__(
+            name=name or f"{left.__name__}×{right.__name__}",
+            identity=(left.identity, right.identity),
+        )
+
+        # Product operations inherit these algebraic properties componentwise.
+        if is_commutative(left) and is_commutative(right):
+            is_commutative.register(self)
+        if is_idempotent(left) and is_idempotent(right):
+            is_idempotent.register(self)
+
+
 Min = Monoid(name="Min", identity=float("inf"))
 Max = Monoid(name="Max", identity=-float("inf"))
 ArgMin = Monoid(name="ArgMin", identity=(Min.identity, None))
@@ -1613,6 +1638,39 @@ def _disjoint_merge[K, V](*dicts: Mapping[K, V]) -> Mapping[K, V]:
     return merged
 
 
+class AssignmentPlus(ObjectInterpretation):
+    """Disjoint-union implementation of :data:`Assignment`."""
+
+    @implements(Assignment.plus)
+    def plus(self, *args):
+        if not args:
+            return Assignment.identity
+        if any(isinstance(arg, Term) for arg in args):
+            return fwd()
+        if not all(isinstance(arg, Mapping) for arg in args):
+            return fwd()
+        return _disjoint_merge(*args)
+
+
+class ProductMonoidPlus(ObjectInterpretation):
+    """Componentwise implementation of :class:`ProductMonoid`."""
+
+    @implements(Monoid.plus)
+    def plus(self, monoid, *args):
+        if not isinstance(monoid, ProductMonoid):
+            return fwd()
+        if not args:
+            return monoid.identity
+        if any(isinstance(arg, Term) for arg in args):
+            return fwd()
+        if not all(isinstance(arg, tuple) and len(arg) == 2 for arg in args):
+            return fwd()
+        return (
+            monoid.left.plus(*(arg[0] for arg in args)),
+            monoid.right.plus(*(arg[1] for arg in args)),
+        )
+
+
 class CartesianProductPlus(ObjectInterpretation):
     """Pure-Python implementation of :data:`CartesianProduct`."""
 
@@ -2130,10 +2188,11 @@ EvaluateIntp = _ExtensibleInterpretation().extend(
     ReducePartial(),
     DeltaConcrete(),
     SumPlus(),
-    SumInverse(),
     MinPlus(),
     MaxPlus(),
     ProductPlus(),
+    AssignmentPlus(),
+    ProductMonoidPlus(),
     ArgMinPlus(),
     ArgMaxPlus(),
     CartesianProductPlus(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -1666,6 +1666,24 @@ class MinOptimumPlus(ObjectInterpretation):
             return fwd()
 
 
+class MaxOptimumPlus(ObjectInterpretation):
+    """Lift :data:`Max` to values carrying maximizing assignments."""
+
+    @implements(Max.plus)
+    def plus(self, *args):
+        if not args or not all(isinstance(a, Optimum) for a in args):
+            return fwd()
+        feasible = [a for a in args if a.feasible]
+        if not feasible:
+            return Optimum(Max.identity, None)
+        if any(isinstance(a.value, Term) for a in feasible):
+            return fwd()
+        try:
+            return max(feasible, key=lambda a: a.value)
+        except (TypeError, ValueError):
+            return fwd()
+
+
 class ArgMaxPlus(ObjectInterpretation):
     """Scalar score implementation of :data:`ArgMax`."""
 
@@ -2276,6 +2294,7 @@ EvaluateIntp = _ExtensibleInterpretation().extend(
     MinPlus(),
     MinOptimumPlus(),
     MaxPlus(),
+    MaxOptimumPlus(),
     ProductPlus(),
     AssignmentPlus(),
     ProductMonoidPlus(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -2246,8 +2246,6 @@ NormalizeIntp = _ExtensibleInterpretation().extend(
     MinPlus(),
     MaxPlus(),
     ProductPlus(),
-    ArgMinPlus(),
-    ArgMaxPlus(),
     CartesianProductPlus(),
     UnionPlus(),
     AndPlus(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -1579,42 +1579,6 @@ class LogSumExpPlus(ObjectInterpretation):
         )
 
 
-class MinOptimumPlus(ObjectInterpretation):
-    """Lift :data:`Min` to values carrying minimizing assignments."""
-
-    @implements(Min.plus)
-    def plus(self, *args):
-        if not args or not all(isinstance(a, Optimum) for a in args):
-            return fwd()
-        feasible = [a for a in args if a.feasible]
-        if not feasible:
-            return Optimum(Min.identity, None)
-        if any(isinstance(a.value, Term) for a in feasible):
-            return fwd()
-        try:
-            return min(feasible, key=lambda a: a.value)
-        except (TypeError, ValueError):
-            return fwd()
-
-
-class MaxOptimumPlus(ObjectInterpretation):
-    """Lift :data:`Max` to values carrying maximizing assignments."""
-
-    @implements(Max.plus)
-    def plus(self, *args):
-        if not args or not all(isinstance(a, Optimum) for a in args):
-            return fwd()
-        feasible = [a for a in args if a.feasible]
-        if not feasible:
-            return Optimum(Max.identity, None)
-        if any(isinstance(a.value, Term) for a in feasible):
-            return fwd()
-        try:
-            return max(feasible, key=lambda a: a.value)
-        except (TypeError, ValueError):
-            return fwd()
-
-
 def _disjoint_merge[K, V](*dicts: Mapping[K, V]) -> Mapping[K, V]:
     merged = {}
     for d in dicts:
@@ -1627,17 +1591,22 @@ def _disjoint_merge[K, V](*dicts: Mapping[K, V]) -> Mapping[K, V]:
     return merged
 
 
-class OptimumPlus(ObjectInterpretation):
-    @staticmethod
-    def _optimum_min_max(func, *args):
-        if (
-            not args
-            or not any(isinstance(a, Optimum) for a in args)
-            or any(isinstance(a, Optimum) and isinstance(a.value, Term) for a in args)
-        ):
-            return fwd()
+class PlusOptimum(ObjectInterpretation):
+    """Sum values that are annotated with a minimizing (or maximizing) assignment."""
 
-        return func(args, key=lambda a: a.value if isinstance(a, Optimum) else a)
+    def _is_reducible(self, args):
+        return (
+            args
+            and any(isinstance(a, Optimum) for a in args)
+            and all(not fvsof(a.value if isinstance(a, Optimum) else a) for a in args)
+        )
+
+    def _optimum_min_max(self, func, *args):
+        return (
+            func(args, key=lambda a: a.value if isinstance(a, Optimum) else a)
+            if self._is_reducible(args)
+            else fwd()
+        )
 
     @implements(Min.plus)
     def _min_plus(self, *args):
@@ -1649,20 +1618,43 @@ class OptimumPlus(ObjectInterpretation):
 
     @implements(Sum.plus)
     def _sum_plus(self, *args):
-        if not args or not any(isinstance(arg, Optimum) for arg in args):
-            return fwd()
-        return Optimum(
-            Sum.plus(*(arg.value if isinstance(arg, Optimum) else arg for arg in args)),
-            _disjoint_merge(
-                *(arg.assignment if isinstance(arg, Optimum) else {} for arg in args)
-            ),
+        return (
+            Optimum(
+                Sum.plus(
+                    *(arg.value if isinstance(arg, Optimum) else arg for arg in args)
+                ),
+                _disjoint_merge(
+                    *(
+                        arg.assignment if isinstance(arg, Optimum) else {}
+                        for arg in args
+                    )
+                ),
+            )
+            if self._is_reducible(args)
+            else fwd()
         )
 
     @implements(Monoid.plus)
     def plus(self, monoid, *args):
-        if not args or not any(isinstance(arg, Optimum) for arg in args):
-            return fwd()
-        return monoid.plus(*(a.value if isinstance(a, Optimum) else a for a in args))
+        return (
+            monoid.plus(*(a.value if isinstance(a, Optimum) else a for a in args))
+            if self._is_reducible(args)
+            else fwd()
+        )
+
+
+class PlusCastOptimum(ObjectInterpretation):
+    """Upcast non-Optimum arguments to Monoid.plus."""
+
+    @implements(Monoid.plus)
+    def plus(self, monoid, *args):
+        num_optimum = sum(isinstance(a, Optimum) for a in args)
+        if 0 < num_optimum < len(args):
+            new_args = (
+                Optimum(a, {}) if not isinstance(a, Optimum) else a for a in args
+            )
+            return monoid.plus(*new_args)
+        return fwd()
 
 
 class CartesianProductPlus(ObjectInterpretation):
@@ -2188,7 +2180,7 @@ EvaluateIntp = _ExtensibleInterpretation().extend(
     CartesianProductPlus(),
     UnionPlus(),
     IntersectionPlus(),
-    OptimumPlus(),
+    PlusOptimum(),
     ReduceWhereToMasks(),
 )
 

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -2232,7 +2232,7 @@ NormalizeIntp = _ExtensibleInterpretation().extend(
     PlusOrder(),
     PlusCastFloat(),
     PlusCastIterable(),
-    OptimumPlus(),
+    PlusOptimum(),
     PlusCastOptimum(),
     MaskFusion(),
     MaskBool(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -213,8 +213,6 @@ class Optimum[T]:
 
 Min = Monoid(name="Min", identity=float("inf"))
 Max = Monoid(name="Max", identity=-float("inf"))
-ArgMin = Monoid(name="ArgMin", identity=(Min.identity, None))
-ArgMax = Monoid(name="ArgMax", identity=(Max.identity, None))
 Sum = Group(name="Sum", identity=0)
 Product = MonoidWithZero(name="Product", identity=1, zero=0)
 LogSumExp = Monoid(name="LogSumExp", identity=float("-inf"))
@@ -1665,20 +1663,6 @@ class OptimumPlus(ObjectInterpretation):
         if not args or not any(isinstance(arg, Optimum) for arg in args):
             return fwd()
         return monoid.plus(*(a.value if isinstance(a, Optimum) else a for a in args))
-
-
-class AssignmentPlus(ObjectInterpretation):
-    """Disjoint-union implementation of :data:`Assignment`."""
-
-    @implements(Assignment.plus)
-    def plus(self, *args):
-        if not args:
-            return Assignment.identity
-        if any(isinstance(arg, Term) for arg in args):
-            return fwd()
-        if not all(isinstance(arg, Mapping) for arg in args):
-            return fwd()
-        return _disjoint_merge(*args)
 
 
 class CartesianProductPlus(ObjectInterpretation):

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -1039,7 +1039,7 @@ def syntactic_hash(__dispatch: Callable[[type], Callable[[Any], int]], x) -> int
     :param x: A term.
     :returns: An integer hash.
     """
-    if dataclasses.is_dataclass(x) and not isinstance(x, type):
+    if dataclasses.is_dataclass(x) and not isinstance(x, type | Term):
         return hash(
             (
                 "dataclass",

--- a/tests/test_handlers_jax_monoid.py
+++ b/tests/test_handlers_jax_monoid.py
@@ -21,15 +21,11 @@ from effectful.handlers.jax.monoid import (
 from effectful.ops.monoid import (
     EliminateSingletonStreams,
     EvaluateIntp,
-    Max,
-    Min,
     NormalizeIntp,
-    Optimum,
     Product,
     Sum,
 )
 from effectful.ops.semantics import coproduct, evaluate, handler
-from effectful.ops.syntax import deffn
 from tests._monoid_helpers import JaxBackend
 
 MONOIDS = [

--- a/tests/test_handlers_jax_monoid.py
+++ b/tests/test_handlers_jax_monoid.py
@@ -21,11 +21,15 @@ from effectful.handlers.jax.monoid import (
 from effectful.ops.monoid import (
     EliminateSingletonStreams,
     EvaluateIntp,
+    Max,
+    Min,
     NormalizeIntp,
+    Optimum,
     Product,
     Sum,
 )
 from effectful.ops.semantics import coproduct, evaluate, handler
+from effectful.ops.syntax import deffn
 from tests._monoid_helpers import JaxBackend
 
 MONOIDS = [
@@ -122,6 +126,47 @@ def test_reduce_array_2(monoid, reductor, backend: JaxBackend):
         )
 
     assert jnp.allclose(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "monoid,expected_value,expected_assignment",
+    [(Min, 0, 1), (Max, 4, 3)],
+)
+def test_reduce_optimum_weighted_stream(
+    monoid, expected_value, expected_assignment, backend: JaxBackend
+):
+    x, v = backend.define_vars("x", "v", ret="scalar")
+    expr = monoid.reduce(
+        (x() - 1) ** 2,
+        {x: Sum.weighted(range(4), deffn(Optimum(0, {x: v()}), v))},
+    )
+
+    with handler(NormalizeIntp), handler(EvaluateIntp):
+        actual = evaluate(expr)
+
+    assert isinstance(actual, Optimum)
+    assert jnp.array_equal(actual.value, expected_value)
+    assert actual.assignment is not None
+    assert jnp.array_equal(actual.assignment[x], expected_assignment)
+
+
+def test_reduce_optimum_jit(backend: JaxBackend):
+    x = backend.define_vars("x", ret="scalar")
+
+    @jax.jit
+    def run(scores):
+        with handler(NormalizeIntp), handler(EvaluateIntp):
+            return Min.reduce(
+                Optimum(unbind_dims(scores, x), {x: x()}),
+                {x: range(scores.shape[0])},
+            )
+
+    actual = run(jnp.asarray([3.0, 1.0, 2.0]))
+
+    assert isinstance(actual, Optimum)
+    assert jnp.array_equal(actual.value, 1.0)
+    assert actual.assignment is not None
+    assert jnp.array_equal(actual.assignment[x], 1)
 
 
 SCALAR_PLUS = [

--- a/tests/test_handlers_jax_monoid.py
+++ b/tests/test_handlers_jax_monoid.py
@@ -128,47 +128,6 @@ def test_reduce_array_2(monoid, reductor, backend: JaxBackend):
     assert jnp.allclose(actual, expected)
 
 
-@pytest.mark.parametrize(
-    "monoid,expected_value,expected_assignment",
-    [(Min, 0, 1), (Max, 4, 3)],
-)
-def test_reduce_optimum_weighted_stream(
-    monoid, expected_value, expected_assignment, backend: JaxBackend
-):
-    x, v = backend.define_vars("x", "v", ret="scalar")
-    expr = monoid.reduce(
-        (x() - 1) ** 2,
-        {x: Sum.weighted(range(4), deffn(Optimum(0, {x: v()}), v))},
-    )
-
-    with handler(NormalizeIntp), handler(EvaluateIntp):
-        actual = evaluate(expr)
-
-    assert isinstance(actual, Optimum)
-    assert jnp.array_equal(actual.value, expected_value)
-    assert actual.assignment is not None
-    assert jnp.array_equal(actual.assignment[x], expected_assignment)
-
-
-def test_reduce_optimum_jit(backend: JaxBackend):
-    x = backend.define_vars("x", ret="scalar")
-
-    @jax.jit
-    def run(scores):
-        with handler(NormalizeIntp), handler(EvaluateIntp):
-            return Min.reduce(
-                Optimum(unbind_dims(scores, x), {x: x()}),
-                {x: range(scores.shape[0])},
-            )
-
-    actual = run(jnp.asarray([3.0, 1.0, 2.0]))
-
-    assert isinstance(actual, Optimum)
-    assert jnp.array_equal(actual.value, 1.0)
-    assert actual.assignment is not None
-    assert jnp.array_equal(actual.assignment[x], 1)
-
-
 SCALAR_PLUS = [
     pytest.param(Sum, 3.0, id="Sum"),
     pytest.param(Product, 2.0, id="Product"),

--- a/tests/test_handlers_numpyro.py
+++ b/tests/test_handlers_numpyro.py
@@ -12,8 +12,8 @@ import effectful.handlers.jax.monoid  # noqa: F401
 import effectful.handlers.jax.numpy as jnp
 import effectful.handlers.numpyro as dist
 from effectful.handlers.jax import bind_dims, jax_getitem, sizesof, unbind_dims
-from effectful.ops.monoid import LogSumExp, Product, Sum
-from effectful.ops.semantics import typeof
+from effectful.ops.monoid import LogSumExp, Min, Optimum, Product, Sum
+from effectful.ops.semantics import handler, typeof
 from effectful.ops.syntax import deffn, defop
 from effectful.ops.types import Operation, Term
 from tests._monoid_helpers import JaxBackend
@@ -1058,3 +1058,87 @@ def test_expand_to_event_chain_end_to_end_mcmc():
         mcmc.run(jr.PRNGKey(0))
 
     assert mcmc.get_samples()["theta"].shape == (20, 3)
+
+
+def test_nest_constraint_min_reduce():
+    x = defop(jax.Array, name="x")
+    y = defop(jax.Array, name="y")
+    constrained = dist.constraint_stream(
+        numpyro.distributions.constraints.positive, jnp.asarray(1.0)
+    )
+
+    with handler(dist.NestConstraintMinReduce()):
+        result = Min.reduce(x(), {x: constrained, y: range(3)})
+
+    assert isinstance(result, Term) and result.op is Min.reduce
+    inner, outer_streams = result.args
+    assert list(outer_streams.values()) == [range(3)]
+    assert isinstance(inner, Term) and inner.op is Min.reduce
+    assert len(inner.args[1]) == 1
+    inner_stream = next(iter(inner.args[1].values()))
+    assert isinstance(inner_stream, Term) and inner_stream.op is dist.constraint_stream
+
+
+def test_adam_constraint_min_reduce():
+    x = defop(jax.Array, name="x")
+    y = defop(jax.Array, name="y")
+    streams = {
+        x: dist.constraint_stream(
+            numpyro.distributions.constraints.positive, jnp.asarray(0.5)
+        ),
+        y: dist.constraint_stream(
+            numpyro.distributions.constraints.real, jnp.asarray(0.0)
+        ),
+    }
+    objective = Optimum(
+        (x() - 2.0) ** 2 + (y() + 1.0) ** 2,
+        {"x": x(), "y": y()},
+    )
+
+    with handler(dist.AdamConstraintMinReduce(step_size=0.05, num_steps=500)):
+        result = Min.reduce(objective, streams)
+
+    assert isinstance(result, Optimum)
+    assert jnp.allclose(result.value, 0.0, atol=1e-5)
+    assert jnp.allclose(result.assignment["x"], 2.0, atol=1e-4)
+    assert jnp.allclose(result.assignment["y"], -1.0, atol=1e-4)
+
+
+def test_adam_constraint_min_reduce_initializes_with_feasible_like():
+    x = defop(jax.Array, name="x")
+    constraint = numpyro.distributions.constraints.interval(-2.0, 4.0)
+    stream = dist.constraint_stream(constraint, jnp.asarray(100.0))
+
+    with handler(dist.AdamConstraintMinReduce(num_steps=0)):
+        result = Min.reduce(x(), {x: stream})
+
+    assert jnp.allclose(result, 1.0)
+
+
+def test_adam_constraint_min_reduce_forwards_mixed_bundle():
+    x = defop(jax.Array, name="x")
+    y = defop(jax.Array, name="y")
+    constrained = dist.constraint_stream(
+        numpyro.distributions.constraints.real, jnp.asarray(0.0)
+    )
+
+    with handler(dist.AdamConstraintMinReduce()):
+        result = Min.reduce(x() ** 2, {x: constrained, y: range(2)})
+
+    assert isinstance(result, Term) and result.op is Min.reduce
+    assert len(result.args[1]) == 2
+
+
+def test_nest_constraint_min_reduce_preserves_stream_dependencies():
+    x = defop(jax.Array, name="x")
+    y = defop(jax.Array, name="y")
+    constrained = dist.constraint_stream(
+        numpyro.distributions.constraints.positive, jnp.asarray(1.0)
+    )
+
+    with handler(dist.NestConstraintMinReduce()):
+        result = Min.reduce(x(), {x: constrained, y: (x(),)})
+
+    assert isinstance(result, Term) and result.op is Min.reduce
+    assert len(result.args[1]) == 2
+    assert not (isinstance(result.args[0], Term) and result.args[0].op is Min.reduce)

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -41,7 +41,6 @@ from effectful.ops.monoid import (
     PlusPartial,
     PlusSingle,
     Product,
-    ProductMonoid,
     ReduceDependentRangeMask,
     ReduceDisjunctiveDisequalityMask,
     ReduceDistributeCartesianProduct,
@@ -580,25 +579,6 @@ def test_assignment_plus_disjoint_merge():
 def test_assignment_plus_rejects_duplicate_keys():
     with handler(EvaluateIntp), pytest.raises(ValueError, match="Duplicate key"):
         Assignment.plus({"x": 1}, {"x": 1})
-
-
-def test_product_monoid_plus():
-    scored_assignment = ProductMonoid(Sum, Assignment)
-
-    with handler(EvaluateIntp):
-        result = scored_assignment.plus((2, {"x": 1}), (3, {"y": 2}))
-
-    assert result == (5, {"x": 1, "y": 2})
-    assert scored_assignment.identity == (0, {})
-    assert is_commutative(scored_assignment)
-    assert not is_idempotent(scored_assignment)
-
-
-def test_product_monoid_inherits_idempotence():
-    extrema = ProductMonoid(Min, Max)
-
-    assert is_commutative(extrema)
-    assert is_idempotent(extrema)
 
 
 def test_plus_partial():
@@ -1637,45 +1617,45 @@ def test_reduce_unfactor_reduces(Sum, Product, backend: Backend):
 
 
 def test_reduce_argmin(backend: Backend):
-    x, v = backend.define_vars("x", "v", ret="scalar")
+    x, xx, v = backend.define_vars("x", "xx", "v", ret="scalar")
 
     expr = Min.reduce(
         (x() - 1) ** 2,
-        {x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {x: v()}), v))},
+        {x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {xx: v()}), v))},
     )
 
     with handler(NormalizeIntp), handler(EvaluateIntp):
         result = evaluate(expr)
 
-    assert result == Optimum(0, {x: 1})
+    assert result == Optimum(0, {xx: 1})
 
 
 def test_reduce_argmin_sum(backend: Backend):
-    x, v = backend.define_vars("x", "v", ret="scalar")
+    x, xx, v = backend.define_vars("x", "xx", "v", ret="scalar")
 
     expr = Min.reduce(
         Sum.plus((x() - 1) ** 2, 2 * (x() - 2) ** 2),
-        {x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {x: v()}), v))},
+        {x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {xx: v()}), v))},
     )
 
     with handler(NormalizeIntp), handler(EvaluateIntp):
         result = evaluate(expr)
 
-    assert result == Optimum(1, {x: 2})
+    assert result == Optimum(1, {xx: 2})
 
 
 def test_reduce_argmin_sum_disjoint(backend: Backend):
-    x, y, v = backend.define_vars("x", "y", "v", ret="scalar")
+    x, xx, y, yy, v = backend.define_vars("x", "xx", "y", "yy", "v", ret="scalar")
 
     expr = Min.reduce(
         Sum.plus((x() - 1) ** 2, (y() - 2) ** 2),
         {
-            x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {x: v()}), v)),
-            y: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {y: v()}), v)),
+            x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {xx: v()}), v)),
+            y: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {yy: v()}), v)),
         },
     )
 
     with handler(NormalizeIntp), handler(EvaluateIntp):
         result = evaluate(expr)
 
-    assert result == Optimum(0, {x: 1, y: 2})
+    assert result == Optimum(0, {xx: 1, yy: 2})

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -1,5 +1,6 @@
 import functools
 import math
+import numbers
 import operator
 import sys
 import typing
@@ -12,6 +13,7 @@ from hypothesis import strategies as st
 import effectful.handlers.jax.monoid  # noqa: F401
 from effectful.ops.monoid import (
     And,
+    Assignment,
     CartesianProduct,
     CartesianProductPlus,
     EliminateSingletonStreams,
@@ -39,6 +41,7 @@ from effectful.ops.monoid import (
     PlusPartial,
     PlusSingle,
     Product,
+    ProductMonoid,
     ReduceDependentRangeMask,
     ReduceDisjunctiveDisequalityMask,
     ReduceDistributeCartesianProduct,
@@ -566,6 +569,36 @@ def test_plus_zero(monoid, backend: Backend):
     rhs = monoid.zero
     backend.check_rewrite(lhs=lhs_right, rhs=rhs, rule={})
     backend.check_rewrite(lhs=lhs_left, rhs=rhs, rule={})
+
+
+def test_assignment_plus_disjoint_merge():
+    with handler(EvaluateIntp):
+        assert Assignment.plus({"x": 1}, {"y": 2}) == {"x": 1, "y": 2}
+        assert Assignment.plus() == {}
+
+
+def test_assignment_plus_rejects_duplicate_keys():
+    with handler(EvaluateIntp), pytest.raises(ValueError, match="Duplicate key"):
+        Assignment.plus({"x": 1}, {"x": 1})
+
+
+def test_product_monoid_plus():
+    scored_assignment = ProductMonoid(Sum, Assignment)
+
+    with handler(EvaluateIntp):
+        result = scored_assignment.plus((2, {"x": 1}), (3, {"y": 2}))
+
+    assert result == (5, {"x": 1, "y": 2})
+    assert scored_assignment.identity == (0, {})
+    assert is_commutative(scored_assignment)
+    assert not is_idempotent(scored_assignment)
+
+
+def test_product_monoid_inherits_idempotence():
+    extrema = ProductMonoid(Min, Max)
+
+    assert is_commutative(extrema)
+    assert is_idempotent(extrema)
 
 
 def test_plus_partial():
@@ -1601,3 +1634,23 @@ def test_reduce_unfactor_reduces(Sum, Product, backend: Backend):
     )
     rhs = Sum.reduce(Product.plus(f(x()), g(y())), {x: X(), y: Y(), z: Z()})
     backend.check_rewrite(lhs=lhs, rhs=rhs, rule=ReduceUnfactor())
+
+
+def test_reduce_argmin(backend: Backend):
+    x, y, z = backend.define_vars("x", "y", "z", ret="scalar")
+    X, Y, Z = backend.define_vars("X", "Y", "Z", ret="stream")
+
+    class ArgValue[T: numbers.Number]:
+        score: T = Sum.identity
+        assignment: Mapping[Operation, Any]
+
+    ArgSum = Monoid(name="ArgSum", identity=ArgValue())
+
+    lhs = Min.reduce(
+        (x() - 1) ** 2,
+        {
+            x: ArgSum.weighted(
+                range(3),
+            )
+        },
+    )

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -68,7 +68,7 @@ from effectful.ops.monoid import (
     solve_group_equality,
 )
 from effectful.ops.semantics import coproduct, evaluate, fvsof, handler
-from effectful.ops.syntax import as_dict, ite, range_, syntactic_eq
+from effectful.ops.syntax import as_dict, deffn, ite, range_, syntactic_eq
 from effectful.ops.types import NotHandled, Operation, Term
 from tests._monoid_helpers import Backend, IntBackend, JaxBackend, syntactic_eq_alpha
 
@@ -1637,22 +1637,45 @@ def test_reduce_unfactor_reduces(Sum, Product, backend: Backend):
 
 
 def test_reduce_argmin(backend: Backend):
-    x = backend.define_vars("x", ret="scalar")
-
-    def record_assignment(value):
-        return Optimum(Sum.identity, {x: value})
+    x, v = backend.define_vars("x", "v", ret="scalar")
 
     expr = Min.reduce(
         (x() - 1) ** 2,
-        {x: Sum.weighted(range(3), record_assignment)},
+        {x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {x: v()}), v))},
     )
-
-    with handler(NormalizeIntp):
-        norm_expr = evaluate(expr)
-
-    breakpoint()
 
     with handler(NormalizeIntp), handler(EvaluateIntp):
         result = evaluate(expr)
 
     assert result == Optimum(0, {x: 1})
+
+
+def test_reduce_argmin_sum(backend: Backend):
+    x, v = backend.define_vars("x", "v", ret="scalar")
+
+    expr = Min.reduce(
+        Sum.plus((x() - 1) ** 2, 2 * (x() - 2) ** 2),
+        {x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {x: v()}), v))},
+    )
+
+    with handler(NormalizeIntp), handler(EvaluateIntp):
+        result = evaluate(expr)
+
+    assert result == Optimum(1, {x: 2})
+
+
+def test_reduce_argmin_sum_disjoint(backend: Backend):
+    x, y, v = backend.define_vars("x", "y", "v", ret="scalar")
+
+    expr = Min.reduce(
+        Sum.plus((x() - 1) ** 2, (y() - 2) ** 2),
+        {
+            x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {x: v()}), v)),
+            y: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {y: v()}), v)),
+        },
+    )
+
+    with handler(NormalizeIntp), handler(EvaluateIntp):
+        result = evaluate(expr)
+
+    assert result == Optimum(0, {x: 1, y: 2})

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -1,6 +1,5 @@
 import functools
 import math
-import numbers
 import operator
 import sys
 import typing
@@ -30,6 +29,7 @@ from effectful.ops.monoid import (
     MonoidOverMapping,
     MonoidOverSequence,
     NormalizeIntp,
+    Optimum,
     Or,
     PlusAssoc,
     PlusCastIterable,
@@ -1637,20 +1637,22 @@ def test_reduce_unfactor_reduces(Sum, Product, backend: Backend):
 
 
 def test_reduce_argmin(backend: Backend):
-    x, y, z = backend.define_vars("x", "y", "z", ret="scalar")
-    X, Y, Z = backend.define_vars("X", "Y", "Z", ret="stream")
+    x = backend.define_vars("x", ret="scalar")
 
-    class ArgValue[T: numbers.Number]:
-        score: T = Sum.identity
-        assignment: Mapping[Operation, Any]
+    def record_assignment(value):
+        return Optimum(Sum.identity, {x: value})
 
-    ArgSum = Monoid(name="ArgSum", identity=ArgValue())
-
-    lhs = Min.reduce(
+    expr = Min.reduce(
         (x() - 1) ** 2,
-        {
-            x: ArgSum.weighted(
-                range(3),
-            )
-        },
+        {x: Sum.weighted(range(3), record_assignment)},
     )
+
+    with handler(NormalizeIntp):
+        norm_expr = evaluate(expr)
+
+    breakpoint()
+
+    with handler(NormalizeIntp), handler(EvaluateIntp):
+        result = evaluate(expr)
+
+    assert result == Optimum(0, {x: 1})

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -12,7 +12,6 @@ from hypothesis import strategies as st
 import effectful.handlers.jax.monoid  # noqa: F401
 from effectful.ops.monoid import (
     And,
-    Assignment,
     CartesianProduct,
     CartesianProductPlus,
     EliminateSingletonStreams,
@@ -567,17 +566,6 @@ def test_plus_zero(monoid, backend: Backend):
     rhs = monoid.zero
     backend.check_rewrite(lhs=lhs_right, rhs=rhs, rule={})
     backend.check_rewrite(lhs=lhs_left, rhs=rhs, rule={})
-
-
-def test_assignment_plus_disjoint_merge():
-    with handler(EvaluateIntp):
-        assert Assignment.plus({"x": 1}, {"y": 2}) == {"x": 1, "y": 2}
-        assert Assignment.plus() == {}
-
-
-def test_assignment_plus_rejects_duplicate_keys():
-    with handler(EvaluateIntp), pytest.raises(ValueError, match="Duplicate key"):
-        Assignment.plus({"x": 1}, {"x": 1})
 
 
 def test_plus_partial():
@@ -1356,6 +1344,86 @@ def test_reduce_weighted_factorization(backend: Backend):
         Sum.reduce(Product.plus(w_a(a()), Product.plus(f(a()))), {a: A()}),
         Sum.reduce(Product.plus(w_b(b()), Product.plus(g(b()))), {b: B()}),
     )
+    backend.check_rewrite(
+        lhs=lhs, rhs=rhs, rule=coproduct(ReduceWeightedStream(), Factor())
+    )
+
+
+def test_reduce_argmin_weighted_factorization(backend: Backend):
+    """Factoring a separable argmin preserves both minimizing assignments."""
+    x, xx, y, yy, v = backend.define_vars("x", "xx", "y", "yy", "v", ret="scalar")
+
+    lhs = Min.reduce(
+        Sum.plus(Optimum((x() - 1) ** 2, {}), Optimum((y() - 2) ** 2, {})),
+        {
+            x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {xx: v()}), v)),
+            y: Sum.weighted(range(4), deffn(Optimum(Sum.identity, {yy: v()}), v)),
+        },
+    )
+    rhs = Sum.plus(
+        Min.reduce(
+            Sum.plus(
+                Optimum(Sum.identity, {xx: x()}),
+                Sum.plus(Optimum((x() - 1) ** 2, {})),
+            ),
+            {x: range(3)},
+        ),
+        Min.reduce(
+            Sum.plus(
+                Optimum(Sum.identity, {yy: y()}),
+                Sum.plus(Optimum((y() - 2) ** 2, {})),
+            ),
+            {y: range(4)},
+        ),
+    )
+
+    backend.check_rewrite(
+        lhs=lhs, rhs=rhs, rule=coproduct(ReduceWeightedStream(), Factor())
+    )
+
+
+def test_reduce_argmin_weighted_repeated_factorization(backend: Backend):
+    """Factoring repeatedly preserves every weighted minimizing assignment."""
+    x, xx, y, yy, z, zz, v = backend.define_vars(
+        "x", "xx", "y", "yy", "z", "zz", "v", ret="scalar"
+    )
+
+    lhs = Min.reduce(
+        Sum.plus(
+            Optimum((x() - 1) ** 2, {}),
+            Optimum((y() - 2) ** 2, {}),
+            Optimum((z() - 3) ** 2, {}),
+        ),
+        {
+            x: Sum.weighted(range(3), deffn(Optimum(Sum.identity, {xx: v()}), v)),
+            y: Sum.weighted(range(4), deffn(Optimum(Sum.identity, {yy: v()}), v)),
+            z: Sum.weighted(range(5), deffn(Optimum(Sum.identity, {zz: v()}), v)),
+        },
+    )
+    rhs = Sum.plus(
+        Min.reduce(
+            Sum.plus(
+                Optimum(Sum.identity, {xx: x()}),
+                Sum.plus(Optimum((x() - 1) ** 2, {})),
+            ),
+            {x: range(3)},
+        ),
+        Min.reduce(
+            Sum.plus(
+                Optimum(Sum.identity, {yy: y()}),
+                Sum.plus(Optimum((y() - 2) ** 2, {})),
+            ),
+            {y: range(4)},
+        ),
+        Min.reduce(
+            Sum.plus(
+                Optimum(Sum.identity, {zz: z()}),
+                Sum.plus(Optimum((z() - 3) ** 2, {})),
+            ),
+            {z: range(5)},
+        ),
+    )
+
     backend.check_rewrite(
         lhs=lhs, rhs=rhs, rule=coproduct(ReduceWeightedStream(), Factor())
     )

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -62,6 +62,7 @@ from effectful.ops.monoid import (
     as_iterable,
     distributes_over,
     is_commutative,
+    is_idempotent,
     solve_group_equality,
 )
 from effectful.ops.semantics import coproduct, evaluate, fvsof, handler

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -63,7 +63,6 @@ from effectful.ops.monoid import (
     as_iterable,
     distributes_over,
     is_commutative,
-    is_idempotent,
     solve_group_equality,
 )
 from effectful.ops.semantics import coproduct, evaluate, fvsof, handler


### PR DESCRIPTION
Replaces the existing `ArgMin` and `ArgMax` monoids because those are incompatible with the factoring transformation.