### PR TITLE
Unify caching mechanisms and separate their management from `Interpretation`s

### DIFF
--- a/effectful/internals/runtime.py
+++ b/effectful/internals/runtime.py
@@ -132,6 +132,24 @@ def _save_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     return _cont_wrapper
 
 
+@weak_memoize
+def _save_then_restore_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
+    # should be equivalent to _restore_args(_save_args(fn)), just fused
+    from effectful.ops.semantics import handler
+
+    sig = inspect.signature(fn)
+    if not sig.parameters:
+        return fn
+
+    @functools.wraps(fn)
+    def _cont_wrapper(*a: P.args, **k: P.kwargs) -> T:
+        a, k = (a, k) if a or k else _get_args()
+        with handler({_get_args: lambda: (a, k)}):
+            return fn(*a, **k)
+
+    return _cont_wrapper
+
+
 def _set_prompt[**P, T](
     prompt: Operation[P, T], cont: Callable[P, T], body: Callable[P, T]
 ) -> Callable[P, T]:

--- a/effectful/internals/runtime.py
+++ b/effectful/internals/runtime.py
@@ -21,8 +21,7 @@ INTERPRETATION: contextvars.ContextVar[Interpretation] = contextvars.ContextVar(
 )
 
 
-def get_interpretation():
-    return INTERPRETATION.get()
+get_interpretation = INTERPRETATION.get
 
 
 @contextlib.contextmanager
@@ -157,7 +156,7 @@ def _set_prompt[**P, T](
 
     @functools.wraps(body)
     def bound_body(*a: P.args, **k: P.kwargs) -> T:
-        next_cont = get_interpretation().get(prompt, prompt.__default_rule__)
+        next_cont = INTERPRETATION.get().get(prompt, prompt.__default_rule__)
         with handler({prompt: handler({prompt: next_cont})(cont)}):
             return body(*a, **k)
 

--- a/effectful/internals/runtime.py
+++ b/effectful/internals/runtime.py
@@ -1,44 +1,100 @@
 import contextlib
-import dataclasses
+import contextvars
 import functools
 import inspect
+import typing
 from collections.abc import Callable, Mapping
-from threading import local
 
 from effectful.internals.weak import AutoIdKeyDictionary
 from effectful.ops.types import Interpretation, Operation
 
+type CacheEntry = AutoIdKeyDictionary[Interpretation, typing.Any]
+type EvalCache = AutoIdKeyDictionary[typing.Any, CacheEntry]
 
-@dataclasses.dataclass
-class Runtime[S, T](local):
-    interpretation: "Interpretation[S, T]"
-    cache: AutoIdKeyDictionary | None
+EVAL_CACHE: contextvars.ContextVar[EvalCache | None] = contextvars.ContextVar(
+    "EVAL_CACHE", default=None
+)
 
 
-@functools.lru_cache(maxsize=1)
-def get_runtime() -> Runtime:
-    return Runtime(interpretation={}, cache=None)
+INTERPRETATION: contextvars.ContextVar[Interpretation] = contextvars.ContextVar(
+    "INTERPRETATION", default=typing.cast(Interpretation, {})
+)
 
 
 def get_interpretation():
-    return get_runtime().interpretation
+    return INTERPRETATION.get()
 
 
 @contextlib.contextmanager
 def interpreter(intp: "Interpretation"):
-    r = get_runtime()
-    old_intp, old_cache = r.interpretation, r.cache
+    token = INTERPRETATION.set(intp)
     try:
-        old_intp, r.interpretation = r.interpretation, intp
-        old_cache, r.cache = (
-            r.cache,
-            old_cache
-            if old_intp is intp and old_cache is not None
-            else AutoIdKeyDictionary(),
-        )
         yield intp
     finally:
-        r.interpretation, r.cache = old_intp, old_cache
+        INTERPRETATION.reset(token)
+
+
+@contextlib.contextmanager
+def cache(store: EvalCache | None = None):
+    """Memoize evaluation under any interpretation for the duration of this block.
+
+    Installs ``store``, or a fresh cache if none is given, and yields it so that a
+    later block can reuse it::
+
+        with cache() as store:
+            ...
+        with cache(store):
+            ...
+
+    :func:`effectful.ops.semantics.evaluate` installs one for the duration of a
+    call when none is active, so a lone call is memoized internally whether or not
+    a scope is open. Holding a scope is what shares that work *between* calls.
+    """
+    store = AutoIdKeyDictionary() if store is None else store
+    token = EVAL_CACHE.set(store)
+    try:
+        yield store
+    finally:
+        EVAL_CACHE.reset(token)
+
+
+def cache_get(
+    store: EvalCache,
+    expr: typing.Any,
+    intp: "Interpretation",
+    default: typing.Any = None,
+) -> typing.Any:
+    """Look ``expr`` up under ``intp``, returning ``default`` if it is not cached."""
+    inner = store.get(expr)
+    return default if inner is None else inner.get(intp, default)
+
+
+def cache_put(
+    store: EvalCache, expr: typing.Any, intp: "Interpretation", value: typing.Any
+) -> None:
+    """Record that ``expr`` evaluates to ``value`` under ``intp``."""
+    inner = store.get(expr)
+    if inner is None:
+        # Same flavour as the outer store, so the inner map accepts the plain
+        # ``dict`` interpretations that ``coproduct`` builds.
+        inner = type(store)()
+        store[expr] = inner
+    inner[intp] = value
+
+
+def copy_cache_entries(src, dst) -> None:
+    """Copy everything cached for ``src`` onto ``dst``.
+
+    :func:`effectful.ops.syntax._build_term` computes a node's type analysis on a
+    throwaway term and then needs it attributed to the term it actually returns.
+    """
+    store = EVAL_CACHE.get()
+    if store is None:
+        return
+    inner = store.get(src)
+    if inner is not None:
+        for intp, value in inner.items():
+            cache_put(store, dst, intp, value)
 
 
 @Operation.define

--- a/effectful/internals/runtime.py
+++ b/effectful/internals/runtime.py
@@ -2,17 +2,17 @@ import contextlib
 import dataclasses
 import functools
 import inspect
-import typing
-from collections.abc import Callable, Mapping, MutableMapping
+from collections.abc import Callable, Mapping
 from threading import local
 
+from effectful.internals.weak import AutoIdKeyDictionary
 from effectful.ops.types import Interpretation, Operation
 
 
 @dataclasses.dataclass
 class Runtime[S, T](local):
     interpretation: "Interpretation[S, T]"
-    cache: MutableMapping[int, typing.Any] | None
+    cache: AutoIdKeyDictionary | None
 
 
 @functools.lru_cache(maxsize=1)
@@ -32,7 +32,9 @@ def interpreter(intp: "Interpretation"):
         old_intp, r.interpretation = r.interpretation, intp
         old_cache, r.cache = (
             r.cache,
-            old_cache if old_intp is intp and old_cache is not None else {},
+            old_cache
+            if old_intp is intp and old_cache is not None
+            else AutoIdKeyDictionary(),
         )
         yield intp
     finally:

--- a/effectful/internals/runtime.py
+++ b/effectful/internals/runtime.py
@@ -5,7 +5,7 @@ import inspect
 import typing
 from collections.abc import Callable, Mapping
 
-from effectful.internals.weak import AutoIdKeyDictionary
+from effectful.internals.weak import AutoIdKeyDictionary, weak_memoize
 from effectful.ops.types import Interpretation, Operation
 
 type CacheEntry = AutoIdKeyDictionary[Interpretation, typing.Any]
@@ -102,6 +102,7 @@ def _get_args() -> tuple[tuple, Mapping]:
     return ((), {})
 
 
+@weak_memoize
 def _restore_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     sig = inspect.signature(fn)
     if not sig.parameters:
@@ -115,6 +116,7 @@ def _restore_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     return _cont_wrapper
 
 
+@weak_memoize
 def _save_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     from effectful.ops.semantics import handler
 

--- a/effectful/internals/runtime.py
+++ b/effectful/internals/runtime.py
@@ -5,7 +5,11 @@ import inspect
 import typing
 from collections.abc import Callable, Mapping
 
-from effectful.internals.weak import AutoIdKeyDictionary, weak_memoize
+from effectful.internals.weak import (
+    AutoIdKeyDictionary,
+    WeakIdKeyDictionary,
+    weak_memoize,
+)
 from effectful.ops.types import Interpretation, Operation
 
 type CacheEntry = AutoIdKeyDictionary[Interpretation, typing.Any]
@@ -101,7 +105,7 @@ def _get_args() -> tuple[tuple, Mapping]:
     return ((), {})
 
 
-@weak_memoize
+@weak_memoize(cache=WeakIdKeyDictionary())
 def _restore_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     sig = inspect.signature(fn)
     if not sig.parameters:
@@ -115,7 +119,7 @@ def _restore_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     return _cont_wrapper
 
 
-@weak_memoize
+@weak_memoize(cache=WeakIdKeyDictionary())
 def _save_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     from effectful.ops.semantics import handler
 
@@ -131,7 +135,7 @@ def _save_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     return _cont_wrapper
 
 
-@weak_memoize
+@weak_memoize(cache=WeakIdKeyDictionary())
 def _save_then_restore_args[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     # should be equivalent to _restore_args(_save_args(fn)), just fused
     from effectful.ops.semantics import handler

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -568,25 +568,41 @@ class AutoIdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
 
 type WeakKeyCache[S, T] = weakref.WeakKeyDictionary[S, T] | WeakIdKeyDictionary[S, T]
 
+# The one-argument functions weak_memoize accepts. Bounding the type variable
+# rather than spelling the signature out as Callable[[S], T] is what lets the
+# decorated function keep its own type parameters instead of having them solved,
+# to Never, at the point the decorator is applied.
+type Memoizable = collections.abc.Callable[[typing.Any], typing.Any]
+
+
+class MemoizeDecorator(typing.Protocol):
+    """What ``weak_memoize(cache=...)`` returns.
+
+    A protocol whose ``__call__`` is generic, rather than a plain
+    ``Callable[[F], F]``: the latter would solve ``F`` at the ``weak_memoize``
+    call, which has nothing to solve it from, instead of where the decorator is
+    applied to a function.
+    """
+
+    def __call__[F: Memoizable](self, fn: F, /) -> F: ...
+
 
 @typing.overload
-def weak_memoize[S, T](
-    fn: collections.abc.Callable[[S], T], *, cache: WeakKeyCache[S, T] | None = None
-) -> collections.abc.Callable[[S], T]: ...
+def weak_memoize[F: Memoizable](
+    fn: F, *, cache: WeakKeyCache[typing.Any, typing.Any] | None = None
+) -> F: ...
 
 
 @typing.overload
-def weak_memoize[S, T](
-    *, cache: WeakKeyCache[S, T] | None = None
-) -> collections.abc.Callable[
-    [collections.abc.Callable[[S], T]], collections.abc.Callable[[S], T]
-]: ...
+def weak_memoize(
+    *, cache: WeakKeyCache[typing.Any, typing.Any] | None = None
+) -> MemoizeDecorator: ...
 
 
-def weak_memoize[S, T](
-    fn: collections.abc.Callable[[S], T] | None = None,
+def weak_memoize(
+    fn: Memoizable | None = None,
     *,
-    cache: WeakKeyCache[S, T] | None = None,
+    cache: WeakKeyCache[typing.Any, typing.Any] | None = None,
 ) -> typing.Any:
     """Memoize ``fn`` on its single argument.
 
@@ -613,7 +629,7 @@ def weak_memoize[S, T](
         cache = AutoIdKeyDictionary()
 
     @functools.wraps(fn)
-    def _memoized(arg: S) -> T:
+    def _memoized(arg: typing.Any) -> typing.Any:
         if arg in cache:
             return cache[arg]
         result = fn(arg)

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -1,0 +1,406 @@
+# note: adapted from https://github.com/pytorch/pytorch/blob/708f706e7ac19247a4d6f26e81c9c706ac14d50d/torch/utils/weak.py
+import collections.abc
+import copy
+import typing
+import weakref
+
+
+# TODO: make weakref properly thread safe following
+# https://github.com/python/cpython/pull/125325
+class _IterationGuard:
+    # This context manager registers itself in the current iterators of the
+    # weak container, such as to delay all removals until the context manager
+    # exits.
+    # This technique should be relatively thread-safe (since sets are).
+
+    def __init__(self, weakcontainer) -> None:
+        # Don't create cycles
+        self.weakcontainer = weakref.ref(weakcontainer)
+
+    def __enter__(self):
+        w = self.weakcontainer()
+        if w is not None:
+            w._iterating.add(self)
+        return self
+
+    def __exit__(self, e, t, b):
+        w = self.weakcontainer()
+        if w is not None:
+            s = w._iterating
+            s.remove(self)
+            if not s:
+                w._commit_removals()
+
+
+# This file defines a variant of WeakKeyDictionary that overrides the hashing
+# behavior of the key to use object identity, rather than the builtin
+# __eq__/__hash__ functions.  This is useful for Tensor weak keys, as their
+# __eq__ implementation return a Tensor (elementwise equality), which means
+# you can't use them directly with the WeakKeyDictionary in standard library.
+#
+# Our implementation strategy is to create a wrapper weak key object, which we
+# use as a key in a stock Python dictionary.  This is similar to how weakref
+# implements WeakKeyDictionary, but instead of using weakref.ref as the
+# wrapper, we use a custom wrapper that has different __eq__ and __hash__
+# behavior.  Note that we subsequently store this weak key directly in an
+# ORDINARY dictionary, since the newly constructed WeakIdKey's only use would
+# be a dictionary so it would have no strong references.  Ensuring that
+# only live WeakIdKeys are in the map is handled by putting finalizers on the
+# original key object.
+
+
+# It is simpler to implement this with composition, but if we want to
+# directly reuse the callback mechanism on weakref, we need the weakref
+# and the key to be exactly the same object.  Reusing the callback mechanism
+# minimizes the divergence between our implementation and Lib/weakref.py
+#
+# NB: Prefer using this when working with weakrefs of Tensors; e.g., do
+# WeakIdRef(tensor) rather than weakref.ref(tensor); it handles a number of
+# easy to get wrong cases transparently for you.
+class WeakIdRef(weakref.ref):
+    __slots__ = ["_id"]
+
+    def __init__(self, key, callback=None) -> None:
+        # Unlike stock weakref, which preserves hash semantics of the
+        # original object but lazily defers hash calls until the first
+        # time the user attempts to hash the weakref, we can eagerly
+        # cache the id of the key as we know this is definitely the hash
+        # method
+        self._id = id(key)
+        super().__init__(key, callback)  # type: ignore[call-arg]
+
+    def __call__(self):
+        r = super().__call__()
+        # Special logic for Tensor PyObject resurrection
+        if hasattr(r, "_fix_weakref"):
+            r._fix_weakref()  # type: ignore[union-attr]
+        return r
+
+    def __hash__(self):
+        return self._id
+
+    def __eq__(self, other):
+        # An attractive but wrong alternate implementation is to only test if
+        # the stored _ids match.  This can lead to an ABA problem if you have:
+        #
+        #   a1 = A()
+        #   w1 = WeakIdRef(a1)
+        #   del a1
+        #   a2 = A()  # suppose it gets the same ID as a1
+        #   w2 = WeakIdRef(a2)
+        #   print(w1 == w2)
+        #
+        # This should be False, as a1 and a2 are unrelated (and a1 is
+        # dead anyway)
+        a = self()
+        b = other()
+        if a is not None and b is not None:
+            return a is b
+        return self is other
+
+
+# This is a strong counterpart to WeakIdRef, for identity keying without weak
+# references. That is what a cache scoped to a block wants: nothing can leak,
+# because the whole dictionary is dropped when the block exits. It also accepts
+# keys that cannot be weakly referenced at all, such as int, str, tuple, list
+# and dict. Used by IdKeyDictionary, and by AutoIdRef for the keys WeakIdRef
+# cannot take.
+class IdRef:
+    __slots__ = ["_id", "_obj"]
+
+    def __init__(self, key, callback=None) -> None:
+        # Accepts and ignores WeakIdKeyDictionary's removal callback: a strong
+        # reference never dies while it is in the dictionary, so it never fires.
+        self._id = id(key)
+        self._obj = key
+
+    def __call__(self):
+        return self._obj
+
+    def __hash__(self):
+        return self._id
+
+    def __eq__(self, other):
+        # AutoIdRef puts both reference types in one dictionary, so this has to
+        # stay symmetric with WeakIdRef.__eq__, which treats a dead referent as
+        # equal only to itself.
+        #
+        # Against another strong reference, comparing ids is enough and is what
+        # we want: neither referent can have died, so an id cannot have been
+        # recycled, and a None key compares equal to itself rather than reading
+        # as dead. Against a weak reference we have to dereference, because a
+        # dead WeakIdRef keeps the id of an object that may since have been
+        # replaced at that address -- the ABA case its own __eq__ guards.
+        if isinstance(other, IdRef):
+            return self._id == other._id
+        return (b := other()) is not None and b is self._obj
+
+
+_WEAKREFABLE: dict[type, bool] = {}
+
+
+# Picks a reference type per key rather than per dictionary: weak where the key
+# supports it, strong otherwise. This lets one dictionary accept any key at all,
+# at the cost of making entries for weak-referenceable keys evictable, so the
+# caller sees hit rates that depend on when the collector runs. Prefer
+# WeakIdKeyDictionary or IdKeyDictionary when the keys allow a single choice.
+#
+# This is a class rather than a factory function so that it can be assigned to
+# WeakIdKeyDictionary.ref_type: a plain function there would be bound as a
+# method and receive the dictionary as its first argument.
+class AutoIdRef:
+    def __new__(cls, key, callback=None):
+        # Weak-referenceability is a property of the type, so it is worth
+        # caching: this runs on every lookup as well as every insertion.
+        ok = _WEAKREFABLE.get(t := type(key))
+        if ok is None:
+            try:
+                weakref.ref(key)
+                ok = True
+            except TypeError:
+                ok = False
+            _WEAKREFABLE[t] = ok
+        return WeakIdRef(key, callback) if ok else IdRef(key, callback)
+
+
+# This is the same as WeakIdRef but equality is checked using hash() rather than id.
+# This will be equivalent to the one above except for classes where hash is not their id.
+class _WeakHashRef(weakref.ref):
+    __slots__ = ["_id"]
+
+    def __init__(self, key, callback=None) -> None:
+        # Unlike stock weakref, which preserves hash semantics of the
+        # original object but lazily defers hash calls until the first
+        # time the user attempts to hash the weakref, we can eagerly
+        # cache the id of the key as we know this is definitely the hash
+        # method
+        self._id = hash(key)
+        super().__init__(key, callback)  # type: ignore[call-arg]
+
+    def __call__(self):
+        r = super().__call__()
+        # Special logic for Tensor PyObject resurrection
+        if hasattr(r, "_fix_weakref"):
+            r._fix_weakref()  # type: ignore[union-attr]
+        return r
+
+    def __hash__(self):
+        return self._id
+
+    def __eq__(self, other):
+        # Use hash equality to determine ref equality.
+        # ScriptObject implements __hash__ to return the wrapped IValue's id, so
+        # this is equivalent to doing an identity comparison.
+        a = self()
+        b = other()
+        if a is not None and b is not None:
+            return hash(a) == hash(b)
+        return self is other
+
+
+# This is directly adapted from cpython/Lib/weakref.py
+class WeakIdKeyDictionary(collections.abc.MutableMapping):
+    # CHANGED: reference strength is a property of the dictionary, so subclasses
+    # select it by overriding this rather than callers passing it per instance.
+    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = WeakIdRef
+
+    def __init__(self, dict=None) -> None:
+        self.data = {}
+
+        def remove(k, selfref=weakref.ref(self)) -> None:
+            self = selfref()
+            if self is not None:
+                if self._iterating:
+                    self._pending_removals.append(k)
+                else:
+                    try:
+                        del self.data[k]
+                    except KeyError:
+                        pass
+
+        self._remove = remove
+        # A list of dead weakrefs (keys to be removed)
+        self._pending_removals = []
+        self._iterating = set()
+        self._dirty_len = False
+        if dict is not None:
+            self.update(dict)
+
+    def _commit_removals(self) -> None:
+        # NOTE: We don't need to call this method before mutating the dict,
+        # because a dead weakref never compares equal to a live weakref,
+        # even if they happened to refer to equal objects.
+        # However, it means keys may already have been removed.
+        pop = self._pending_removals.pop
+        d = self.data
+        while True:
+            try:
+                key = pop()
+            except IndexError:
+                return
+
+            try:
+                del d[key]
+            except KeyError:
+                pass
+
+    def _scrub_removals(self) -> None:
+        d = self.data
+        self._pending_removals = [k for k in self._pending_removals if k in d]
+        self._dirty_len = False
+
+    def __delitem__(self, key) -> None:
+        self._dirty_len = True
+        del self.data[self.ref_type(key)]  # CHANGED
+
+    def __getitem__(self, key):
+        return self.data[self.ref_type(key)]  # CHANGED
+
+    def __len__(self) -> int:
+        if self._dirty_len and self._pending_removals:
+            # self._pending_removals may still contain keys which were
+            # explicitly removed, we have to scrub them (see issue #21173).
+            self._scrub_removals()
+        return len(self.data) - len(self._pending_removals)
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} at {id(self):#x}>"
+
+    def __setitem__(self, key, value) -> None:
+        self.data[self.ref_type(key, self._remove)] = value  # CHANGED
+
+    def copy(self):
+        new = self.__class__()  # CHANGED: preserve the subclass's ref_type
+        with _IterationGuard(self):
+            for key, value in self.data.items():
+                o = key()
+                if o is not None:
+                    new[o] = value
+        return new
+
+    __copy__ = copy
+
+    def __deepcopy__(self, memo):
+        new = self.__class__()
+        with _IterationGuard(self):
+            for key, value in self.data.items():
+                o = key()
+                if o is not None:
+                    new[o] = copy.deepcopy(value, memo)
+        return new
+
+    def get(self, key, default=None):
+        return self.data.get(self.ref_type(key), default)  # CHANGED
+
+    def __contains__(self, key) -> bool:
+        try:
+            wr = self.ref_type(key)  # CHANGED
+        except TypeError:
+            return False
+        return wr in self.data
+
+    def items(self):
+        with _IterationGuard(self):
+            for wr, value in self.data.items():
+                key = wr()
+                if key is not None:
+                    yield key, value
+
+    def keys(self):
+        with _IterationGuard(self):
+            for wr in self.data:
+                obj = wr()
+                if obj is not None:
+                    yield obj
+
+    __iter__ = keys
+
+    def values(self):
+        with _IterationGuard(self):
+            for wr, value in self.data.items():
+                if wr() is not None:
+                    yield value
+
+    def keyrefs(self):
+        """Return a list of weak references to the keys.
+
+        The references are not guaranteed to be 'live' at the time
+        they are used, so the result of calling the references needs
+        to be checked before being used.  This can be used to avoid
+        creating references that will cause the garbage collector to
+        keep the keys around longer than needed.
+
+        """
+        return list(self.data)
+
+    def popitem(self):
+        self._dirty_len = True
+        while True:
+            key, value = self.data.popitem()
+            o = key()
+            if o is not None:
+                return o, value
+
+    # pyrefly: ignore [bad-override]
+    def pop(self, key, *args):
+        self._dirty_len = True
+
+        return self.data.pop(self.ref_type(key), *args)  # CHANGED
+
+    def setdefault(self, key, default=None):
+        return self.data.setdefault(
+            self.ref_type(key, self._remove), default
+        )  # CHANGED
+
+    def update(self, dict=None, **kwargs) -> None:  # type: ignore[override]
+        d = self.data
+        if dict is not None:
+            if not hasattr(dict, "items"):
+                dict = type({})(dict)
+            for key, value in dict.items():
+                d[self.ref_type(key, self._remove)] = value  # CHANGED
+        if kwargs:
+            self.update(kwargs)
+
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
+    def __or__(self, other):
+        if isinstance(other, collections.abc.Mapping):
+            c = self.copy()
+            c.update(other)
+            return c
+        return NotImplemented
+
+    def __ror__(self, other):
+        if isinstance(other, collections.abc.Mapping):
+            c = self.__class__()
+            c.update(other)
+            c.update(self)
+            return c
+        return NotImplemented
+
+    # Default Mapping equality will tests keys for equality, but
+    # we want to test ids for equality
+    def __eq__(self, other):
+        if not isinstance(other, collections.abc.Mapping):
+            return NotImplemented
+        return {id(k): v for k, v in self.items()} == {
+            id(k): v for k, v in other.items()
+        }
+
+
+# CHANGED: the strong counterpart of WeakIdKeyDictionary. Keys are compared by
+# identity and kept alive, so this accepts keys that cannot be weakly referenced
+# and its entries never disappear on their own. Use it for a cache whose own
+# lifetime already bounds the entries', such as one scoped to a block.
+class IdKeyDictionary(WeakIdKeyDictionary):
+    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = IdRef
+
+
+# CHANGED: accepts any key, holding it weakly where that is possible. This is
+# the one to reach for when a single cache has to serve keys of both kinds; see
+# AutoIdRef for what it gives up relative to the two dictionaries above.
+class AutoIdKeyDictionary(WeakIdKeyDictionary):
+    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = AutoIdRef

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -2,29 +2,39 @@
 import collections.abc
 import copy
 import functools
+import types
 import typing
 import weakref
 
 
 # TODO: make weakref properly thread safe following
 # https://github.com/python/cpython/pull/125325
-class _IterationGuard:
+class _IterationGuard[K, V]:
     # This context manager registers itself in the current iterators of the
     # weak container, such as to delay all removals until the context manager
     # exits.
     # This technique should be relatively thread-safe (since sets are).
 
-    def __init__(self, weakcontainer) -> None:
+    # CHANGED: parameterised by the container's key and value types, so that the
+    # attribute below names the container rather than being an opaque weakref.
+    weakcontainer: weakref.ref["WeakIdKeyDictionary[K, V]"]
+
+    def __init__(self, weakcontainer: "WeakIdKeyDictionary[K, V]") -> None:
         # Don't create cycles
         self.weakcontainer = weakref.ref(weakcontainer)
 
-    def __enter__(self):
+    def __enter__(self) -> typing.Self:
         w = self.weakcontainer()
         if w is not None:
             w._iterating.add(self)
         return self
 
-    def __exit__(self, e, t, b):
+    def __exit__(
+        self,
+        e: type[BaseException] | None,
+        t: BaseException | None,
+        b: types.TracebackType | None,
+    ) -> None:
         w = self.weakcontainer()
         if w is not None:
             s = w._iterating
@@ -95,11 +105,26 @@ class WeakIdRef[T](weakref.ref[T]):
         #
         # This should be False, as a1 and a2 are unrelated (and a1 is
         # dead anyway)
+        #
+        # CHANGED: defer to the other operand for anything that is not a
+        # reference, as stock weakref.ref does. Dereferencing it below would
+        # raise TypeError instead of answering the comparison.
+        if not isinstance(other, (weakref.ref, IdRef)):
+            return NotImplemented
         a = self()
         b = other()
         if a is not None and b is not None:
             return a is b
         return self is other
+
+    def __ne__(self, other: typing.Any) -> bool:
+        # CHANGED: weakref.ref implements == and != together in C, and its !=
+        # compares the referents with the equality operator. Overriding __eq__
+        # alone leaves != inherited from there, disagreeing with == and calling
+        # the very __eq__ this class exists to route around -- for a Tensor key
+        # that returns another Tensor rather than a bool.
+        eq = self.__eq__(other)
+        return eq if eq is NotImplemented else not eq
 
 
 # This is a strong counterpart to WeakIdRef, for identity keying without weak
@@ -140,6 +165,8 @@ class IdRef[T]:
         # replaced at that address -- the ABA case its own __eq__ guards.
         if isinstance(other, IdRef):
             return self._id == other._id
+        if not isinstance(other, weakref.ref):
+            return NotImplemented
         return (b := other()) is not None and b is self._obj
 
 
@@ -182,43 +209,6 @@ class AutoIdRef[T]:
         return WeakIdRef(key, callback) if is_weakrefable(key) else IdRef(key, callback)
 
 
-# This is the same as WeakIdRef but equality is checked using hash() rather than id.
-# This will be equivalent to the one above except for classes where hash is not their id.
-class _WeakHashRef[T](weakref.ref[T]):
-    __slots__ = ["_id"]
-
-    def __init__(
-        self, key: T, callback: collections.abc.Callable[..., typing.Any] | None = None
-    ) -> None:
-        # Unlike stock weakref, which preserves hash semantics of the
-        # original object but lazily defers hash calls until the first
-        # time the user attempts to hash the weakref, we can eagerly
-        # cache the id of the key as we know this is definitely the hash
-        # method
-        self._id = hash(key)
-        super().__init__(key, callback)  # type: ignore[call-arg]
-
-    def __call__(self) -> T | None:
-        r = super().__call__()
-        # Special logic for Tensor PyObject resurrection
-        if r is not None and hasattr(r, "_fix_weakref"):
-            r._fix_weakref()
-        return r
-
-    def __hash__(self) -> int:
-        return self._id
-
-    def __eq__(self, other: typing.Any) -> bool:
-        # Use hash equality to determine ref equality.
-        # ScriptObject implements __hash__ to return the wrapped IValue's id, so
-        # this is equivalent to doing an identity comparison.
-        a = self()
-        b = other()
-        if a is not None and b is not None:
-            return hash(a) == hash(b)
-        return self is other
-
-
 # This is directly adapted from cpython/Lib/weakref.py
 class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
     # CHANGED: reference strength is a property of the dictionary, so subclasses
@@ -231,7 +221,7 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
     # parameter below shadows the builtin the annotations would need.
     data: dict[typing.Any, V]
     _pending_removals: list[typing.Any]
-    _iterating: set[_IterationGuard]
+    _iterating: set[_IterationGuard[K, V]]
     _dirty_len: bool
 
     def __init__(self, dict: collections.abc.Mapping[K, V] | None = None) -> None:
@@ -475,6 +465,7 @@ def weak_memoize[S, T](
     if cache is None:
         cache = AutoIdKeyDictionary()
 
+    @functools.wraps(fn)
     def _memoized(arg: S) -> T:
         if arg in cache:
             return cache[arg]

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -57,10 +57,12 @@ class _IterationGuard:
 # NB: Prefer using this when working with weakrefs of Tensors; e.g., do
 # WeakIdRef(tensor) rather than weakref.ref(tensor); it handles a number of
 # easy to get wrong cases transparently for you.
-class WeakIdRef(weakref.ref):
+class WeakIdRef[T](weakref.ref[T]):
     __slots__ = ["_id"]
 
-    def __init__(self, key, callback=None) -> None:
+    def __init__(
+        self, key: T, callback: collections.abc.Callable[..., typing.Any] | None = None
+    ) -> None:
         # Unlike stock weakref, which preserves hash semantics of the
         # original object but lazily defers hash calls until the first
         # time the user attempts to hash the weakref, we can eagerly
@@ -69,17 +71,17 @@ class WeakIdRef(weakref.ref):
         self._id = id(key)
         super().__init__(key, callback)  # type: ignore[call-arg]
 
-    def __call__(self):
+    def __call__(self) -> T | None:
         r = super().__call__()
         # Special logic for Tensor PyObject resurrection
-        if hasattr(r, "_fix_weakref"):
-            r._fix_weakref()  # type: ignore[union-attr]
+        if r is not None and hasattr(r, "_fix_weakref"):
+            r._fix_weakref()
         return r
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self._id
 
-    def __eq__(self, other):
+    def __eq__(self, other: typing.Any) -> bool:
         # An attractive but wrong alternate implementation is to only test if
         # the stored _ids match.  This can lead to an ABA problem if you have:
         #
@@ -105,22 +107,26 @@ class WeakIdRef(weakref.ref):
 # keys that cannot be weakly referenced at all, such as int, str, tuple, list
 # and dict. Used by IdKeyDictionary, and by AutoIdRef for the keys WeakIdRef
 # cannot take.
-class IdRef:
+class IdRef[T]:
     __slots__ = ["_id", "_obj"]
 
-    def __init__(self, key, callback=None) -> None:
+    def __init__(
+        self, key: T, callback: collections.abc.Callable[..., typing.Any] | None = None
+    ) -> None:
         # Accepts and ignores WeakIdKeyDictionary's removal callback: a strong
         # reference never dies while it is in the dictionary, so it never fires.
         self._id = id(key)
         self._obj = key
 
-    def __call__(self):
+    def __call__(self) -> T | None:
+        # Never actually None, but typed to match WeakIdRef so the two are
+        # interchangeable as a dictionary's ref_type and inside AutoIdRef.
         return self._obj
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self._id
 
-    def __eq__(self, other):
+    def __eq__(self, other: typing.Any) -> bool:
         # AutoIdRef puts both reference types in one dictionary, so this has to
         # stay symmetric with WeakIdRef.__eq__, which treats a dead referent as
         # equal only to itself.
@@ -139,6 +145,26 @@ class IdRef:
 _WEAKREFABLE: dict[type, bool] = {}
 
 
+def is_weakrefable(obj: object) -> bool:
+    """Report whether ``obj`` can be the target of a weak reference.
+
+    Answers without raising, so callers can branch on it rather than catching
+    ``TypeError`` -- worth doing where the answer is usually "no", as it is for
+    the ``int``, ``str`` and ``tuple`` leaves of an expression.
+    """
+    # Weak-referenceability is a property of the type, so caching by type turns
+    # this into one dict lookup on the hot path.
+    ok = _WEAKREFABLE.get(t := type(obj))
+    if ok is None:
+        try:
+            weakref.ref(obj)
+            ok = True
+        except TypeError:
+            ok = False
+        _WEAKREFABLE[t] = ok
+    return ok
+
+
 # Picks a reference type per key rather than per dictionary: weak where the key
 # supports it, strong otherwise. This lets one dictionary accept any key at all,
 # at the cost of making entries for weak-referenceable keys evictable, so the
@@ -148,27 +174,21 @@ _WEAKREFABLE: dict[type, bool] = {}
 # This is a class rather than a factory function so that it can be assigned to
 # WeakIdKeyDictionary.ref_type: a plain function there would be bound as a
 # method and receive the dictionary as its first argument.
-class AutoIdRef:
-    def __new__(cls, key, callback=None):
-        # Weak-referenceability is a property of the type, so it is worth
-        # caching: this runs on every lookup as well as every insertion.
-        ok = _WEAKREFABLE.get(t := type(key))
-        if ok is None:
-            try:
-                weakref.ref(key)
-                ok = True
-            except TypeError:
-                ok = False
-            _WEAKREFABLE[t] = ok
-        return WeakIdRef(key, callback) if ok else IdRef(key, callback)
+class AutoIdRef[T]:
+    def __new__(  # type: ignore[misc]  # deliberately returns another class
+        cls, key: T, callback: collections.abc.Callable[..., typing.Any] | None = None
+    ) -> "WeakIdRef[T] | IdRef[T]":
+        return WeakIdRef(key, callback) if is_weakrefable(key) else IdRef(key, callback)
 
 
 # This is the same as WeakIdRef but equality is checked using hash() rather than id.
 # This will be equivalent to the one above except for classes where hash is not their id.
-class _WeakHashRef(weakref.ref):
+class _WeakHashRef[T](weakref.ref[T]):
     __slots__ = ["_id"]
 
-    def __init__(self, key, callback=None) -> None:
+    def __init__(
+        self, key: T, callback: collections.abc.Callable[..., typing.Any] | None = None
+    ) -> None:
         # Unlike stock weakref, which preserves hash semantics of the
         # original object but lazily defers hash calls until the first
         # time the user attempts to hash the weakref, we can eagerly
@@ -177,17 +197,17 @@ class _WeakHashRef(weakref.ref):
         self._id = hash(key)
         super().__init__(key, callback)  # type: ignore[call-arg]
 
-    def __call__(self):
+    def __call__(self) -> T | None:
         r = super().__call__()
         # Special logic for Tensor PyObject resurrection
-        if hasattr(r, "_fix_weakref"):
-            r._fix_weakref()  # type: ignore[union-attr]
+        if r is not None and hasattr(r, "_fix_weakref"):
+            r._fix_weakref()
         return r
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self._id
 
-    def __eq__(self, other):
+    def __eq__(self, other: typing.Any) -> bool:
         # Use hash equality to determine ref equality.
         # ScriptObject implements __hash__ to return the wrapped IValue's id, so
         # this is equivalent to doing an identity comparison.
@@ -199,12 +219,21 @@ class _WeakHashRef(weakref.ref):
 
 
 # This is directly adapted from cpython/Lib/weakref.py
-class WeakIdKeyDictionary(collections.abc.MutableMapping):
+class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
     # CHANGED: reference strength is a property of the dictionary, so subclasses
     # select it by overriding this rather than callers passing it per instance.
+    # Not parameterised by K: a ClassVar cannot refer to the class's type
+    # variables, so the reference type it builds is only known as a callable.
     ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = WeakIdRef
 
-    def __init__(self, dict=None) -> None:
+    # Declared here rather than annotated in ``__init__``, where the ``dict``
+    # parameter below shadows the builtin the annotations would need.
+    data: dict[typing.Any, V]
+    _pending_removals: list[typing.Any]
+    _iterating: set[_IterationGuard]
+    _dirty_len: bool
+
+    def __init__(self, dict: collections.abc.Mapping[K, V] | None = None) -> None:
         self.data = {}
 
         def remove(k, selfref=weakref.ref(self)) -> None:
@@ -249,11 +278,11 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
         self._pending_removals = [k for k in self._pending_removals if k in d]
         self._dirty_len = False
 
-    def __delitem__(self, key) -> None:
+    def __delitem__(self, key: K) -> None:
         self._dirty_len = True
         del self.data[self.ref_type(key)]  # CHANGED
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: K) -> V:
         return self.data[self.ref_type(key)]  # CHANGED
 
     def __len__(self) -> int:
@@ -266,10 +295,10 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} at {id(self):#x}>"
 
-    def __setitem__(self, key, value) -> None:
+    def __setitem__(self, key: K, value: V) -> None:
         self.data[self.ref_type(key, self._remove)] = value  # CHANGED
 
-    def copy(self):
+    def copy(self) -> typing.Self:
         new = self.__class__()  # CHANGED: preserve the subclass's ref_type
         with _IterationGuard(self):
             for key, value in self.data.items():
@@ -280,7 +309,7 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
 
     __copy__ = copy
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo) -> typing.Self:
         new = self.__class__()
         with _IterationGuard(self):
             for key, value in self.data.items():
@@ -289,24 +318,26 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
                     new[o] = copy.deepcopy(value, memo)
         return new
 
-    def get(self, key, default=None):
+    def get(self, key: K, default: V | None = None) -> V | None:  # type: ignore[override]
         return self.data.get(self.ref_type(key), default)  # CHANGED
 
-    def __contains__(self, key) -> bool:
+    def __contains__(self, key: object) -> bool:
         try:
             wr = self.ref_type(key)  # CHANGED
         except TypeError:
             return False
         return wr in self.data
 
-    def items(self):
+    # Generators rather than the views MutableMapping specifies: a view would
+    # have to hold the dictionary, and these have to skip keys that died mid-walk.
+    def items(self) -> collections.abc.Iterator[tuple[K, V]]:  # type: ignore[override]
         with _IterationGuard(self):
             for wr, value in self.data.items():
                 key = wr()
                 if key is not None:
                     yield key, value
 
-    def keys(self):
+    def keys(self) -> collections.abc.Iterator[K]:  # type: ignore[override]
         with _IterationGuard(self):
             for wr in self.data:
                 obj = wr()
@@ -315,13 +346,13 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
 
     __iter__ = keys
 
-    def values(self):
+    def values(self) -> collections.abc.Iterator[V]:  # type: ignore[override]
         with _IterationGuard(self):
             for wr, value in self.data.items():
                 if wr() is not None:
                     yield value
 
-    def keyrefs(self):
+    def keyrefs(self) -> list[typing.Any]:
         """Return a list of weak references to the keys.
 
         The references are not guaranteed to be 'live' at the time
@@ -333,7 +364,7 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
         """
         return list(self.data)
 
-    def popitem(self):
+    def popitem(self) -> tuple[K, V]:
         self._dirty_len = True
         while True:
             key, value = self.data.popitem()
@@ -342,17 +373,17 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
                 return o, value
 
     # pyrefly: ignore [bad-override]
-    def pop(self, key, *args):
+    def pop(self, key: K, *args: typing.Any) -> typing.Any:
         self._dirty_len = True
 
         return self.data.pop(self.ref_type(key), *args)  # CHANGED
 
-    def setdefault(self, key, default=None):
+    def setdefault(self, key: K, default: typing.Any = None) -> typing.Any:
         return self.data.setdefault(
             self.ref_type(key, self._remove), default
         )  # CHANGED
 
-    def update(self, dict=None, **kwargs) -> None:  # type: ignore[override]
+    def update(self, dict=None, **kwargs) -> None:
         d = self.data
         if dict is not None:
             if not hasattr(dict, "items"):
@@ -395,12 +426,12 @@ class WeakIdKeyDictionary(collections.abc.MutableMapping):
 # identity and kept alive, so this accepts keys that cannot be weakly referenced
 # and its entries never disappear on their own. Use it for a cache whose own
 # lifetime already bounds the entries', such as one scoped to a block.
-class IdKeyDictionary(WeakIdKeyDictionary):
+class IdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
     ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = IdRef
 
 
 # CHANGED: accepts any key, holding it weakly where that is possible. This is
 # the one to reach for when a single cache has to serve keys of both kinds; see
 # AutoIdRef for what it gives up relative to the two dictionaries above.
-class AutoIdKeyDictionary(WeakIdKeyDictionary):
+class AutoIdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
     ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = AutoIdRef

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -435,3 +435,23 @@ class IdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
 # AutoIdRef for what it gives up relative to the two dictionaries above.
 class AutoIdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
     ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = AutoIdRef
+
+
+def weak_memoize[S, T](
+    fn: collections.abc.Callable[[S], T],
+) -> collections.abc.Callable[[S], T]:
+    """Memoize ``fn`` using weak references to its argument and result.
+
+    The memoization is scoped to the lifetime of the argument, so that when the
+    argument is garbage collected, the memoized result is also discarded.
+    """
+    cache: WeakIdKeyDictionary[S, T] = WeakIdKeyDictionary()
+
+    def _memoized(arg: S) -> T:
+        if arg in cache:
+            return cache[arg]
+        result = fn(arg)
+        cache[arg] = result
+        return result
+
+    return _memoized

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -109,7 +109,7 @@ class WeakIdRef[T](weakref.ref[T]):
         # CHANGED: defer to the other operand for anything that is not a
         # reference, as stock weakref.ref does. Dereferencing it below would
         # raise TypeError instead of answering the comparison.
-        if not isinstance(other, (weakref.ref, IdRef)):
+        if not isinstance(other, (weakref.ref, StrongIdRef)):
             return NotImplemented
         a = self()
         b = other()
@@ -133,7 +133,7 @@ class WeakIdRef[T](weakref.ref[T]):
 # keys that cannot be weakly referenced at all, such as int, str, tuple, list
 # and dict. Used by IdKeyDictionary, and by AutoIdRef for the keys WeakIdRef
 # cannot take.
-class IdRef[T]:
+class StrongIdRef[T]:
     __slots__ = ["_id", "_obj"]
 
     def __init__(
@@ -163,14 +163,14 @@ class IdRef[T]:
         # as dead. Against a weak reference we have to dereference, because a
         # dead WeakIdRef keeps the id of an object that may since have been
         # replaced at that address -- the ABA case its own __eq__ guards.
-        if isinstance(other, IdRef):
+        if isinstance(other, StrongIdRef):
             return self._id == other._id
         if not isinstance(other, weakref.ref):
             return NotImplemented
         return (b := other()) is not None and b is self._obj
 
 
-_WEAKREFABLE: dict[type, bool] = {}
+_WEAKREFABLE: weakref.WeakKeyDictionary[type, bool] = weakref.WeakKeyDictionary()
 
 
 def is_weakrefable(obj: object) -> bool:
@@ -205,8 +205,12 @@ def is_weakrefable(obj: object) -> bool:
 class AutoIdRef[T]:
     def __new__(  # type: ignore[misc]  # deliberately returns another class
         cls, key: T, callback: collections.abc.Callable[..., typing.Any] | None = None
-    ) -> "WeakIdRef[T] | IdRef[T]":
-        return WeakIdRef(key, callback) if is_weakrefable(key) else IdRef(key, callback)
+    ) -> "WeakIdRef[T] | StrongIdRef[T]":
+        return (
+            WeakIdRef(key, callback)
+            if is_weakrefable(key)
+            else StrongIdRef(key, callback)
+        )
 
 
 # This is directly adapted from cpython/Lib/weakref.py
@@ -417,8 +421,8 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
 # identity and kept alive, so this accepts keys that cannot be weakly referenced
 # and its entries never disappear on their own. Use it for a cache whose own
 # lifetime already bounds the entries', such as one scoped to a block.
-class IdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
-    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = IdRef
+class StrongIdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
+    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = StrongIdRef
 
 
 # CHANGED: accepts any key, holding it weakly where that is possible. This is

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -1,6 +1,7 @@
 # note: adapted from https://github.com/pytorch/pytorch/blob/708f706e7ac19247a4d6f26e81c9c706ac14d50d/torch/utils/weak.py
 import collections.abc
 import copy
+import functools
 import typing
 import weakref
 
@@ -437,15 +438,42 @@ class AutoIdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
     ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = AutoIdRef
 
 
+type WeakKeyCache[S, T] = weakref.WeakKeyDictionary[S, T] | WeakIdKeyDictionary[S, T]
+
+
+@typing.overload
 def weak_memoize[S, T](
-    fn: collections.abc.Callable[[S], T],
-) -> collections.abc.Callable[[S], T]:
+    fn: collections.abc.Callable[[S], T], *, cache: WeakKeyCache[S, T] | None = None
+) -> collections.abc.Callable[[S], T]: ...
+
+
+@typing.overload
+def weak_memoize[S, T](
+    *, cache: WeakKeyCache[S, T] | None = None
+) -> collections.abc.Callable[
+    [collections.abc.Callable[[S], T]], collections.abc.Callable[[S], T]
+]: ...
+
+
+def weak_memoize[S, T](
+    fn: collections.abc.Callable[[S], T] | None = None,
+    *,
+    cache: WeakKeyCache[S, T] | None = None,
+) -> typing.Any:
     """Memoize ``fn`` using weak references to its argument and result.
 
     The memoization is scoped to the lifetime of the argument, so that when the
     argument is garbage collected, the memoized result is also discarded.
+
+    Usable bare or with arguments: ``@weak_memoize`` and
+    ``@weak_memoize(cache=...)`` are both decorators, which is what the two
+    overloads above distinguish.
     """
-    cache: WeakIdKeyDictionary[S, T] = WeakIdKeyDictionary()
+    if fn is None:
+        return functools.partial(weak_memoize, cache=cache)
+
+    if cache is None:
+        cache = AutoIdKeyDictionary()
 
     def _memoized(arg: S) -> T:
         if arg in cache:

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -170,68 +170,112 @@ class StrongIdRef[T]:
         return (b := other()) is not None and b is self._obj
 
 
-_WEAKREFABLE: weakref.WeakKeyDictionary[type, bool] = weakref.WeakKeyDictionary()
-
-
-def is_weakrefable(obj: object) -> bool:
-    """Report whether ``obj`` can be the target of a weak reference.
-
-    Answers without raising, so callers can branch on it rather than catching
-    ``TypeError`` -- worth doing where the answer is usually "no", as it is for
-    the ``int``, ``str`` and ``tuple`` leaves of an expression.
-    """
-    # Weak-referenceability is a property of the type, so caching by type turns
-    # this into one dict lookup on the hot path.
-    ok = _WEAKREFABLE.get(t := type(obj))
-    if ok is None:
-        try:
-            weakref.ref(obj)
-            ok = True
-        except TypeError:
-            ok = False
-        _WEAKREFABLE[t] = ok
-    return ok
-
-
 # Picks a reference type per key rather than per dictionary: weak where the key
 # supports it, strong otherwise. This lets one dictionary accept any key at all,
 # at the cost of making entries for weak-referenceable keys evictable, so the
 # caller sees hit rates that depend on when the collector runs. Prefer
-# WeakIdKeyDictionary or IdKeyDictionary when the keys allow a single choice.
+# WeakIdKeyDictionary or StrongIdKeyDictionary when the keys allow a single
+# choice.
 #
 # This is a class rather than a factory function so that it can be assigned to
-# WeakIdKeyDictionary.ref_type: a plain function there would be bound as a
-# method and receive the dictionary as its first argument.
+# WeakIdKeyDictionary.ref_type: a plain function there would be bound as a method
+# and receive the dictionary as its first argument. Being a class also gives the
+# weak-referenceability check somewhere to live other than the module's public
+# surface, which is right: choosing between the two reference types is the only
+# thing that check is for.
 class AutoIdRef[T]:
+    # CHANGED: weak-referenceability is a property of the type, so caching by
+    # type turns the check into one lookup on the hot path. Weakly keyed, so that
+    # having been asked about a dynamically created class does not pin it.
+    _WEAKREFABLE: typing.ClassVar[weakref.WeakKeyDictionary[type, bool]] = (
+        weakref.WeakKeyDictionary()
+    )
+
+    @classmethod
+    def _is_weakrefable(cls, obj: object) -> bool:
+        """Report whether ``obj`` can be the target of a weak reference.
+
+        Answers without raising, so the caller can branch on it rather than
+        catching ``TypeError`` -- worth doing where the answer is usually "no",
+        as it is for the ``int``, ``str`` and ``tuple`` leaves of an expression.
+        """
+        ok = cls._WEAKREFABLE.get(t := type(obj))
+        if ok is None:
+            try:
+                weakref.ref(obj)
+                ok = True
+            except TypeError:
+                ok = False
+            cls._WEAKREFABLE[t] = ok
+        return ok
+
     def __new__(  # type: ignore[misc]  # deliberately returns another class
         cls, key: T, callback: collections.abc.Callable[..., typing.Any] | None = None
     ) -> "WeakIdRef[T] | StrongIdRef[T]":
         return (
             WeakIdRef(key, callback)
-            if is_weakrefable(key)
+            if cls._is_weakrefable(key)
             else StrongIdRef(key, callback)
         )
+
+
+# CHANGED: the handle a ``ref_type`` builds for a key -- hashable by the key's
+# identity, and callable to get the key back, or None where the reference was
+# weak and the key has since died. Naming it lets ``data``, ``_pending_removals``
+# and ``keyrefs`` say what they hold instead of falling back to Any, and puts the
+# "check the result before using it" of keyrefs' docstring into the type.
+class KeyRef[T](typing.Protocol):
+    def __call__(self) -> T | None: ...
+
+
+# CHANGED: what may be assigned to ``ref_type``. Both call shapes are here: bare
+# to look a key up, and with the dictionary's removal callback to build an entry.
+# Not parameterised by the key type: this is used as a ClassVar, which cannot
+# refer to the class's type variables.
+class RefType(typing.Protocol):
+    def __call__(
+        self,
+        key: typing.Any,
+        callback: collections.abc.Callable[..., typing.Any] | None = None,
+        /,
+    ) -> KeyRef[typing.Any]: ...
+
+
+# CHANGED: the part of a mapping that ``update`` needs from its argument, which
+# is what ``dict(...)`` accepts too. This is ``_typeshed.SupportsKeysAndGetItem``,
+# spelled out here because that module does not exist at runtime; taking anything
+# narrower, such as a Mapping, would be a signature that MutableMapping.update
+# does not permit.
+class KeysAndGetItem[K, V](typing.Protocol):
+    def keys(self) -> collections.abc.Iterable[K]: ...
+    def __getitem__(self, key: K, /) -> V: ...
+
+
+# Distinguishes "no default given" from a default of None, in pop below.
+_MISSING: typing.Final = object()
 
 
 # This is directly adapted from cpython/Lib/weakref.py
 class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
     # CHANGED: reference strength is a property of the dictionary, so subclasses
     # select it by overriding this rather than callers passing it per instance.
-    # Not parameterised by K: a ClassVar cannot refer to the class's type
-    # variables, so the reference type it builds is only known as a callable.
-    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = WeakIdRef
+    ref_type: typing.ClassVar[RefType] = WeakIdRef
 
     # Declared here rather than annotated in ``__init__``, where the ``dict``
     # parameter below shadows the builtin the annotations would need.
-    data: dict[typing.Any, V]
-    _pending_removals: list[typing.Any]
+    data: dict[KeyRef[K], V]
+    _remove: collections.abc.Callable[[KeyRef[K]], None]
+    _pending_removals: list[KeyRef[K]]
     _iterating: set[_IterationGuard[K, V]]
     _dirty_len: bool
 
     def __init__(self, dict: collections.abc.Mapping[K, V] | None = None) -> None:
         self.data = {}
 
-        def remove(k, selfref=weakref.ref(self)) -> None:
+        def remove(
+            k: KeyRef[K],
+            selfref: weakref.ref["WeakIdKeyDictionary[K, V]"] = weakref.ref(self),
+        ) -> None:
             self = selfref()
             if self is not None:
                 if self._iterating:
@@ -304,7 +348,7 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
 
     __copy__ = copy
 
-    def __deepcopy__(self, memo) -> typing.Self:
+    def __deepcopy__(self, memo: dict[int, typing.Any]) -> typing.Self:
         new = self.__class__()
         with _IterationGuard(self):
             for key, value in self.data.items():
@@ -313,7 +357,18 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
                     new[o] = copy.deepcopy(value, memo)
         return new
 
-    def get(self, key: K, default: V | None = None) -> V | None:  # type: ignore[override]
+    # CHANGED: the overloads Mapping.get declares, rather than one signature that
+    # forced the default to be a V and had to be excused from the override check.
+    @typing.overload
+    def get(self, key: K) -> V | None: ...
+
+    @typing.overload
+    def get(self, key: K, default: V) -> V: ...
+
+    @typing.overload
+    def get[D](self, key: K, default: D) -> V | D: ...
+
+    def get(self, key: K, default: typing.Any = None) -> typing.Any:
         return self.data.get(self.ref_type(key), default)  # CHANGED
 
     def __contains__(self, key: object) -> bool:
@@ -347,7 +402,7 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
                 if wr() is not None:
                     yield value
 
-    def keyrefs(self) -> list[typing.Any]:
+    def keyrefs(self) -> list[KeyRef[K]]:
         """Return a list of weak references to the keys.
 
         The references are not guaranteed to be 'live' at the time
@@ -367,39 +422,80 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
             if o is not None:
                 return o, value
 
-    # pyrefly: ignore [bad-override]
-    def pop(self, key: K, *args: typing.Any) -> typing.Any:
+    # CHANGED: the overloads MutableMapping.pop declares, which is also what makes
+    # the implementation's *args legible: the second argument is the default.
+    @typing.overload
+    def pop(self, key: K) -> V: ...
+
+    @typing.overload
+    def pop(self, key: K, default: V) -> V: ...
+
+    @typing.overload
+    def pop[D](self, key: K, default: D) -> V | D: ...
+
+    def pop(self, key: K, default: typing.Any = _MISSING) -> typing.Any:
         self._dirty_len = True
 
-        return self.data.pop(self.ref_type(key), *args)  # CHANGED
+        # CHANGED: a sentinel rather than *args, so that the signature says which
+        # argument the overloads above are talking about.
+        if default is _MISSING:
+            return self.data.pop(self.ref_type(key))
+        return self.data.pop(self.ref_type(key), default)
+
+    # CHANGED: as MutableMapping.setdefault declares it. Omitting the default is
+    # only meaningful when None is a value this dictionary can hold, which is what
+    # the first overload's annotated self says.
+    @typing.overload
+    def setdefault(
+        self: "WeakIdKeyDictionary[K, V | None]", key: K, default: None = None
+    ) -> V | None: ...
+
+    @typing.overload
+    def setdefault(self, key: K, default: V) -> V: ...
 
     def setdefault(self, key: K, default: typing.Any = None) -> typing.Any:
         return self.data.setdefault(
             self.ref_type(key, self._remove), default
         )  # CHANGED
 
-    def update(self, dict=None, **kwargs) -> None:
+    def update(  # CHANGED: annotated
+        self,
+        dict: KeysAndGetItem[K, V]
+        | collections.abc.Iterable[tuple[K, V]]
+        | None = None,
+        **kwargs: V,
+    ) -> None:
         d = self.data
         if dict is not None:
-            if not hasattr(dict, "items"):
-                dict = type({})(dict)
-            for key, value in dict.items():
+            # Any because the fallback is whatever the builtin dict() accepts,
+            # which covers both forms above and is not expressible as a type.
+            source: typing.Any = dict
+            if not hasattr(source, "items"):
+                source = type({})(source)
+            for key, value in source.items():
                 d[self.ref_type(key, self._remove)] = value  # CHANGED
         if kwargs:
-            self.update(kwargs)
+            # Only well typed when K is str, which no annotation here can say.
+            self.update(typing.cast(KeysAndGetItem[K, V], kwargs))
 
-    def __ior__(self, other):
+    def __ior__(
+        self, other: KeysAndGetItem[K, V] | collections.abc.Iterable[tuple[K, V]]
+    ) -> typing.Self:
         self.update(other)
         return self
 
-    def __or__(self, other):
+    def __or__(
+        self, other: collections.abc.Mapping[K, V]
+    ) -> "typing.Self | types.NotImplementedType":
         if isinstance(other, collections.abc.Mapping):
             c = self.copy()
             c.update(other)
             return c
         return NotImplemented
 
-    def __ror__(self, other):
+    def __ror__(
+        self, other: collections.abc.Mapping[K, V]
+    ) -> "typing.Self | types.NotImplementedType":
         if isinstance(other, collections.abc.Mapping):
             c = self.__class__()
             c.update(other)
@@ -409,7 +505,7 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
 
     # Default Mapping equality will tests keys for equality, but
     # we want to test ids for equality
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, collections.abc.Mapping):
             return NotImplemented
         return {id(k): v for k, v in self.items()} == {

--- a/effectful/internals/weak.py
+++ b/effectful/internals/weak.py
@@ -1,4 +1,36 @@
-# note: adapted from https://github.com/pytorch/pytorch/blob/708f706e7ac19247a4d6f26e81c9c706ac14d50d/torch/utils/weak.py
+"""Dictionaries that key on object identity rather than ``__eq__`` and ``__hash__``.
+
+Adapted from pytorch's ``torch/utils/weak.py`` at 708f706, which is itself
+adapted from cpython's ``Lib/weakref.py``:
+https://github.com/pytorch/pytorch/blob/708f706e7ac19247a4d6f26e81c9c706ac14d50d/torch/utils/weak.py
+
+A stock :class:`weakref.WeakKeyDictionary` compares its keys with ``==`` and
+hashes them, which rules out most of what this package wants to cache on. A
+term's ``__eq__`` is itself an operation, so comparing two of them builds
+another term rather than answering the question; an interpretation is a plain
+``dict``, so it cannot be hashed at all. Upstream the same problem arises for
+Tensor keys, whose ``__eq__`` returns a Tensor of elementwise results. Keying on
+``id`` sidesteps all of it, because the key's own protocols are never invoked.
+
+The strategy is to wrap each key in a small object that hashes as ``id(key)``
+and compares by identity, and to use that wrapper as the key of an ordinary
+``dict``. Three wrappers are on offer, with a dictionary for each:
+
+* :class:`WeakIdRef` and :class:`WeakIdKeyDictionary` hold the key weakly, so
+  an entry disappears when its key is collected. Only some objects can be
+  weakly referenced: ``int``, ``str``, ``tuple`` and the other leaves of an
+  expression cannot.
+* :class:`StrongIdRef` and :class:`StrongIdKeyDictionary` hold the key
+  strongly, so they take any key at all, at the cost of bounding an entry's
+  lifetime by the dictionary's rather than by the key's.
+* :class:`AutoIdRef` and :class:`AutoIdKeyDictionary` decide per key, holding
+  it weakly where that is possible.
+
+Because the wrappers are stored in an ordinary ``dict``, nothing else refers to
+them, and keeping only live ones in the map is the job of finalizers installed
+on the original keys.
+"""
+
 import collections.abc
 import copy
 import functools
@@ -10,13 +42,14 @@ import weakref
 # TODO: make weakref properly thread safe following
 # https://github.com/python/cpython/pull/125325
 class _IterationGuard[K, V]:
-    # This context manager registers itself in the current iterators of the
-    # weak container, such as to delay all removals until the context manager
-    # exits.
-    # This technique should be relatively thread-safe (since sets are).
+    """Delays a weak container's removals until an iteration over it finishes.
 
-    # CHANGED: parameterised by the container's key and value types, so that the
-    # attribute below names the container rather than being an opaque weakref.
+    Registers itself in the container's set of current iterators on entry and
+    commits the removals that piled up on exit, so that a key dying mid-walk
+    does not mutate the dictionary out from under the walk. Relatively
+    thread-safe, since sets are.
+    """
+
     weakcontainer: weakref.ref["WeakIdKeyDictionary[K, V]"]
 
     def __init__(self, weakcontainer: "WeakIdKeyDictionary[K, V]") -> None:
@@ -43,32 +76,18 @@ class _IterationGuard[K, V]:
                 w._commit_removals()
 
 
-# This file defines a variant of WeakKeyDictionary that overrides the hashing
-# behavior of the key to use object identity, rather than the builtin
-# __eq__/__hash__ functions.  This is useful for Tensor weak keys, as their
-# __eq__ implementation return a Tensor (elementwise equality), which means
-# you can't use them directly with the WeakKeyDictionary in standard library.
-#
-# Our implementation strategy is to create a wrapper weak key object, which we
-# use as a key in a stock Python dictionary.  This is similar to how weakref
-# implements WeakKeyDictionary, but instead of using weakref.ref as the
-# wrapper, we use a custom wrapper that has different __eq__ and __hash__
-# behavior.  Note that we subsequently store this weak key directly in an
-# ORDINARY dictionary, since the newly constructed WeakIdKey's only use would
-# be a dictionary so it would have no strong references.  Ensuring that
-# only live WeakIdKeys are in the map is handled by putting finalizers on the
-# original key object.
-
-
-# It is simpler to implement this with composition, but if we want to
-# directly reuse the callback mechanism on weakref, we need the weakref
-# and the key to be exactly the same object.  Reusing the callback mechanism
-# minimizes the divergence between our implementation and Lib/weakref.py
-#
-# NB: Prefer using this when working with weakrefs of Tensors; e.g., do
-# WeakIdRef(tensor) rather than weakref.ref(tensor); it handles a number of
-# easy to get wrong cases transparently for you.
 class WeakIdRef[T](weakref.ref[T]):
+    """A weak reference that hashes and compares by its referent's identity.
+
+    Subclasses :class:`weakref.ref` rather than wrapping one. Composition would
+    be simpler, but reusing weakref's callback mechanism requires the reference
+    and the key to be exactly the same object, and reusing it keeps the
+    divergence from ``Lib/weakref.py`` small.
+
+    Prefer this over a bare ``weakref.ref`` whenever the reference will be used
+    as a key; it handles a number of easy to get wrong cases transparently.
+    """
+
     __slots__ = ["_id"]
 
     def __init__(
@@ -92,7 +111,13 @@ class WeakIdRef[T](weakref.ref[T]):
     def __hash__(self) -> int:
         return self._id
 
-    def __eq__(self, other: typing.Any) -> bool:
+    def __eq__(self, other: object) -> bool:
+        # Anything that is not a reference is the other operand's business:
+        # dereferencing it below would raise TypeError rather than answer the
+        # comparison. Stock weakref.ref defers here too.
+        if not isinstance(other, (weakref.ref, StrongIdRef)):
+            return NotImplemented
+
         # An attractive but wrong alternate implementation is to only test if
         # the stored _ids match.  This can lead to an ABA problem if you have:
         #
@@ -105,35 +130,33 @@ class WeakIdRef[T](weakref.ref[T]):
         #
         # This should be False, as a1 and a2 are unrelated (and a1 is
         # dead anyway)
-        #
-        # CHANGED: defer to the other operand for anything that is not a
-        # reference, as stock weakref.ref does. Dereferencing it below would
-        # raise TypeError instead of answering the comparison.
-        if not isinstance(other, (weakref.ref, StrongIdRef)):
-            return NotImplemented
         a = self()
         b = other()
         if a is not None and b is not None:
             return a is b
         return self is other
 
-    def __ne__(self, other: typing.Any) -> bool:
-        # CHANGED: weakref.ref implements == and != together in C, and its !=
-        # compares the referents with the equality operator. Overriding __eq__
-        # alone leaves != inherited from there, disagreeing with == and calling
-        # the very __eq__ this class exists to route around -- for a Tensor key
-        # that returns another Tensor rather than a bool.
+    def __ne__(self, other: object) -> bool:
+        # Not redundant with __eq__: weakref.ref implements == and != together
+        # in C, and its != compares the referents with the equality operator.
+        # Overriding __eq__ alone leaves != inherited from there, disagreeing
+        # with == and calling the very __eq__ this class exists to route around.
         eq = self.__eq__(other)
         return eq if eq is NotImplemented else not eq
 
 
-# This is a strong counterpart to WeakIdRef, for identity keying without weak
-# references. That is what a cache scoped to a block wants: nothing can leak,
-# because the whole dictionary is dropped when the block exits. It also accepts
-# keys that cannot be weakly referenced at all, such as int, str, tuple, list
-# and dict. Used by IdKeyDictionary, and by AutoIdRef for the keys WeakIdRef
-# cannot take.
 class StrongIdRef[T]:
+    """A strong reference with the same interface as :class:`WeakIdRef`.
+
+    Identity keying without weak references is what a cache scoped to a block
+    wants: nothing can leak, because the whole dictionary is dropped when the
+    block exits. It also accepts keys that cannot be weakly referenced at all,
+    such as ``int``, ``str``, ``tuple``, ``list`` and ``dict``.
+
+    Used by :class:`StrongIdKeyDictionary`, and by :class:`AutoIdRef` for the
+    keys :class:`WeakIdRef` cannot take.
+    """
+
     __slots__ = ["_id", "_obj"]
 
     def __init__(
@@ -152,7 +175,7 @@ class StrongIdRef[T]:
     def __hash__(self) -> int:
         return self._id
 
-    def __eq__(self, other: typing.Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         # AutoIdRef puts both reference types in one dictionary, so this has to
         # stay symmetric with WeakIdRef.__eq__, which treats a dead referent as
         # equal only to itself.
@@ -170,23 +193,27 @@ class StrongIdRef[T]:
         return (b := other()) is not None and b is self._obj
 
 
-# Picks a reference type per key rather than per dictionary: weak where the key
-# supports it, strong otherwise. This lets one dictionary accept any key at all,
-# at the cost of making entries for weak-referenceable keys evictable, so the
-# caller sees hit rates that depend on when the collector runs. Prefer
-# WeakIdKeyDictionary or StrongIdKeyDictionary when the keys allow a single
-# choice.
-#
-# This is a class rather than a factory function so that it can be assigned to
-# WeakIdKeyDictionary.ref_type: a plain function there would be bound as a method
-# and receive the dictionary as its first argument. Being a class also gives the
-# weak-referenceability check somewhere to live other than the module's public
-# surface, which is right: choosing between the two reference types is the only
-# thing that check is for.
 class AutoIdRef[T]:
-    # CHANGED: weak-referenceability is a property of the type, so caching by
-    # type turns the check into one lookup on the hot path. Weakly keyed, so that
-    # having been asked about a dynamically created class does not pin it.
+    """Builds a :class:`WeakIdRef`, or a :class:`StrongIdRef` where it must.
+
+    Picking the reference type per key rather than per dictionary lets one
+    dictionary accept any key at all. The cost is that entries for weakly
+    referenceable keys are evictable while the rest are not, so the caller sees
+    hit rates that depend on when the collector runs. Prefer
+    :class:`WeakIdKeyDictionary` or :class:`StrongIdKeyDictionary` where the
+    keys allow a single choice.
+
+    A class rather than a factory function so that it can be assigned to
+    :attr:`WeakIdKeyDictionary.ref_type`, where a plain function would be bound
+    as a method and receive the dictionary as its first argument. Being a class
+    also gives the weak-referenceability check below somewhere to live other
+    than the module's public surface, which is where it belongs: choosing
+    between the two reference types is the only thing that check is for.
+    """
+
+    # Weak-referenceability is a property of the type, so caching by type turns
+    # the check into one lookup on the hot path. Weakly keyed, so that having
+    # been asked about a dynamically created class does not pin it.
     _WEAKREFABLE: typing.ClassVar[weakref.WeakKeyDictionary[type, bool]] = (
         weakref.WeakKeyDictionary()
     )
@@ -219,20 +246,25 @@ class AutoIdRef[T]:
         )
 
 
-# CHANGED: the handle a ``ref_type`` builds for a key -- hashable by the key's
-# identity, and callable to get the key back, or None where the reference was
-# weak and the key has since died. Naming it lets ``data``, ``_pending_removals``
-# and ``keyrefs`` say what they hold instead of falling back to Any, and puts the
-# "check the result before using it" of keyrefs' docstring into the type.
 class KeyRef[T](typing.Protocol):
+    """The handle a :attr:`WeakIdKeyDictionary.ref_type` builds for a key.
+
+    Hashable by the key's identity, and callable to get the key back -- or
+    ``None`` where the reference was weak and the key has since died, which is
+    why the result has to be checked before it is used.
+    """
+
     def __call__(self) -> T | None: ...
 
 
-# CHANGED: what may be assigned to ``ref_type``. Both call shapes are here: bare
-# to look a key up, and with the dictionary's removal callback to build an entry.
-# Not parameterised by the key type: this is used as a ClassVar, which cannot
-# refer to the class's type variables.
 class RefType(typing.Protocol):
+    """What may be assigned to :attr:`WeakIdKeyDictionary.ref_type`.
+
+    Both call shapes are here: bare, to look a key up, and with the
+    dictionary's removal callback, to build an entry. Not parameterised by the
+    key type, because a ``ClassVar`` cannot refer to its class's type variables.
+    """
+
     def __call__(
         self,
         key: typing.Any,
@@ -241,12 +273,15 @@ class RefType(typing.Protocol):
     ) -> KeyRef[typing.Any]: ...
 
 
-# CHANGED: the part of a mapping that ``update`` needs from its argument, which
-# is what ``dict(...)`` accepts too. This is ``_typeshed.SupportsKeysAndGetItem``,
-# spelled out here because that module does not exist at runtime; taking anything
-# narrower, such as a Mapping, would be a signature that MutableMapping.update
-# does not permit.
 class KeysAndGetItem[K, V](typing.Protocol):
+    """The part of a mapping that :meth:`WeakIdKeyDictionary.update` needs.
+
+    This is ``_typeshed.SupportsKeysAndGetItem``, spelled out because that
+    module does not exist at runtime. Anything narrower, a ``Mapping`` say,
+    would be a signature that ``MutableMapping.update`` does not permit an
+    override to have.
+    """
+
     def keys(self) -> collections.abc.Iterable[K]: ...
     def __getitem__(self, key: K, /) -> V: ...
 
@@ -255,10 +290,17 @@ class KeysAndGetItem[K, V](typing.Protocol):
 _MISSING: typing.Final = object()
 
 
-# This is directly adapted from cpython/Lib/weakref.py
 class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
-    # CHANGED: reference strength is a property of the dictionary, so subclasses
-    # select it by overriding this rather than callers passing it per instance.
+    """A :class:`weakref.WeakKeyDictionary` keyed on ``id`` rather than ``==``.
+
+    Directly adapted from cpython's ``Lib/weakref.py``. Keys are held weakly and
+    their entries disappear once they are collected, which is also why ``keys``,
+    ``values`` and ``items`` are generators rather than the views a ``Mapping``
+    would normally return: they have to skip keys that died mid-walk.
+    """
+
+    # Reference strength is a property of the dictionary, so subclasses select
+    # it by overriding this rather than callers passing it per instance.
     ref_type: typing.ClassVar[RefType] = WeakIdRef
 
     # Declared here rather than annotated in ``__init__``, where the ``dict``
@@ -287,7 +329,6 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
                         pass
 
         self._remove = remove
-        # A list of dead weakrefs (keys to be removed)
         self._pending_removals = []
         self._iterating = set()
         self._dirty_len = False
@@ -319,10 +360,10 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
 
     def __delitem__(self, key: K) -> None:
         self._dirty_len = True
-        del self.data[self.ref_type(key)]  # CHANGED
+        del self.data[self.ref_type(key)]
 
     def __getitem__(self, key: K) -> V:
-        return self.data[self.ref_type(key)]  # CHANGED
+        return self.data[self.ref_type(key)]
 
     def __len__(self) -> int:
         if self._dirty_len and self._pending_removals:
@@ -335,10 +376,10 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
         return f"<{self.__class__.__name__} at {id(self):#x}>"
 
     def __setitem__(self, key: K, value: V) -> None:
-        self.data[self.ref_type(key, self._remove)] = value  # CHANGED
+        self.data[self.ref_type(key, self._remove)] = value
 
     def copy(self) -> typing.Self:
-        new = self.__class__()  # CHANGED: preserve the subclass's ref_type
+        new = self.__class__()  # not WeakIdKeyDictionary: keep the subclass's ref_type
         with _IterationGuard(self):
             for key, value in self.data.items():
                 o = key()
@@ -357,8 +398,6 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
                     new[o] = copy.deepcopy(value, memo)
         return new
 
-    # CHANGED: the overloads Mapping.get declares, rather than one signature that
-    # forced the default to be a V and had to be excused from the override check.
     @typing.overload
     def get(self, key: K) -> V | None: ...
 
@@ -369,17 +408,16 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
     def get[D](self, key: K, default: D) -> V | D: ...
 
     def get(self, key: K, default: typing.Any = None) -> typing.Any:
-        return self.data.get(self.ref_type(key), default)  # CHANGED
+        return self.data.get(self.ref_type(key), default)
 
     def __contains__(self, key: object) -> bool:
         try:
-            wr = self.ref_type(key)  # CHANGED
+            wr = self.ref_type(key)
         except TypeError:
+            # A key the ref_type cannot take is simply not in the dictionary.
             return False
         return wr in self.data
 
-    # Generators rather than the views MutableMapping specifies: a view would
-    # have to hold the dictionary, and these have to skip keys that died mid-walk.
     def items(self) -> collections.abc.Iterator[tuple[K, V]]:  # type: ignore[override]
         with _IterationGuard(self):
             for wr, value in self.data.items():
@@ -403,14 +441,12 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
                     yield value
 
     def keyrefs(self) -> list[KeyRef[K]]:
-        """Return a list of weak references to the keys.
+        """Return a list of references to the keys.
 
-        The references are not guaranteed to be 'live' at the time
-        they are used, so the result of calling the references needs
-        to be checked before being used.  This can be used to avoid
-        creating references that will cause the garbage collector to
-        keep the keys around longer than needed.
-
+        The references are not guaranteed to be 'live' at the time they are
+        used, so the result of calling one needs to be checked before being
+        used. This can be used to avoid creating references that will cause the
+        garbage collector to keep the keys around longer than needed.
         """
         return list(self.data)
 
@@ -422,8 +458,6 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
             if o is not None:
                 return o, value
 
-    # CHANGED: the overloads MutableMapping.pop declares, which is also what makes
-    # the implementation's *args legible: the second argument is the default.
     @typing.overload
     def pop(self, key: K) -> V: ...
 
@@ -436,15 +470,13 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
     def pop(self, key: K, default: typing.Any = _MISSING) -> typing.Any:
         self._dirty_len = True
 
-        # CHANGED: a sentinel rather than *args, so that the signature says which
-        # argument the overloads above are talking about.
         if default is _MISSING:
             return self.data.pop(self.ref_type(key))
         return self.data.pop(self.ref_type(key), default)
 
-    # CHANGED: as MutableMapping.setdefault declares it. Omitting the default is
-    # only meaningful when None is a value this dictionary can hold, which is what
-    # the first overload's annotated self says.
+    # Omitting the default is only meaningful when None is a value this
+    # dictionary can hold, which is what the first overload's annotated self
+    # says. Both are as MutableMapping.setdefault declares them.
     @typing.overload
     def setdefault(
         self: "WeakIdKeyDictionary[K, V | None]", key: K, default: None = None
@@ -454,11 +486,9 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
     def setdefault(self, key: K, default: V) -> V: ...
 
     def setdefault(self, key: K, default: typing.Any = None) -> typing.Any:
-        return self.data.setdefault(
-            self.ref_type(key, self._remove), default
-        )  # CHANGED
+        return self.data.setdefault(self.ref_type(key, self._remove), default)
 
-    def update(  # CHANGED: annotated
+    def update(
         self,
         dict: KeysAndGetItem[K, V]
         | collections.abc.Iterable[tuple[K, V]]
@@ -473,7 +503,7 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
             if not hasattr(source, "items"):
                 source = type({})(source)
             for key, value in source.items():
-                d[self.ref_type(key, self._remove)] = value  # CHANGED
+                d[self.ref_type(key, self._remove)] = value
         if kwargs:
             # Only well typed when K is str, which no annotation here can say.
             self.update(typing.cast(KeysAndGetItem[K, V], kwargs))
@@ -503,9 +533,9 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
             return c
         return NotImplemented
 
-    # Default Mapping equality will tests keys for equality, but
-    # we want to test ids for equality
     def __eq__(self, other: object) -> bool:
+        # Mapping's default equality tests the keys for equality, and this
+        # dictionary's whole point is that its keys are compared by identity.
         if not isinstance(other, collections.abc.Mapping):
             return NotImplemented
         return {id(k): v for k, v in self.items()} == {
@@ -513,19 +543,27 @@ class WeakIdKeyDictionary[K, V](collections.abc.MutableMapping[K, V]):
         }
 
 
-# CHANGED: the strong counterpart of WeakIdKeyDictionary. Keys are compared by
-# identity and kept alive, so this accepts keys that cannot be weakly referenced
-# and its entries never disappear on their own. Use it for a cache whose own
-# lifetime already bounds the entries', such as one scoped to a block.
 class StrongIdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
-    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = StrongIdRef
+    """The strong counterpart of :class:`WeakIdKeyDictionary`.
+
+    Keys are compared by identity and kept alive, so this accepts keys that
+    cannot be weakly referenced and its entries never disappear on their own.
+    Use it for a cache whose own lifetime already bounds its entries', such as
+    one scoped to a block.
+    """
+
+    ref_type: typing.ClassVar[RefType] = StrongIdRef
 
 
-# CHANGED: accepts any key, holding it weakly where that is possible. This is
-# the one to reach for when a single cache has to serve keys of both kinds; see
-# AutoIdRef for what it gives up relative to the two dictionaries above.
 class AutoIdKeyDictionary[K, V](WeakIdKeyDictionary[K, V]):
-    ref_type: typing.ClassVar[collections.abc.Callable[..., typing.Any]] = AutoIdRef
+    """Accepts any key, holding it weakly where that is possible.
+
+    The one to reach for when a single cache has to serve keys of both kinds;
+    see :class:`AutoIdRef` for what it gives up relative to the two dictionaries
+    above.
+    """
+
+    ref_type: typing.ClassVar[RefType] = AutoIdRef
 
 
 type WeakKeyCache[S, T] = weakref.WeakKeyDictionary[S, T] | WeakIdKeyDictionary[S, T]
@@ -550,14 +588,23 @@ def weak_memoize[S, T](
     *,
     cache: WeakKeyCache[S, T] | None = None,
 ) -> typing.Any:
-    """Memoize ``fn`` using weak references to its argument and result.
+    """Memoize ``fn`` on its single argument.
 
-    The memoization is scoped to the lifetime of the argument, so that when the
-    argument is garbage collected, the memoized result is also discarded.
+    How the argument is keyed, and how long an entry lives, are both properties
+    of ``cache`` rather than of this function. The default is an
+    :class:`AutoIdKeyDictionary`, which keys on the argument's identity and
+    scopes the entry to the argument's lifetime wherever the argument can be
+    weakly referenced. A :class:`weakref.WeakKeyDictionary` keys on ``==``
+    instead; a :class:`StrongIdKeyDictionary` keeps every entry, and every key,
+    for as long as the cache itself lives.
 
-    Usable bare or with arguments: ``@weak_memoize`` and
-    ``@weak_memoize(cache=...)`` are both decorators, which is what the two
-    overloads above distinguish.
+    An entry outlives its key even in the weak cases if the result refers back
+    to the argument, as a wrapper built by :func:`functools.wraps` does: the
+    value keeps its own key alive.
+
+    Usable bare, with arguments, or as a plain call: ``@weak_memoize``,
+    ``@weak_memoize(cache=...)`` and ``weak_memoize(fn, cache=...)`` are all
+    supported, and the first two are what the overloads above distinguish.
     """
     if fn is None:
         return functools.partial(weak_memoize, cache=cache)

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -91,8 +91,8 @@ def coproduct(intp: Interpretation, intp2: Interpretation) -> Interpretation:
     """
     from effectful.internals.runtime import (
         _get_args,
-        _restore_args,
         _save_args,
+        _save_then_restore_args,
         _set_prompt,
     )
 
@@ -104,7 +104,7 @@ def coproduct(intp: Interpretation, intp2: Interpretation) -> Interpretation:
             # calling fwd in the right handler should dispatch to the left handler
             i1 = intp.get(op)
             res[op] = (
-                _set_prompt(fwd, _restore_args(_save_args(i1)), _save_args(i2))
+                _set_prompt(fwd, _save_then_restore_args(i1), _save_args(i2))
                 if i1 is not None
                 else _save_args(i2)
             )

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -5,10 +5,10 @@ import functools
 import operator
 import types
 import typing
-import weakref
 from collections.abc import Callable
 from typing import Any
 
+from effectful.internals.weak import WeakIdKeyDictionary
 from effectful.ops.syntax import (
     ConstructorOperation,
     DataclassConstructorOperation,
@@ -130,6 +130,9 @@ def as_tuple(*args) -> tuple:
     return tuple(args)
 
 
+_MISSING: Any = object()
+
+
 @_CustomSingleDispatchCallable
 def evaluate[T](
     __dispatch: Callable[[type], Callable[..., Expr[T]]],
@@ -160,13 +163,11 @@ def evaluate[T](
     with interpreter(intp if intp is not None else get_runtime().interpretation):
         cache = get_runtime().cache
         assert cache is not None, "Cache should be initialized by interpreter"
-        key = id(expr)
-        if key in cache:
-            ref, result = cache[key]
-            if ref is expr:
-                return result
+        result = cache.get(expr, _MISSING)
+        if result is not _MISSING:
+            return result
         result = __dispatch(type(expr))(expr)
-        cache[key] = (expr, result)
+        cache[expr] = result
         return result
 
 
@@ -195,14 +196,12 @@ _EVALUATION_CACHE_ATTR = "__effectful_evaluation_cache__"
 
 def _term_cache(
     expr: Term,
-) -> weakref.WeakKeyDictionary[PureInterpretation, Any] | None:
+) -> WeakIdKeyDictionary | None:
     """Return the cache owned by ``expr``, or ``None`` if it cannot store one."""
     try:
         return getattr(expr, _EVALUATION_CACHE_ATTR)
     except AttributeError:
-        cache: weakref.WeakKeyDictionary[PureInterpretation, Any] = (
-            weakref.WeakKeyDictionary()
-        )
+        cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
         try:
             setattr(expr, _EVALUATION_CACHE_ATTR, cache)
         except (AttributeError, TypeError):

--- a/effectful/ops/semantics.py
+++ b/effectful/ops/semantics.py
@@ -8,7 +8,6 @@ import typing
 from collections.abc import Callable
 from typing import Any
 
-from effectful.internals.weak import WeakIdKeyDictionary
 from effectful.ops.syntax import (
     ConstructorOperation,
     DataclassConstructorOperation,
@@ -158,16 +157,31 @@ def evaluate[T](
     6
 
     """
-    from effectful.internals.runtime import get_runtime, interpreter
+    from effectful.internals.runtime import (
+        EVAL_CACHE,
+        cache,
+        cache_get,
+        cache_put,
+        get_interpretation,
+        interpreter,
+    )
 
-    with interpreter(intp if intp is not None else get_runtime().interpretation):
-        cache = get_runtime().cache
-        assert cache is not None, "Cache should be initialized by interpreter"
-        result = cache.get(expr, _MISSING)
+    with interpreter(intp if intp is not None else get_interpretation()) as current:
+        store = EVAL_CACHE.get()
+        if store is None:
+            # No cache installed. Open one for the duration of this call and start
+            # over. Without it, an expression that reaches a subexpression along
+            # several paths re-evaluates it once per path, which is exponential in
+            # the depth of a DAG. Only the outermost call takes this branch, so the
+            # extra re-entry is paid once.
+            with cache():
+                return evaluate(expr, intp=current)
+
+        result = cache_get(store, expr, current, _MISSING)
         if result is not _MISSING:
             return result
         result = __dispatch(type(expr))(expr)
-        cache[expr] = result
+        cache_put(store, expr, current, result)
         return result
 
 
@@ -191,42 +205,11 @@ def _evaluate_dataclass[T](expr: T, **kwargs) -> T:
     )
 
 
-_EVALUATION_CACHE_ATTR = "__effectful_evaluation_cache__"
-
-
-def _term_cache(
-    expr: Term,
-) -> WeakIdKeyDictionary | None:
-    """Return the cache owned by ``expr``, or ``None`` if it cannot store one."""
-    try:
-        return getattr(expr, _EVALUATION_CACHE_ATTR)
-    except AttributeError:
-        cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
-        try:
-            setattr(expr, _EVALUATION_CACHE_ATTR, cache)
-        except (AttributeError, TypeError):
-            return None
-        return cache
-
-
 @evaluate.register(Term)
 def _evaluate_term(expr: Term, **kwargs):
-    from effectful.internals.runtime import get_interpretation
-
-    current_intp = get_interpretation()
-    if isinstance(current_intp, PureInterpretation):
-        cache = _term_cache(expr)
-        if cache is not None and current_intp in cache:
-            return cache[current_intp]
-    else:
-        cache = None
-
     args = tuple(evaluate(arg) for arg in expr.args)
     kwargs = {k: evaluate(v) for k, v in expr.kwargs.items()}
-    result = expr.op(*args, **kwargs)
-    if cache is not None:
-        cache[current_intp] = result
-    return result
+    return expr.op(*args, **kwargs)
 
 
 @evaluate.register(Operation)

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -445,15 +445,16 @@ def _build_term[T](
     type from the types of its arguments and dispatches on that type to pick a
     constructor.
     """
-    from effectful.ops.semantics import _simple_type, _typeof, _term_cache, typeof
+    from effectful.internals.runtime import copy_cache_entries
+    from effectful.ops.semantics import typeof
 
-    # typed_args = tuple(_typeof(arg) for arg in args)
-    # typed_kwargs = {k: _typeof(v) for k, v in kwargs.items()}
-    # dispatch_type = _simple_type(op.__type_rule__(*typed_args, **typed_kwargs))
-    raw_term = _BaseTerm(op, *args, **kwargs)
-    dispatch_type = typeof(raw_term)
+    # Compute the type on a throwaway node so that the analysis is cached against
+    # something, then move that cache onto the node actually returned: a parent's
+    # later typeof on this child is then a hit rather than a fresh traversal.
+    raw_term: Expr[T] = _BaseTerm(op, *args, **kwargs)
+    dispatch_type: type = typeof(raw_term)
     result = __dispatch(dispatch_type)(dispatch_type, op, *args, **kwargs)
-    _term_cache(result).update(_term_cache(raw_term))
+    copy_cache_entries(raw_term, result)
     return result
 
 

--- a/effectful/ops/syntax.py
+++ b/effectful/ops/syntax.py
@@ -445,12 +445,16 @@ def _build_term[T](
     type from the types of its arguments and dispatches on that type to pick a
     constructor.
     """
-    from effectful.ops.semantics import _simple_type, _typeof
+    from effectful.ops.semantics import _simple_type, _typeof, _term_cache, typeof
 
-    typed_args = tuple(_typeof(arg) for arg in args)
-    typed_kwargs = {k: _typeof(v) for k, v in kwargs.items()}
-    dispatch_type = _simple_type(op.__type_rule__(*typed_args, **typed_kwargs))
-    return __dispatch(dispatch_type)(dispatch_type, op, *args, **kwargs)
+    # typed_args = tuple(_typeof(arg) for arg in args)
+    # typed_kwargs = {k: _typeof(v) for k, v in kwargs.items()}
+    # dispatch_type = _simple_type(op.__type_rule__(*typed_args, **typed_kwargs))
+    raw_term = _BaseTerm(op, *args, **kwargs)
+    dispatch_type = typeof(raw_term)
+    result = __dispatch(dispatch_type)(dispatch_type, op, *args, **kwargs)
+    _term_cache(result).update(_term_cache(raw_term))
+    return result
 
 
 @_CustomSingleDispatchCallable

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -504,8 +504,14 @@ class Operation[**Q, V]:
         else:
             return self
 
+    @functools.cached_property
+    def _default_rule_with_args(self):
+        from effectful.internals.runtime import _restore_args
+
+        return _restore_args(self.__default_rule__)
+
     def __call__(self, *args: Q.args, **kwargs: Q.kwargs) -> V:
-        from effectful.internals.runtime import _restore_args, get_interpretation
+        from effectful.internals.runtime import get_interpretation
         from effectful.ops.semantics import fwd, handler
 
         intp = get_interpretation()
@@ -514,9 +520,7 @@ class Operation[**Q, V]:
         if self_handler is not None:
             # ensure that fwd is bound to the default rule. if this handler has
             # a bound fwd, it will override this binding
-            fwd_intp = typing.cast(
-                Interpretation, {fwd: _restore_args(self.__default_rule__)}
-            )
+            fwd_intp = typing.cast(Interpretation, {fwd: self._default_rule_with_args})
             with handler(fwd_intp):
                 return self_handler(*args, **kwargs)
         elif args and isinstance(args[0], Operation) and self is args[0].__apply__:

--- a/effectful/ops/types.py
+++ b/effectful/ops/types.py
@@ -80,19 +80,17 @@ class Operation[**Q, V]:
 
     def __init__(self, default: Callable[Q, V], name: str | None = None):
         functools.update_wrapper(self, default)
-        # update_wrapper copies the wrapped callable's __dict__. Do not retain a
-        # signature cached by another Operation, since `default` may now be a
-        # bound version of that operation.
-        self.__dict__.pop("_signature", None)
+        # update_wrapper copies the wrapped callable's __dict__,
+        #   clear any cached_property values that may have been copied
+        for var, val in vars(self.__class__).items():
+            if isinstance(val, functools.cached_property) and var in self.__dict__:
+                self.__dict__.pop(var, None)
+
         self.__default__ = default
         self.__name__ = name or default.__name__
 
-    @property
-    def __signature__(self):
-        return self._signature
-
     @functools.cached_property
-    def _signature(self):
+    def __signature__(self):
         # Resolve forward references (e.g. -> "MyClass") using the
         # default function's __globals__.  This handles module-level
         # forward refs; local forward refs will raise NameError.
@@ -411,6 +409,12 @@ class Operation[**Q, V]:
         subst_type = substitute(return_anno, unify(self.__signature__, bound_sig))
         return typing.cast(type[V], subst_type)
 
+    @functools.cached_property
+    def _signature_with_scopes(self):
+        from effectful.ops.syntax import Scoped
+
+        return Scoped.infer_annotations(self.__signature__)
+
     @typing.final
     def __fvs_rule__(self, *args: Q.args, **kwargs: Q.kwargs) -> inspect.BoundArguments:
         """Returns the sets of variables that appear free in each argument and
@@ -425,7 +429,7 @@ class Operation[**Q, V]:
         """
         from effectful.ops.syntax import Scoped
 
-        sig = Scoped.infer_annotations(self.__signature__)
+        sig = self._signature_with_scopes
         bound_sig = sig.bind(*args, **kwargs)
         bound_sig.apply_defaults()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ test = [
     "pytest-cov",
     "pytest-xdist",
     "pytest-benchmark",
+    "pytest-timeout",
     "mypy",
     "ruff",
     "nbval",

--- a/tests/test_internals_weak.py
+++ b/tests/test_internals_weak.py
@@ -1410,6 +1410,34 @@ def test_memoize_is_scoped_to_the_arguments_lifetime() -> None:
     assert len(fn.calls) == 1
 
 
+def test_memoize_keying_and_lifetime_follow_the_cache() -> None:
+    """F8, F10: what ``weak_memoize``'s docstring promises about each cache type.
+
+    Neither the identity keying nor the scoping to the argument's lifetime is a
+    property of ``weak_memoize`` itself; both come from the cache, and the two
+    non-default cache types in the signature give up one each.
+    """
+    # A stock WeakKeyDictionary keys on == , so equal-but-distinct arguments
+    # share one entry.
+    by_equality = counted(lambda x: x.arg)
+    memoized = weak_memoize(by_equality, cache=weakref.WeakKeyDictionary())
+    a, b = Obj(1), Obj(1)
+    memoized(a)
+    memoized(b)
+    assert by_equality.calls == [id(a)]
+
+    # A StrongIdKeyDictionary keeps the entry, and the key, alive.
+    cache: StrongIdKeyDictionary = StrongIdKeyDictionary()
+    kept = weak_memoize(lambda x: x.arg, cache=cache)
+    k = Obj(2)
+    probe = weakref.ref(k)
+    kept(k)
+    del k
+    gc_collect()
+    assert len(cache) == 1
+    assert probe() is not None
+
+
 def test_memoize_entry_survives_when_the_result_holds_the_argument() -> None:
     """F11: the documented hazard of caching values that reference their key.
 

--- a/tests/test_internals_weak.py
+++ b/tests/test_internals_weak.py
@@ -1339,7 +1339,7 @@ def test_memoize_decorator_forms_agree() -> None:
     assert bare(k) == with_kwarg(k) == positional(k) == 7
     assert bare(k) == with_kwarg(k) == positional(k) == 7
     for memoized in (bare, with_kwarg, positional):
-        assert len(memoized.__wrapped__.calls) == 1  # type: ignore[attr-defined]
+        assert len(memoized.__wrapped__.calls) == 1
 
 
 def test_memoize_uses_the_supplied_cache() -> None:

--- a/tests/test_internals_weak.py
+++ b/tests/test_internals_weak.py
@@ -1,0 +1,1517 @@
+"""Tests for :mod:`effectful.internals.weak`.
+
+Two complementary strategies:
+
+* Hand-written invariant tests, parameterised over the dictionary flavours, that
+  name the law they check (``M3``, ``K5``, ...). These give a named failure.
+* A differential harness that replays a random operation sequence against both
+  :class:`weakref.WeakKeyDictionary` and the dictionary under test, over the
+  domain where the two are meant to be indistinguishable: weakly referenceable
+  keys whose ``__eq__``/``__hash__`` are the inherited identity-based defaults.
+
+Everything here is extensional: no test reads ``_dirty_len``, ``_iterating``,
+``_pending_removals`` or ``data``.
+
+The ports are from cpython's ``Lib/test/test_weakref.py`` (``MappingTestCase``)
+and pytorch's ``test/test_weak.py``, which is where this module was forked from.
+
+Beware of accidentally keeping a key alive: a ``for`` loop leaves its variable
+bound after the loop, which is enough to make a "dead" key outlive a
+``gc_collect()``. Build key lists with ``map`` and delete anything that lingers.
+"""
+
+import collections.abc
+import contextlib
+import copy
+import dataclasses
+import functools
+import gc
+import random
+import re
+import threading
+import typing
+import weakref
+
+import pytest
+
+from effectful.internals.weak import (
+    AutoIdKeyDictionary,
+    AutoIdRef,
+    IdKeyDictionary,
+    IdRef,
+    WeakIdKeyDictionary,
+    WeakIdRef,
+    is_weakrefable,
+    weak_memoize,
+)
+
+AnyDict = WeakIdKeyDictionary[typing.Any, typing.Any]
+
+
+def gc_collect() -> None:
+    """Force collection, twice, so cycles found in the first pass are freed."""
+    gc.collect()
+    gc.collect()
+
+
+class Obj:
+    """A key with *equality* semantics -- cpython's ``test_weakref.Object``.
+
+    Equal-but-distinct instances are what make the identity-keying laws
+    meaningful: a stock ``WeakKeyDictionary`` collapses them into one entry.
+    """
+
+    def __init__(self, arg: int) -> None:
+        self.arg = arg
+
+    def __repr__(self) -> str:
+        return f"<Obj {self.arg!r}>"
+
+    def __eq__(self, other: object) -> typing.Any:
+        return self.arg == other.arg if isinstance(other, Obj) else NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self.arg)
+
+
+class Plain:
+    """A key with the inherited identity semantics.
+
+    This is the domain on which the dictionaries here and
+    :class:`weakref.WeakKeyDictionary` must agree; see the differential tests.
+    """
+
+    def __init__(self, arg: int) -> None:
+        self.arg = arg
+
+
+class Hostile:
+    """A key the standard library cannot hold: unhashable, and ``__eq__`` raises.
+
+    Holding one of these is the whole reason this module exists -- upstream it is
+    a Tensor, whose ``__eq__`` returns another Tensor rather than a bool.
+    """
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __eq__(self, other: object) -> bool:
+        raise AssertionError("the key's __eq__ must never be called")
+
+
+class Slotted:
+    """Not weakly referenceable, despite being an ordinary instance."""
+
+    __slots__ = ("x",)
+
+
+class RefCycle:
+    """Only collectable by the cycle collector, as in cpython's len tests."""
+
+    def __init__(self) -> None:
+        self.cycle = self
+
+
+def big_int(i: int) -> int:
+    """A non-weakrefable key that is *not* interned, so twins are distinguishable."""
+    return 10**18 + i
+
+
+def tup(i: int) -> tuple[int, ...]:
+    return (i, i + 1)
+
+
+@dataclasses.dataclass(frozen=True)
+class Flavor:
+    """A dictionary class paired with a kind of key it accepts."""
+
+    cls: type[AnyDict]
+    key: collections.abc.Callable[[int], typing.Any]
+    weak: bool
+    label: str
+
+    def keys(self, n: int) -> list[typing.Any]:
+        return [self.key(i) for i in range(n)]
+
+
+FLAVORS = [
+    Flavor(WeakIdKeyDictionary, Obj, weak=True, label="weak/obj"),
+    Flavor(IdKeyDictionary, Obj, weak=False, label="strong/obj"),
+    Flavor(IdKeyDictionary, big_int, weak=False, label="strong/int"),
+    Flavor(AutoIdKeyDictionary, Obj, weak=True, label="auto/obj"),
+    Flavor(AutoIdKeyDictionary, tup, weak=False, label="auto/tuple"),
+]
+WEAK_FLAVORS = [f for f in FLAVORS if f.weak]
+
+DICT_CLASSES = [WeakIdKeyDictionary, IdKeyDictionary, AutoIdKeyDictionary]
+
+
+def flavors(cases: list[Flavor] = FLAVORS) -> typing.Any:
+    return pytest.mark.parametrize("flavor", cases, ids=[f.label for f in cases])
+
+
+classes = pytest.mark.parametrize(
+    "cls", DICT_CLASSES, ids=[c.__name__ for c in DICT_CLASSES]
+)
+
+
+def build(flavor: Flavor, n: int = 3) -> tuple[AnyDict, list, dict[int, int]]:
+    """A dictionary of ``n`` entries, its keys, and the ``id(key) -> value`` model."""
+    d = flavor.cls()
+    keys = flavor.keys(n)
+    for i, k in enumerate(keys):
+        d[k] = i
+    return d, keys, {id(k): i for i, k in enumerate(keys)}
+
+
+def assert_model(
+    d: AnyDict,
+    model: dict[int, typing.Any],
+    present: collections.abc.Iterable = (),
+    absent: collections.abc.Iterable = (),
+) -> None:
+    """Assert every observable of ``d`` agrees with ``model`` (``id(key) -> value``)."""
+    assert len(d) == len(model)
+    assert bool(d) == bool(model)
+    assert {id(k): v for k, v in d.items()} == model
+    assert sorted(id(k) for k in d.keys()) == sorted(model)
+    assert sorted(id(k) for k in d) == sorted(model)
+    assert sorted(d.values()) == sorted(model.values())
+    # dict(d) goes through keys() and __getitem__; it collapses equal-but-distinct
+    # keys, so compare it against a plain dict built the same way rather than the
+    # identity-keyed model.
+    assert dict(d) == dict(d.items())
+    assert sorted(id(r()) for r in d.keyrefs() if r() is not None) == sorted(model)
+    assert d == d.copy()
+    for k in present:
+        assert k in d
+        assert d[k] == model[id(k)]
+        assert d.get(k) == model[id(k)]
+    for k in absent:
+        assert k not in d
+        assert d.get(k) is None
+        assert d.get(k, "default") == "default"
+
+
+###############################################################################
+# Reference types: WeakIdRef, IdRef, AutoIdRef
+###############################################################################
+
+REF_TYPES = [WeakIdRef, IdRef, AutoIdRef]
+ref_types = pytest.mark.parametrize(
+    "ref_type", REF_TYPES, ids=[t.__name__ for t in REF_TYPES]
+)
+
+
+@ref_types
+def test_ref_deref_and_hash(ref_type: typing.Any) -> None:
+    """R1, R2: a live ref dereferences to its key and hashes as its id."""
+    o = Obj(1)
+    r = ref_type(o)
+    assert r() is o
+    assert hash(r) == id(o)
+
+
+@ref_types
+def test_ref_equal_to_itself_and_to_a_twin(ref_type: typing.Any) -> None:
+    """R3, R4: reflexive, and two refs to one object are equal and hash alike."""
+    o = Obj(1)
+    r, s = ref_type(o), ref_type(o)
+    assert r == r
+    assert r == s and s == r
+    assert hash(r) == hash(s)
+
+
+@ref_types
+def test_ref_uses_identity_not_equality(ref_type: typing.Any) -> None:
+    """R5: refs to equal-but-distinct objects are unequal."""
+    a, b = Obj(1), Obj(1)
+    assert a == b and hash(a) == hash(b)
+    assert ref_type(a) != ref_type(b)
+    assert ref_type(b) != ref_type(a)
+
+
+@ref_types
+def test_ref_never_touches_the_keys_protocols(ref_type: typing.Any) -> None:
+    """R6: an unhashable key whose ``__eq__`` raises still works as a referent."""
+    a, b = Hostile(), Hostile()
+    with pytest.raises(TypeError):
+        hash(a)
+    assert hash(ref_type(a)) == id(a)
+    assert ref_type(a) == ref_type(a)
+    assert ref_type(a) != ref_type(b)
+
+
+def test_weak_ref_death() -> None:
+    """R2, R3, R7: a dead ref still hashes, equals only itself, derefs to None."""
+    live = Obj(1)
+    live_ref = WeakIdRef(live)
+    dying = Obj(2)
+    dead_ref = WeakIdRef(dying)
+    dead_id = id(dying)
+    del dying
+    gc_collect()
+
+    assert dead_ref() is None
+    assert hash(dead_ref) == dead_id
+    assert dead_ref == dead_ref
+    assert dead_ref != live_ref
+    assert live_ref != dead_ref
+
+
+def test_weak_ref_aba() -> None:
+    """R8: a dead ref is not equal to a fresh ref that reused its address."""
+    for _ in range(1000):
+        first = Plain(1)
+        recycled = id(first)
+        dead_ref = WeakIdRef(first)
+        del first
+        gc_collect()
+        second = Plain(2)
+        if id(second) != recycled:
+            del second
+            continue
+        live_ref = WeakIdRef(second)
+        assert dead_ref() is None
+        assert hash(dead_ref) == hash(live_ref)  # the trap: equal hashes
+        assert dead_ref != live_ref
+        assert live_ref != dead_ref
+        return
+    pytest.skip("no address reuse observed")
+
+
+def test_ref_cross_type_symmetry() -> None:
+    """R9: weak and strong refs to one object are interchangeable in one dict."""
+    o = Obj(1)
+    w, s = WeakIdRef(o), IdRef(o)
+    assert w == s and s == w
+    assert hash(w) == hash(s) == id(o)
+
+
+def test_ref_cross_type_death() -> None:
+    """R9: a dead weak ref is not equal to a strong ref, in either direction."""
+    live = Obj(1)
+    strong = IdRef(live)
+    dying = Obj(2)
+    dead = WeakIdRef(dying)
+    del dying
+    gc_collect()
+    assert dead != strong
+    assert strong != dead
+
+
+def test_id_ref_is_strong() -> None:
+    """R10: an IdRef keeps its referent alive."""
+    o = Obj(1)
+    r = IdRef(o)
+    probe = weakref.ref(o)
+    del o
+    gc_collect()
+    assert probe() is not None
+    assert r() is probe()
+
+
+NON_WEAKREFABLE = [
+    ("int", 1),
+    ("str", "s"),
+    ("tuple", (1, 2)),
+    ("list", [1]),
+    ("dict", {1: 2}),
+    ("float", 1.5),
+    ("object", object()),
+    ("slotted", Slotted()),
+]
+
+
+@pytest.mark.parametrize(
+    "key", [v for _, v in NON_WEAKREFABLE], ids=[n for n, _ in NON_WEAKREFABLE]
+)
+def test_id_ref_accepts_non_weakrefable_keys(key: typing.Any) -> None:
+    """R10: IdRef takes keys weakref cannot."""
+    assert not is_weakrefable(key)
+    r = IdRef(key)
+    assert r() is key
+    assert hash(r) == id(key)
+    assert r == IdRef(key)
+
+
+AUTO_CASES = [
+    ("obj", Obj(1)),
+    ("set", set()),
+    ("class", Obj),
+    ("int", 1),
+    ("str", "s"),
+    ("tuple", (1,)),
+    ("list", [1]),
+    ("object", object()),
+]
+
+
+@pytest.mark.parametrize(
+    "key", [v for _, v in AUTO_CASES], ids=[n for n, _ in AUTO_CASES]
+)
+def test_auto_id_ref_picks_by_weakrefability(key: typing.Any) -> None:
+    """R11: AutoIdRef is a WeakIdRef exactly when the key supports it."""
+    r = AutoIdRef(key)
+    assert isinstance(r, WeakIdRef if is_weakrefable(key) else IdRef)
+    assert not isinstance(r, AutoIdRef)
+    assert r() is key
+    assert hash(r) == id(key)
+
+
+def test_weak_id_ref_callback_fires() -> None:
+    """R12."""
+    fired: list = []
+    o = Obj(1)
+    r = WeakIdRef(o, fired.append)
+    del o
+    gc_collect()
+    assert fired == [r]
+
+
+def test_id_ref_callback_never_fires() -> None:
+    """R12: IdRef accepts the removal callback and ignores it."""
+    fired: list = []
+    o = Obj(1)
+    r = IdRef(o, fired.append)
+    del o
+    gc_collect()
+    assert fired == []
+    assert r() is not None
+
+
+NON_REFS = [("int", 5), ("str", "x"), ("none", None), ("obj", Obj(1))]
+
+
+@ref_types
+@pytest.mark.parametrize(
+    "other", [v for _, v in NON_REFS], ids=[n for n, _ in NON_REFS]
+)
+def test_ref_compared_to_a_non_ref(ref_type: typing.Any, other: typing.Any) -> None:
+    """R13: comparing against a non-reference answers False rather than raising."""
+    r = ref_type(Obj(99))
+    assert (r == other) is False
+    assert (other == r) is False
+    assert (r != other) is True
+
+
+###############################################################################
+# is_weakrefable
+###############################################################################
+
+
+def weakrefable_ground_truth(value: typing.Any) -> bool:
+    try:
+        weakref.ref(value)
+    except TypeError:
+        return False
+    return True
+
+
+WEAKREF_CASES = [
+    ("int", 1),
+    ("float", 1.5),
+    ("bool", True),
+    ("str", "s"),
+    ("bytes", b"b"),
+    ("tuple", (1,)),
+    ("list", [1]),
+    ("dict", {1: 2}),
+    ("none", None),
+    ("object", object()),
+    ("slotted", Slotted()),
+    ("set", set()),
+    ("frozenset", frozenset()),
+    ("obj", Obj(1)),
+    ("class", Obj),
+    ("type", int),
+    ("function", weakrefable_ground_truth),
+    ("module", weakref),
+]
+
+
+@pytest.mark.parametrize(
+    "value", [v for _, v in WEAKREF_CASES], ids=[n for n, _ in WEAKREF_CASES]
+)
+def test_is_weakrefable_matches_weakref_ref(value: typing.Any) -> None:
+    """W1, W2: agrees with ``weakref.ref``, and never raises."""
+    assert is_weakrefable(value) is weakrefable_ground_truth(value)
+
+
+def test_is_weakrefable_cache_is_invisible() -> None:
+    """W3: repeated calls and sibling instances of a cold type all agree."""
+
+    class Fresh:  # a type the cache has certainly not seen
+        pass
+
+    a, b = Fresh(), Fresh()
+    assert is_weakrefable(a) is True
+    assert is_weakrefable(b) is True
+    assert is_weakrefable(a) is True
+
+    class FreshSlotted:
+        __slots__ = ()
+
+    c, d = FreshSlotted(), FreshSlotted()
+    assert is_weakrefable(c) is False
+    assert is_weakrefable(d) is False
+
+
+###############################################################################
+# Mapping laws, shared by every flavour
+###############################################################################
+
+
+@flavors()
+def test_set_and_get(flavor: Flavor) -> None:
+    """M1, M2: assignment round-trips; re-assignment overwrites in place."""
+    d = flavor.cls()
+    k = flavor.key(0)
+    value = ["a value"]
+    d[k] = value
+    assert d[k] is value
+    assert d.get(k) is value
+    assert len(d) == 1
+
+    other = ["another"]
+    d[k] = other
+    assert d[k] is other
+    assert len(d) == 1
+
+
+@flavors()
+def test_keys_are_compared_by_identity(flavor: Flavor) -> None:
+    """M3: equal-but-distinct keys are distinct entries."""
+    k1, k2 = flavor.key(0), flavor.key(0)
+    assert k1 == k2 and k1 is not k2
+
+    d = flavor.cls()
+    d[k1] = "first"
+    assert_model(d, {id(k1): "first"}, present=[k1], absent=[k2])
+
+    d[k2] = "second"
+    assert_model(d, {id(k1): "first", id(k2): "second"}, present=[k1, k2])
+    assert d[k1] == "first"
+
+
+@flavors()
+def test_delitem(flavor: Flavor) -> None:
+    """M4."""
+    d, keys, model = build(flavor)
+    del d[keys[1]]
+    del model[id(keys[1])]
+    assert_model(d, model, present=[keys[0], keys[2]], absent=[keys[1]])
+
+    with pytest.raises(KeyError):
+        del d[keys[1]]
+
+
+@flavors()
+def test_pop(flavor: Flavor) -> None:
+    """M5: ports ``WeakKeyDictionaryTestCase.test_pop``."""
+    d, keys, model = build(flavor)
+    assert d.pop(keys[1]) == model.pop(id(keys[1]))
+    assert_model(d, model, absent=[keys[1]])
+
+    with pytest.raises(KeyError):
+        d.pop(keys[1])
+    assert d.pop(keys[1], "default") == "default"
+    assert_model(d, model, absent=[keys[1]])
+
+
+@flavors()
+def test_popitem(flavor: Flavor) -> None:
+    """M6: ports ``check_popitem`` from pytorch's test_weak.py."""
+    d, keys, model = build(flavor, n=2)
+    for _ in range(2):
+        k, v = d.popitem()
+        assert model.pop(id(k)) == v
+        assert_model(d, model, absent=[k])
+    with pytest.raises(KeyError):
+        d.popitem()
+
+
+@flavors()
+def test_setdefault(flavor: Flavor) -> None:
+    """M7: ports ``check_setdefault`` from pytorch's test_weak.py."""
+    first, second = ["first"], ["second"]
+    d = flavor.cls()
+    k = flavor.key(0)
+
+    assert d.setdefault(k, first) is first
+    assert_model(d, {id(k): first}, present=[k])
+
+    assert d.setdefault(k, second) is first
+    assert_model(d, {id(k): first}, present=[k])
+
+
+@flavors()
+def test_update(flavor: Flavor) -> None:
+    """M8: ports ``check_update``; mapping, same-class, pairs, and no-op forms."""
+    keys = flavor.keys(3)
+    model = {id(k): i for i, k in enumerate(keys)}
+    source = dict(zip(keys, range(3)))
+
+    from_mapping = flavor.cls()
+    from_mapping.update(source)
+    assert_model(from_mapping, model, present=keys)
+
+    from_pairs = flavor.cls()
+    from_pairs.update(list(source.items()))
+    assert_model(from_pairs, model, present=keys)
+
+    from_same_class = flavor.cls()
+    from_same_class.update(from_mapping)
+    assert_model(from_same_class, model, present=keys)
+
+    from_ctor = flavor.cls(source)
+    assert_model(from_ctor, model, present=keys)
+
+    from_mapping.update()
+    assert_model(from_mapping, model, present=keys)
+
+
+@flavors()
+def test_clear(flavor: Flavor) -> None:
+    """M9."""
+    d, keys, _ = build(flavor)
+    d.clear()
+    assert_model(d, {}, absent=keys)
+
+
+@flavors()
+def test_copy(flavor: Flavor) -> None:
+    """M10: preserves the subclass, shares keys and values, is independent."""
+    d, keys, model = build(flavor)
+    c = d.copy()
+
+    assert type(c) is flavor.cls
+    assert c == d
+    assert_model(c, model, present=keys)
+    for k in keys:
+        assert c[k] is d[k]
+    assert sorted(id(k) for k in c.keys()) == sorted(id(k) for k in d.keys())
+
+    del c[keys[0]]
+    assert keys[0] in d
+    assert copy.copy(d) == d
+
+
+@flavors()
+def test_deepcopy(flavor: Flavor) -> None:
+    """M11: keys by identity, values deep-copied."""
+    d = flavor.cls()
+    keys = flavor.keys(2)
+    for i, k in enumerate(keys):
+        d[k] = [i]
+    c = copy.deepcopy(d)
+
+    assert type(c) is flavor.cls
+    assert c == d
+    for k in keys:
+        assert c[k] == d[k]
+        assert c[k] is not d[k]
+
+
+@flavors()
+def test_union_operators(flavor: Flavor) -> None:
+    """M12: ports ``test_weak_keyed_union_operators`` from both upstreams."""
+    o1, o2, o3 = flavor.keys(3)
+    wkd1 = flavor.cls({o1: 1, o2: 2})
+    wkd2 = flavor.cls({o3: 3, o1: 4})
+    wkd3 = wkd1.copy()
+    d1 = {o2: "5", o3: "6"}
+    pairs = [(o2, 7), (o3, 8)]
+
+    def as_model(m: typing.Any) -> dict[int, typing.Any]:
+        items = m.items() if hasattr(m, "items") else m
+        return {id(k): v for k, v in items}
+
+    tmp1 = wkd1 | wkd2
+    assert as_model(tmp1) == as_model(wkd1) | as_model(wkd2)
+    assert type(tmp1) is flavor.cls
+    wkd1 |= wkd2
+    assert wkd1 == tmp1
+
+    tmp2 = wkd2 | d1
+    assert as_model(tmp2) == as_model(wkd2) | as_model(d1)
+    assert type(tmp2) is flavor.cls
+    wkd2 |= d1
+    assert wkd2 == tmp2
+
+    tmp3 = wkd3.copy()
+    tmp3 |= pairs
+    assert as_model(tmp3) == as_model(wkd3) | as_model(pairs)
+    assert type(tmp3) is flavor.cls
+
+    tmp4 = d1 | wkd3
+    assert as_model(tmp4) == as_model(d1) | as_model(wkd3)
+    assert type(tmp4) is flavor.cls
+
+
+@flavors()
+def test_union_with_a_non_mapping(flavor: Flavor) -> None:
+    """M12."""
+    d, _, _ = build(flavor)
+    with pytest.raises(TypeError):
+        d | 5
+    with pytest.raises(TypeError):
+        5 | d
+
+
+@flavors()
+def test_eq_is_identity_based(flavor: Flavor) -> None:
+    """M13: equality compares key *identity*, not key equality."""
+    d, keys, _ = build(flavor)
+
+    assert d == d
+    assert d == flavor.cls(dict(zip(keys, range(3))))
+    assert d == {k: v for k, v in d.items()}
+    assert d != flavor.cls()
+    assert flavor.cls() == flavor.cls()
+
+    twins = {flavor.key(i): i for i in range(3)}
+    assert list(twins) == keys  # equal keys...
+    assert d != twins  # ...but not the same objects
+
+    assert d.__eq__(5) is NotImplemented
+    assert (d == 5) is False
+    assert (d != 5) is True
+
+
+@flavors()
+def test_repr(flavor: Flavor) -> None:
+    """M14: ports ``test_make_weak_keyed_dict_repr``; names the actual subclass."""
+    assert re.fullmatch(rf"<{flavor.cls.__name__} at 0x[0-9a-f]+>", repr(flavor.cls()))
+
+
+@flavors()
+def test_keyrefs(flavor: Flavor) -> None:
+    """M16."""
+    d, keys, _ = build(flavor)
+    refs = d.keyrefs()
+    assert sorted(id(r()) for r in refs) == sorted(id(k) for k in keys)
+    assert all(hash(r) == id(r()) for r in refs)
+
+
+@flavors()
+def test_views_are_generators(flavor: Flavor) -> None:
+    """M17."""
+    d, keys, _ = build(flavor)
+    for view in (d.keys(), d.values(), d.items(), iter(d)):
+        assert hasattr(view, "__iter__") and hasattr(view, "__next__")
+        with pytest.raises(TypeError):
+            len(view)  # type: ignore[arg-type]
+    assert sorted(id(k) for k in iter(d)) == sorted(id(k) for k in d.keys())
+
+
+@classes
+def test_hostile_keys_are_supported(cls: type[AnyDict]) -> None:
+    """M18: the fork's premise -- keys whose ``__eq__``/``__hash__`` are unusable."""
+    d = cls()
+    a, b = Hostile(), Hostile()
+    d[a] = "a"
+    d[b] = "b"
+
+    assert len(d) == 2
+    assert d[a] == "a" and d[b] == "b"
+    assert a in d and b in d
+    assert sorted(id(k) for k in d.keys()) == sorted([id(a), id(b)])
+    del d[a]
+    assert a not in d and b in d
+
+    with pytest.raises(TypeError):
+        {a: 1}  # a stock dict cannot even build this
+
+
+###############################################################################
+# Weak keys: eviction, iteration guards, deferred removals
+###############################################################################
+
+
+def make_dict(flavor: Flavor, n: int = 10) -> tuple[AnyDict, list]:
+    """cpython's ``make_weak_keyed_dict``, minus the lingering loop variable."""
+    d = flavor.cls()
+    objs = flavor.keys(n)
+    for i, k in enumerate(objs):
+        d[k] = i
+    del k
+    return d, objs
+
+
+def test_weak_bad_key_types() -> None:
+    """K1: ports ``test_weak_keyed_bad_delitem``."""
+    d: typing.Any = WeakIdKeyDictionary()
+    o = Obj(1)
+
+    with pytest.raises(KeyError):
+        del d[o]
+    with pytest.raises(KeyError):
+        d[o]
+
+    for op in (
+        lambda: d.__delitem__(13),
+        lambda: d.__getitem__(13),
+        lambda: d.__setitem__(13, 13),
+        lambda: d.get(13),
+        lambda: d.pop(13),
+        lambda: d.setdefault(13, 13),
+    ):
+        with pytest.raises(TypeError):
+            op()
+
+    assert 13 not in d  # __contains__ answers rather than raising
+
+
+@flavors(WEAK_FLAVORS)
+def test_death_removes_the_entry(flavor: Flavor) -> None:
+    """K2, K3: the entry goes when the key does, and the dict never keeps it."""
+    d = flavor.cls()
+    keys = flavor.keys(3)
+    for i, k in enumerate(keys):
+        d[k] = i
+    del k
+
+    probe = weakref.ref(keys[1])
+    model = {id(keys[0]): 0, id(keys[2]): 2}
+    del keys[1]
+    gc_collect()
+
+    assert probe() is None
+    assert_model(d, model, present=keys)
+    assert len(d.keyrefs()) == 2
+
+
+@flavors(WEAK_FLAVORS)
+def test_dict_level_aba(flavor: Flavor) -> None:
+    """K4: a new object reusing a dead key's address is not in the dictionary."""
+    for _ in range(1000):
+        d = flavor.cls()
+        first = flavor.key(0)
+        recycled = id(first)
+        d[first] = "gone"
+        del first
+        gc_collect()
+        second = flavor.key(1)
+        if id(second) != recycled:
+            del second
+            continue
+        assert second not in d
+        assert len(d) == 0
+        with pytest.raises(KeyError):
+            d[second]
+        return
+    pytest.skip("no address reuse observed")
+
+
+@flavors(WEAK_FLAVORS)
+def test_removal_is_deferred_while_iterating(flavor: Flavor) -> None:
+    """K5: a death mid-iteration is deferred, but never visible in ``len``.
+
+    The entry stays in place until the iterator is dropped -- otherwise the walk
+    would mutate the dictionary underneath itself -- so the dead reference is
+    still among the ``keyrefs``. ``len`` discounts it regardless.
+    """
+    d, objs = make_dict(flavor)
+    it = iter(d.items())
+    next(it)
+
+    del objs[-1]
+    gc_collect()
+    assert len(d) == 9
+    assert len(d.keyrefs()) == 10
+    assert sum(r() is None for r in d.keyrefs()) == 1
+
+    del it
+    gc_collect()
+    assert len(d) == 9
+    assert len(d.keyrefs()) == 9
+    assert all(r() is not None for r in d.keyrefs())
+
+
+@flavors(WEAK_FLAVORS)
+@pytest.mark.parametrize("iter_name", ["keys", "items", "values", "keyrefs"])
+def test_destroy_while_iterating(flavor: Flavor, iter_name: str) -> None:
+    """K6: ports cpython's ``check_weak_destroy_while_iterating``."""
+    d, objs = make_dict(flavor)
+    n = len(d)
+    it = iter(getattr(d, iter_name)())
+    next(it)
+    del objs[-1]
+    gc_collect()
+    assert len(list(it)) in (len(objs), len(objs) - 1)
+    del it
+    gc_collect()
+    assert len(d) == n - 1
+
+
+@contextlib.contextmanager
+def killing_one_key(d: AnyDict, objs: list) -> collections.abc.Iterator[typing.Any]:
+    """cpython's ``testcontext``: kill a key with an iterator held open."""
+    it: typing.Any = iter(d.items())
+    try:
+        next(it)
+        objs.pop()
+        gc_collect()
+        yield
+    finally:
+        it = None
+        del it
+        gc_collect()
+
+
+@flavors(WEAK_FLAVORS)
+def test_destroy_and_mutate_while_iterating(flavor: Flavor) -> None:
+    """K7: ports cpython's ``check_weak_destroy_and_mutate_while_iterating``."""
+    d, objs = make_dict(flavor)
+    k, v = flavor.key(99), "v"
+
+    with killing_one_key(d, objs):
+        assert k not in d
+    with killing_one_key(d, objs):
+        with pytest.raises(KeyError):
+            del d[k]
+    assert k not in d
+    with killing_one_key(d, objs):
+        with pytest.raises(KeyError):
+            d.pop(k)
+    assert k not in d
+    with killing_one_key(d, objs):
+        d[k] = v
+    assert d[k] == v
+
+    ddict = copy.copy(d)
+    with killing_one_key(d, objs):
+        d.update(ddict)
+    assert d == ddict
+    with killing_one_key(d, objs):
+        d.clear()
+    assert len(d) == 0
+
+
+@flavors(WEAK_FLAVORS)
+def test_del_and_len_while_iterating(flavor: Flavor) -> None:
+    """K8: ports cpython's ``check_weak_del_and_len_while_iterating``.
+
+    This is the extensional exercise of the pending-removal bookkeeping that
+    cpython issue #21173 added ``_scrub_removals`` for.
+    """
+    d, objs = make_dict(flavor)
+    extra = flavor.key(123456)
+
+    with killing_one_key(d, objs):
+        n = len(d)
+        d.pop(next(d.keys()))
+        assert len(d) == n - 1
+        d[extra] = extra
+        assert len(d) == n
+    with killing_one_key(d, objs):
+        assert len(d) == n - 1
+        d.popitem()
+        assert len(d) == n - 2
+    with killing_one_key(d, objs):
+        assert len(d) == n - 3
+        del d[next(d.keys())]
+        assert len(d) == n - 4
+    with killing_one_key(d, objs):
+        assert len(d) == n - 5
+        d.popitem()
+        assert len(d) == n - 6
+    with killing_one_key(d, objs):
+        d.clear()
+        assert len(d) == 0
+    assert len(d) == 0
+
+
+@flavors(WEAK_FLAVORS)
+def test_explicit_delete_then_death_while_iterating(flavor: Flavor) -> None:
+    """K9: a key deleted by hand and *then* collected is not counted twice."""
+    d, objs = make_dict(flavor)
+    it = iter(d.items())
+    next(it)
+
+    doomed = objs.pop()
+    del d[doomed]
+    del doomed
+    gc_collect()
+    assert len(d) == 9
+
+    del it
+    gc_collect()
+    assert len(d) == 9
+
+
+@flavors(WEAK_FLAVORS)
+def test_copy_skips_dead_keys(flavor: Flavor) -> None:
+    """K10."""
+    d, objs = make_dict(flavor, n=4)
+    del objs[1:3]
+    gc_collect()
+
+    for c in (d.copy(), copy.deepcopy(d)):
+        assert len(c) == 2
+        assert sorted(id(k) for k in c.keys()) == sorted(id(k) for k in objs)
+
+
+@flavors(WEAK_FLAVORS)
+def test_len_with_cycles(flavor: Flavor) -> None:
+    """K11: ports cpython's ``check_len_cycles``."""
+    n = 20
+    items = [RefCycle() for _ in range(n)]
+    d = flavor.cls({o: 1 for o in items})
+    it = d.items()
+    with contextlib.suppress(StopIteration):
+        next(it)
+    del items
+    gc.collect()
+    n1 = len(d)
+    del it
+    gc.collect()
+    n2 = len(d)
+    assert n1 in (0, 1)
+    assert n2 == 0
+
+
+@flavors(WEAK_FLAVORS)
+def test_len_race_against_the_collector(flavor: Flavor) -> None:
+    """K11: ports cpython's ``check_len_race``."""
+    thresholds = gc.get_threshold()
+    try:
+        for th in range(1, 100, 7):
+            n = 20
+            gc.collect(0)
+            gc.set_threshold(th, th, th)
+            items = [RefCycle() for _ in range(n)]
+            d = flavor.cls({o: 1 for o in items})
+            del items
+            it = d.items()
+            with contextlib.suppress(StopIteration):
+                next(it)
+            n1 = len(d)
+            del it
+            n2 = len(d)
+            assert 0 <= n1 <= n
+            assert 0 <= n2 <= n1
+    finally:
+        gc.set_threshold(*thresholds)
+
+
+@flavors(WEAK_FLAVORS)
+def test_clear_with_only_dead_keys(flavor: Flavor) -> None:
+    """M9, K10: ``clear`` drives ``popitem``, which must survive dead refs."""
+    d, objs = make_dict(flavor, n=3)
+    del objs[:]
+    gc_collect()
+    d.clear()
+    assert_model(d, {})
+
+
+###############################################################################
+# Strong keys: IdKeyDictionary
+###############################################################################
+
+
+def test_id_key_dictionary_keeps_keys_alive() -> None:
+    """S1, S3."""
+    d: IdKeyDictionary = IdKeyDictionary()
+    k = Obj(1)
+    probe = weakref.ref(k)
+    d[k] = "v"
+    key_id = id(k)
+    del k
+    gc_collect()
+
+    assert probe() is not None
+    assert len(d) == 1
+    assert [id(x) for x in d.keys()] == [key_id]
+    assert d[probe()] == "v"
+
+
+@pytest.mark.parametrize(
+    "key", [v for _, v in NON_WEAKREFABLE], ids=[n for n, _ in NON_WEAKREFABLE]
+)
+def test_id_key_dictionary_accepts_non_weakrefable_keys(key: typing.Any) -> None:
+    """S2: including unhashable ones such as list and dict."""
+    d: IdKeyDictionary = IdKeyDictionary()
+    d[key] = "v"
+    assert d[key] == "v"
+    assert key in d
+    assert len(d) == 1
+    del d[key]
+    assert key not in d
+
+
+def test_id_key_dictionary_is_stable_across_collection() -> None:
+    """S3, S4: nothing ever disappears on its own."""
+    d, objs = make_dict(Flavor(IdKeyDictionary, Obj, weak=False, label="strong/obj"))
+    del objs[:]
+    for _ in range(3):
+        gc_collect()
+        assert len(d) == 10
+    assert len(list(d.items())) == 10
+
+
+def test_id_key_dictionary_accepts_string_kwargs() -> None:
+    """S2: ``update(**kwargs)``, which the weak dictionary cannot take."""
+    d: IdKeyDictionary = IdKeyDictionary()
+    d.update(a=1, b=2)
+    assert sorted((k, v) for k, v in d.items()) == [("a", 1), ("b", 2)]
+
+
+###############################################################################
+# AutoIdKeyDictionary
+###############################################################################
+
+
+def test_auto_mixes_weak_and_strong_keys() -> None:
+    """A1, A2: one dictionary, two reference strengths, chosen per key."""
+    d: AutoIdKeyDictionary = AutoIdKeyDictionary()
+    weak_key, strong_key = Obj(1), (1, 2)
+    d[weak_key] = "weak"
+    d[strong_key] = "strong"
+
+    assert len(d) == 2
+    assert d[weak_key] == "weak" and d[strong_key] == "strong"
+
+    probe = weakref.ref(weak_key)
+    del weak_key
+    gc_collect()
+
+    assert probe() is None
+    assert len(d) == 1
+    assert d[strong_key] == "strong"  # the non-weakrefable entry is not evictable
+
+
+def test_auto_accepts_string_kwargs() -> None:
+    """A3."""
+    d: AutoIdKeyDictionary = AutoIdKeyDictionary()
+    d.update(a=1, b=2)
+    assert sorted((k, v) for k, v in d.items()) == [("a", 1), ("b", 2)]
+
+    weak: typing.Any = WeakIdKeyDictionary()
+    with pytest.raises(TypeError):
+        weak.update(a=1)
+
+
+###############################################################################
+# Differential equivalence with weakref.WeakKeyDictionary
+###############################################################################
+
+
+def snapshot(d: typing.Any) -> tuple:
+    """Every observable that both implementations must agree on.
+
+    Excludes ``repr``, ``type(d.copy())`` and the class of ``keyrefs()`` elements,
+    which legitimately differ; those are pinned by M10/M14/M16 instead.
+    """
+    return (
+        len(d),
+        sorted((id(k), v) for k, v in d.items()),
+        sorted(id(k) for k in d.keys()),
+        sorted(id(k) for k in d),
+        sorted(d.values()),
+        sorted((id(k), v) for k, v in dict(d).items()),
+        bool(d),
+        sorted(id(r()) for r in d.keyrefs() if r() is not None),
+    )
+
+
+def attempt(fn: collections.abc.Callable[[], typing.Any]) -> typing.Any:
+    """Run ``fn``, returning its result or the name of the exception it raised."""
+    try:
+        return ("ok", fn())
+    except Exception as e:
+        return ("raised", type(e).__name__)
+
+
+OPS = [
+    "set",
+    "del",
+    "pop",
+    "popitem",
+    "setdefault",
+    "update",
+    "clear",
+    "copy",
+    "deepcopy",
+    "get",
+    "contains",
+    "eq",
+    "kill",
+    "new",
+]
+
+
+@pytest.mark.parametrize("seed", range(6))
+@classes
+def test_agrees_with_weak_key_dictionary(cls: type[AnyDict], seed: int) -> None:
+    """D1, D2, D3: identical observable behaviour on identity-semantics keys.
+
+    ``IdKeyDictionary`` agrees too, for a reason worth spelling out: it holds its
+    keys strongly, which keeps the *reference* implementation's entries alive as
+    well, so both dictionaries observe the same (empty) set of key deaths.
+
+    Iterators are never left open on one side only -- that would defer removals
+    asymmetrically. Those cases are covered directly by the K tests.
+    """
+    rng = random.Random(seed)
+    ref: typing.Any = weakref.WeakKeyDictionary()
+    test: typing.Any = cls()
+    live = [Plain(i) for i in range(8)]
+
+    for step in range(200):
+        op = rng.choice(OPS)
+        k: typing.Any = rng.choice(live)
+        v = rng.randrange(1000)
+        detail = f"class={cls.__name__} seed={seed} step={step} op={op}"
+
+        if op == "set":
+            ref[k] = v
+            test[k] = v
+        elif op == "del":
+            assert attempt(lambda: ref.__delitem__(k)) == attempt(
+                lambda: test.__delitem__(k)
+            ), detail
+        elif op == "pop":
+            assert attempt(lambda: ref.pop(k, "miss")) == attempt(
+                lambda: test.pop(k, "miss")
+            ), detail
+        elif op == "popitem":
+            expected = attempt(lambda: ref.popitem())
+            actual = attempt(lambda: test.popitem())
+            if expected[0] == "ok":
+                expected = ("ok", (id(expected[1][0]), expected[1][1]))
+                actual = ("ok", (id(actual[1][0]), actual[1][1]))
+            assert expected == actual, detail
+        elif op == "setdefault":
+            assert ref.setdefault(k, v) == test.setdefault(k, v), detail
+        elif op == "update":
+            source = {rng.choice(live): rng.randrange(1000) for _ in range(3)}
+            ref.update(source)
+            test.update(source)
+        elif op == "clear":
+            ref.clear()
+            test.clear()
+        elif op == "copy":
+            assert snapshot(ref.copy()) == snapshot(test.copy()), detail
+        elif op == "deepcopy":
+            assert snapshot(copy.deepcopy(ref)) == snapshot(copy.deepcopy(test)), detail
+        elif op == "get":
+            assert ref.get(k) == test.get(k), detail
+            assert ref.get(k, "default") == test.get(k, "default"), detail
+        elif op == "contains":
+            assert (k in ref) == (k in test), detail
+        elif op == "eq":
+            assert (ref == dict(ref.items())) == (test == dict(test.items())), detail
+        elif op == "kill" and len(live) > 1:
+            del live[rng.randrange(len(live))]
+            gc.collect()  # Plain has no cycles, so one pass is enough
+        elif op == "new":
+            live.append(Plain(rng.randrange(1000)))
+
+        # Drop the local reference so that a later "kill" can really collect it.
+        k = None
+        assert snapshot(ref) == snapshot(test), detail
+
+
+def test_diverges_from_weak_key_dictionary_on_equality_keys() -> None:
+    """D4: the witness that identity keying is not equality keying."""
+    k1, k2 = Obj(1), Obj(1)
+
+    ref: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+    test: WeakIdKeyDictionary = WeakIdKeyDictionary()
+    for d in (ref, test):
+        d[k1] = "first"
+        d[k2] = "second"
+
+    assert len(ref) == 1 and ref[k1] == "second"
+    assert len(test) == 2 and test[k1] == "first" and test[k2] == "second"
+
+
+def test_diverges_from_weak_key_dictionary_on_hostile_keys() -> None:
+    """D5: keys the standard library cannot hold at all."""
+    k = Hostile()
+
+    ref: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+    with pytest.raises(TypeError):
+        ref[k] = "v"
+
+    test: WeakIdKeyDictionary = WeakIdKeyDictionary()
+    test[k] = "v"
+    assert test[k] == "v"
+
+
+###############################################################################
+# weak_memoize
+###############################################################################
+
+
+def counted(fn: collections.abc.Callable) -> typing.Any:
+    """``fn`` plus a record of the arguments it was actually called with.
+
+    Records ``id(arg)`` rather than ``arg``: keeping the argument would defeat
+    every test of when a cache entry is collected.
+    """
+    calls: list[int] = []
+
+    @functools.wraps(fn)
+    def wrapper(arg: typing.Any) -> typing.Any:
+        calls.append(id(arg))
+        return fn(arg)
+
+    wrapper.calls = calls  # type: ignore[attr-defined]
+    return wrapper
+
+
+PURE_FUNCTIONS = [
+    ("identity", lambda x: x),
+    ("arg", lambda x: x.arg),
+    ("none", lambda x: None),
+    ("falsy", lambda x: 0),
+    ("tuple", lambda x: (x.arg, x.arg)),
+]
+
+
+@pytest.mark.parametrize(
+    "fn", [f for _, f in PURE_FUNCTIONS], ids=[n for n, _ in PURE_FUNCTIONS]
+)
+def test_memoize_agrees_with_the_bare_function(fn: typing.Any) -> None:
+    """F1, F4: same answers, including for None and other falsy results."""
+    memoized = weak_memoize(fn)
+    keys = [Obj(i) for i in range(3)]
+    for k in keys:
+        assert memoized(k) == fn(k)
+        assert memoized(k) == fn(k)
+
+
+def test_memoize_calls_once_per_argument() -> None:
+    """F2, F4."""
+    fn = counted(lambda x: None)
+    memoized = weak_memoize(fn)
+    a, b = Obj(1), Obj(2)
+
+    for _ in range(3):
+        assert memoized(a) is None
+        assert memoized(b) is None
+
+    assert fn.calls == [id(a), id(b)]
+
+
+def test_memoize_keys_on_identity_not_equality() -> None:
+    """F3."""
+    fn = counted(lambda x: x.arg)
+    memoized = weak_memoize(fn)
+    a, b = Obj(1), Obj(1)
+    assert a == b
+
+    memoized(a)
+    memoized(b)
+    assert fn.calls == [id(a), id(b)]
+
+
+def test_memoize_does_not_cache_exceptions() -> None:
+    """F5."""
+    calls: list = []
+
+    @weak_memoize
+    def boom(x: typing.Any) -> typing.Any:
+        calls.append(x)
+        raise ValueError("nope")
+
+    k = Obj(1)
+    for _ in range(2):
+        with pytest.raises(ValueError):
+            boom(k)
+    assert len(calls) == 2
+
+
+def test_memoize_decorator_forms_agree() -> None:
+    """F6."""
+    cache: AutoIdKeyDictionary = AutoIdKeyDictionary()
+    bare = weak_memoize(counted(lambda x: x.arg))
+    with_kwarg = weak_memoize(cache=cache)(counted(lambda x: x.arg))
+    positional = weak_memoize(counted(lambda x: x.arg), cache=AutoIdKeyDictionary())
+
+    k = Obj(7)
+    assert bare(k) == with_kwarg(k) == positional(k) == 7
+    assert bare(k) == with_kwarg(k) == positional(k) == 7
+    for memoized in (bare, with_kwarg, positional):
+        assert len(memoized.__wrapped__.calls) == 1  # type: ignore[attr-defined]
+
+
+def test_memoize_uses_the_supplied_cache() -> None:
+    """F7."""
+    cache: AutoIdKeyDictionary = AutoIdKeyDictionary()
+    fn = counted(lambda x: x.arg)
+    memoized = weak_memoize(fn, cache=cache)
+
+    k = Obj(3)
+    assert memoized(k) == 3
+    assert k in cache and cache[k] == 3
+
+    seeded = Obj(4)
+    cache[seeded] = "pre-seeded"
+    assert memoized(seeded) == "pre-seeded"
+    assert fn.calls == [id(k)]
+
+
+CACHE_FACTORIES = [
+    ("WeakKeyDictionary", weakref.WeakKeyDictionary),
+    ("WeakIdKeyDictionary", WeakIdKeyDictionary),
+    ("IdKeyDictionary", IdKeyDictionary),
+    ("AutoIdKeyDictionary", AutoIdKeyDictionary),
+]
+
+
+@pytest.mark.parametrize(
+    "factory", [f for _, f in CACHE_FACTORIES], ids=[n for n, _ in CACHE_FACTORIES]
+)
+def test_memoize_works_with_every_cache_type(factory: typing.Any) -> None:
+    """F8."""
+    fn = counted(lambda x: x.arg)
+    memoized = weak_memoize(fn, cache=factory())
+    keys = [Obj(i) for i in range(3)]
+
+    for _ in range(2):
+        for k in keys:
+            assert memoized(k) == k.arg
+    assert len(fn.calls) == 3
+
+
+def test_memoize_and_non_weakrefable_arguments() -> None:
+    """F9: the default cache takes them; an explicit weak cache does not."""
+    fn = counted(lambda x: str(x))
+    memoized = weak_memoize(fn)
+    key = (1, 2)
+    assert memoized(key) == memoized(key) == "(1, 2)"
+    assert len(fn.calls) == 1
+
+    weak_only: typing.Any = weak_memoize(lambda x: x, cache=weakref.WeakKeyDictionary())
+    with pytest.raises(TypeError):
+        weak_only((1, 2))
+
+
+def test_memoize_is_scoped_to_the_arguments_lifetime() -> None:
+    """F10."""
+    cache: AutoIdKeyDictionary = AutoIdKeyDictionary()
+    fn = counted(lambda x: x.arg)
+    memoized = weak_memoize(fn, cache=cache)
+
+    k = Obj(1)
+    memoized(k)
+    assert len(cache) == 1
+
+    del k
+    gc_collect()
+    assert len(cache) == 0
+    assert len(fn.calls) == 1
+
+
+def test_memoize_entry_survives_when_the_result_holds_the_argument() -> None:
+    """F11: the documented hazard of caching values that reference their key.
+
+    The entry can never be collected, because the value keeps the key alive. This
+    is inherent to a weak-keyed cache; the test exists so that anyone changing the
+    caching strategy sees it.
+    """
+    cache: AutoIdKeyDictionary = AutoIdKeyDictionary()
+
+    @weak_memoize(cache=cache)
+    def wrap(fn: typing.Any) -> typing.Any:
+        @functools.wraps(fn)  # sets __wrapped__ = fn, a strong reference back
+        def inner() -> typing.Any:
+            return fn()
+
+        return inner
+
+    def target() -> int:
+        return 1
+
+    probe = weakref.ref(target)
+    wrap(target)
+    del target
+    gc_collect()
+
+    assert probe() is not None
+    assert len(cache) == 1
+
+
+def test_memoize_preserves_wrapper_metadata() -> None:
+    """F12."""
+
+    def original(x: typing.Any) -> typing.Any:
+        """A docstring."""
+        return x
+
+    memoized = weak_memoize(original)
+    assert memoized.__name__ == "original"
+    assert memoized.__doc__ == "A docstring."
+    assert memoized.__wrapped__ is original  # type: ignore[attr-defined]
+
+
+def test_memoize_agrees_with_functools_cache() -> None:
+    """F13: on identity-semantics arguments held alive, the two are the same cache."""
+    reference = counted(lambda x: x.arg * 2)
+    test = counted(lambda x: x.arg * 2)
+    cached = functools.cache(reference)
+    memoized = weak_memoize(test)
+
+    rng = random.Random(0)
+    live = [Plain(i) for i in range(5)]
+    for _ in range(100):
+        k = rng.choice(live)
+        assert cached(k) == memoized(k)
+    assert reference.calls == test.calls
+
+
+###############################################################################
+# Concurrency
+###############################################################################
+
+
+@pytest.mark.timeout(30)
+@classes
+@pytest.mark.parametrize("deep", [False, True], ids=["copy", "deepcopy"])
+def test_threaded_copy_under_collection(cls: type[AnyDict], deep: bool) -> None:
+    """Ports pytorch's ``check_threaded_weak_dict_copy``, scaled down.
+
+    Copying while another thread drops keys must not raise, however the removal
+    callbacks interleave.
+    """
+    count = 2000
+    exc: list[BaseException] = []
+
+    class DummyKey:
+        def __init__(self, ctr: int) -> None:
+            self.ctr = ctr
+
+    def dict_copy(d: AnyDict) -> None:
+        try:
+            copy.deepcopy(d) if deep else d.copy()
+        except BaseException as e:  # noqa: BLE001
+            exc.append(e)
+
+    def pop_and_collect(lst: list) -> None:
+        collected = 0
+        while lst:
+            lst.pop(random.Random(len(lst)).randrange(len(lst)))
+            collected += 1
+            if collected % 250 == 0:
+                gc.collect()
+
+    d = cls()
+    keys = []
+    for i in range(count):
+        k = DummyKey(i)
+        keys.append(k)
+        d[k] = i
+        del k
+
+    copier = threading.Thread(target=dict_copy, args=(d,))
+    collector = threading.Thread(target=pop_and_collect, args=(keys,))
+    copier.start()
+    collector.start()
+    copier.join()
+    collector.join()
+
+    if exc:
+        raise exc[0]

--- a/tests/test_internals_weak.py
+++ b/tests/test_internals_weak.py
@@ -41,7 +41,6 @@ from effectful.internals.weak import (
     StrongIdRef,
     WeakIdKeyDictionary,
     WeakIdRef,
-    is_weakrefable,
     weak_memoize,
 )
 
@@ -52,6 +51,19 @@ def gc_collect() -> None:
     """Force collection, twice, so cycles found in the first pass are freed."""
     gc.collect()
     gc.collect()
+
+
+def weakrefable_ground_truth(value: typing.Any) -> bool:
+    """Whether ``value`` can be weakly referenced, decided the expensive way.
+
+    The reference for what ``AutoIdRef`` must agree with. Computed rather than
+    tabulated, so the test cases cannot drift away from the truth.
+    """
+    try:
+        weakref.ref(value)
+    except TypeError:
+        return False
+    return True
 
 
 class Obj:
@@ -259,13 +271,17 @@ def test_weak_ref_death() -> None:
 
 
 def test_weak_ref_aba() -> None:
-    """R8: a dead ref is not equal to a fresh ref that reused its address."""
-    for _ in range(1000):
+    """R8: a dead ref is not equal to a fresh ref that reused its address.
+
+    Deliberately no collection between the two allocations: ``Plain`` has no
+    cycles, so refcounting frees it at the ``del``, and a ``gc.collect()`` in
+    between only disturbs the free list that makes the address reuse happen.
+    """
+    for _ in range(100):
         first = Plain(1)
         recycled = id(first)
         dead_ref = WeakIdRef(first)
         del first
-        gc_collect()
         second = Plain(2)
         if id(second) != recycled:
             del second
@@ -326,36 +342,12 @@ NON_WEAKREFABLE = [
     "key", [v for _, v in NON_WEAKREFABLE], ids=[n for n, _ in NON_WEAKREFABLE]
 )
 def test_id_ref_accepts_non_weakrefable_keys(key: typing.Any) -> None:
-    """R10: IdRef takes keys weakref cannot."""
-    assert not is_weakrefable(key)
+    """R10: StrongIdRef takes keys weakref cannot."""
+    assert not weakrefable_ground_truth(key)
     r = StrongIdRef(key)
     assert r() is key
     assert hash(r) == id(key)
     assert r == StrongIdRef(key)
-
-
-AUTO_CASES = [
-    ("obj", Obj(1)),
-    ("set", set()),
-    ("class", Obj),
-    ("int", 1),
-    ("str", "s"),
-    ("tuple", (1,)),
-    ("list", [1]),
-    ("object", object()),
-]
-
-
-@pytest.mark.parametrize(
-    "key", [v for _, v in AUTO_CASES], ids=[n for n, _ in AUTO_CASES]
-)
-def test_auto_id_ref_picks_by_weakrefability(key: typing.Any) -> None:
-    """R11: AutoIdRef is a WeakIdRef exactly when the key supports it."""
-    r = AutoIdRef(key)
-    assert isinstance(r, WeakIdRef if is_weakrefable(key) else StrongIdRef)
-    assert not isinstance(r, AutoIdRef)
-    assert r() is key
-    assert hash(r) == id(key)
 
 
 def test_weak_id_ref_callback_fires() -> None:
@@ -395,16 +387,11 @@ def test_ref_compared_to_a_non_ref(ref_type: typing.Any, other: typing.Any) -> N
 
 
 ###############################################################################
-# is_weakrefable
+# Choosing a reference strength per key
+#
+# AutoIdRef._is_weakrefable is private, so it is tested through the only thing it
+# decides: which reference AutoIdRef builds.
 ###############################################################################
-
-
-def weakrefable_ground_truth(value: typing.Any) -> bool:
-    try:
-        weakref.ref(value)
-    except TypeError:
-        return False
-    return True
 
 
 WEAKREF_CASES = [
@@ -430,30 +417,40 @@ WEAKREF_CASES = [
 
 
 @pytest.mark.parametrize(
-    "value", [v for _, v in WEAKREF_CASES], ids=[n for n, _ in WEAKREF_CASES]
+    "key", [v for _, v in WEAKREF_CASES], ids=[n for n, _ in WEAKREF_CASES]
 )
-def test_is_weakrefable_matches_weakref_ref(value: typing.Any) -> None:
-    """W1, W2: agrees with ``weakref.ref``, and never raises."""
-    assert is_weakrefable(value) is weakrefable_ground_truth(value)
+def test_auto_id_ref_picks_by_weakrefability(key: typing.Any) -> None:
+    """R11, W1, W2: weak exactly when ``weakref.ref`` would have worked.
+
+    Covers every kind of key the check can be asked about, including the ones it
+    has to answer "no" for without raising.
+    """
+    r = AutoIdRef(key)
+    assert isinstance(r, WeakIdRef) is weakrefable_ground_truth(key)
+    assert isinstance(r, (WeakIdRef, StrongIdRef))
+    assert not isinstance(r, AutoIdRef)
+    assert r() is key
+    assert hash(r) == id(key)
 
 
-def test_is_weakrefable_cache_is_invisible() -> None:
-    """W3: repeated calls and sibling instances of a cold type all agree."""
+def test_auto_id_ref_type_cache_is_invisible() -> None:
+    """W3: repeated keys and sibling instances of a cold type all get the same answer.
 
-    class Fresh:  # a type the cache has certainly not seen
+    Fresh classes, so the per-type cache starts empty for them and both the miss
+    and the hit path are exercised.
+    """
+
+    class Fresh:
         pass
-
-    a, b = Fresh(), Fresh()
-    assert is_weakrefable(a) is True
-    assert is_weakrefable(b) is True
-    assert is_weakrefable(a) is True
 
     class FreshSlotted:
         __slots__ = ()
 
-    c, d = FreshSlotted(), FreshSlotted()
-    assert is_weakrefable(c) is False
-    assert is_weakrefable(d) is False
+    for _ in range(2):
+        assert isinstance(AutoIdRef(Fresh()), WeakIdRef)
+        assert isinstance(AutoIdRef(Fresh()), WeakIdRef)
+        assert isinstance(AutoIdRef(FreshSlotted()), StrongIdRef)
+        assert isinstance(AutoIdRef(FreshSlotted()), StrongIdRef)
 
 
 ###############################################################################
@@ -652,10 +649,11 @@ def test_union_operators(flavor: Flavor) -> None:
 def test_union_with_a_non_mapping(flavor: Flavor) -> None:
     """M12."""
     d, _, _ = build(flavor)
+    # The annotations now reject these statically too, which is the point.
     with pytest.raises(TypeError):
-        d | 5
+        d | 5  # type: ignore[operator]
     with pytest.raises(TypeError):
-        5 | d
+        5 | d  # type: ignore[operator]
 
 
 @flavors()
@@ -783,14 +781,18 @@ def test_death_removes_the_entry(flavor: Flavor) -> None:
 
 @flavors(WEAK_FLAVORS)
 def test_dict_level_aba(flavor: Flavor) -> None:
-    """K4: a new object reusing a dead key's address is not in the dictionary."""
-    for _ in range(1000):
+    """K4: a new object reusing a dead key's address is not in the dictionary.
+
+    As in ``test_weak_ref_aba``, no collection between the two allocations: the
+    key dies by refcount at the ``del``, and collecting in between makes the
+    address reuse this depends on far less likely.
+    """
+    for _ in range(100):
         d = flavor.cls()
         first = flavor.key(0)
         recycled = id(first)
         d[first] = "gone"
         del first
-        gc_collect()
         second = flavor.key(1)
         if id(second) != recycled:
             del second

--- a/tests/test_internals_weak.py
+++ b/tests/test_internals_weak.py
@@ -37,8 +37,8 @@ import pytest
 from effectful.internals.weak import (
     AutoIdKeyDictionary,
     AutoIdRef,
-    IdKeyDictionary,
-    IdRef,
+    StrongIdKeyDictionary,
+    StrongIdRef,
     WeakIdKeyDictionary,
     WeakIdRef,
     is_weakrefable,
@@ -135,14 +135,14 @@ class Flavor:
 
 FLAVORS = [
     Flavor(WeakIdKeyDictionary, Obj, weak=True, label="weak/obj"),
-    Flavor(IdKeyDictionary, Obj, weak=False, label="strong/obj"),
-    Flavor(IdKeyDictionary, big_int, weak=False, label="strong/int"),
+    Flavor(StrongIdKeyDictionary, Obj, weak=False, label="strong/obj"),
+    Flavor(StrongIdKeyDictionary, big_int, weak=False, label="strong/int"),
     Flavor(AutoIdKeyDictionary, Obj, weak=True, label="auto/obj"),
     Flavor(AutoIdKeyDictionary, tup, weak=False, label="auto/tuple"),
 ]
 WEAK_FLAVORS = [f for f in FLAVORS if f.weak]
 
-DICT_CLASSES = [WeakIdKeyDictionary, IdKeyDictionary, AutoIdKeyDictionary]
+DICT_CLASSES = [WeakIdKeyDictionary, StrongIdKeyDictionary, AutoIdKeyDictionary]
 
 
 def flavors(cases: list[Flavor] = FLAVORS) -> typing.Any:
@@ -196,7 +196,7 @@ def assert_model(
 # Reference types: WeakIdRef, IdRef, AutoIdRef
 ###############################################################################
 
-REF_TYPES = [WeakIdRef, IdRef, AutoIdRef]
+REF_TYPES = [WeakIdRef, StrongIdRef, AutoIdRef]
 ref_types = pytest.mark.parametrize(
     "ref_type", REF_TYPES, ids=[t.__name__ for t in REF_TYPES]
 )
@@ -282,7 +282,7 @@ def test_weak_ref_aba() -> None:
 def test_ref_cross_type_symmetry() -> None:
     """R9: weak and strong refs to one object are interchangeable in one dict."""
     o = Obj(1)
-    w, s = WeakIdRef(o), IdRef(o)
+    w, s = WeakIdRef(o), StrongIdRef(o)
     assert w == s and s == w
     assert hash(w) == hash(s) == id(o)
 
@@ -290,7 +290,7 @@ def test_ref_cross_type_symmetry() -> None:
 def test_ref_cross_type_death() -> None:
     """R9: a dead weak ref is not equal to a strong ref, in either direction."""
     live = Obj(1)
-    strong = IdRef(live)
+    strong = StrongIdRef(live)
     dying = Obj(2)
     dead = WeakIdRef(dying)
     del dying
@@ -302,7 +302,7 @@ def test_ref_cross_type_death() -> None:
 def test_id_ref_is_strong() -> None:
     """R10: an IdRef keeps its referent alive."""
     o = Obj(1)
-    r = IdRef(o)
+    r = StrongIdRef(o)
     probe = weakref.ref(o)
     del o
     gc_collect()
@@ -328,10 +328,10 @@ NON_WEAKREFABLE = [
 def test_id_ref_accepts_non_weakrefable_keys(key: typing.Any) -> None:
     """R10: IdRef takes keys weakref cannot."""
     assert not is_weakrefable(key)
-    r = IdRef(key)
+    r = StrongIdRef(key)
     assert r() is key
     assert hash(r) == id(key)
-    assert r == IdRef(key)
+    assert r == StrongIdRef(key)
 
 
 AUTO_CASES = [
@@ -352,7 +352,7 @@ AUTO_CASES = [
 def test_auto_id_ref_picks_by_weakrefability(key: typing.Any) -> None:
     """R11: AutoIdRef is a WeakIdRef exactly when the key supports it."""
     r = AutoIdRef(key)
-    assert isinstance(r, WeakIdRef if is_weakrefable(key) else IdRef)
+    assert isinstance(r, WeakIdRef if is_weakrefable(key) else StrongIdRef)
     assert not isinstance(r, AutoIdRef)
     assert r() is key
     assert hash(r) == id(key)
@@ -372,7 +372,7 @@ def test_id_ref_callback_never_fires() -> None:
     """R12: IdRef accepts the removal callback and ignores it."""
     fired: list = []
     o = Obj(1)
-    r = IdRef(o, fired.append)
+    r = StrongIdRef(o, fired.append)
     del o
     gc_collect()
     assert fired == []
@@ -1012,7 +1012,7 @@ def test_clear_with_only_dead_keys(flavor: Flavor) -> None:
 
 def test_id_key_dictionary_keeps_keys_alive() -> None:
     """S1, S3."""
-    d: IdKeyDictionary = IdKeyDictionary()
+    d: StrongIdKeyDictionary = StrongIdKeyDictionary()
     k = Obj(1)
     probe = weakref.ref(k)
     d[k] = "v"
@@ -1031,7 +1031,7 @@ def test_id_key_dictionary_keeps_keys_alive() -> None:
 )
 def test_id_key_dictionary_accepts_non_weakrefable_keys(key: typing.Any) -> None:
     """S2: including unhashable ones such as list and dict."""
-    d: IdKeyDictionary = IdKeyDictionary()
+    d: StrongIdKeyDictionary = StrongIdKeyDictionary()
     d[key] = "v"
     assert d[key] == "v"
     assert key in d
@@ -1042,7 +1042,9 @@ def test_id_key_dictionary_accepts_non_weakrefable_keys(key: typing.Any) -> None
 
 def test_id_key_dictionary_is_stable_across_collection() -> None:
     """S3, S4: nothing ever disappears on its own."""
-    d, objs = make_dict(Flavor(IdKeyDictionary, Obj, weak=False, label="strong/obj"))
+    d, objs = make_dict(
+        Flavor(StrongIdKeyDictionary, Obj, weak=False, label="strong/obj")
+    )
     del objs[:]
     for _ in range(3):
         gc_collect()
@@ -1052,7 +1054,7 @@ def test_id_key_dictionary_is_stable_across_collection() -> None:
 
 def test_id_key_dictionary_accepts_string_kwargs() -> None:
     """S2: ``update(**kwargs)``, which the weak dictionary cannot take."""
-    d: IdKeyDictionary = IdKeyDictionary()
+    d: StrongIdKeyDictionary = StrongIdKeyDictionary()
     d.update(a=1, b=2)
     assert sorted((k, v) for k, v in d.items()) == [("a", 1), ("b", 2)]
 
@@ -1357,7 +1359,7 @@ def test_memoize_uses_the_supplied_cache() -> None:
 CACHE_FACTORIES = [
     ("WeakKeyDictionary", weakref.WeakKeyDictionary),
     ("WeakIdKeyDictionary", WeakIdKeyDictionary),
-    ("IdKeyDictionary", IdKeyDictionary),
+    ("IdKeyDictionary", StrongIdKeyDictionary),
     ("AutoIdKeyDictionary", AutoIdKeyDictionary),
 ]
 

--- a/tests/test_ops_semantics.py
+++ b/tests/test_ops_semantics.py
@@ -1,6 +1,5 @@
 import contextlib
 import dataclasses
-import functools
 import itertools
 import logging
 from collections.abc import Callable, Mapping
@@ -473,7 +472,7 @@ def test_evaluate():
 
 
 def test_memoized_interpretation():
-    from effectful.internals.runtime import interpreter
+    from effectful.internals.runtime import cache, interpreter
 
     @defop
     def node(x: object) -> object:
@@ -494,34 +493,38 @@ def test_memoized_interpretation():
     intp = PureInterpretation(intp_impl)
     expected = ("node", (("node", (1,), {}),), {})
 
-    assert interpreter(intp)(evaluate)(term) == expected
-    assert intp_impl.calls == 2
+    # ``evaluate`` installs a cache for the duration of a call when none is
+    # active, so results are shared between separate calls only while a scope
+    # holds one open.
+    with cache():
+        assert interpreter(intp)(evaluate)(term) == expected
+        assert intp_impl.calls == 2
 
-    # The root cache is checked before its children are traversed, including
-    # when evaluation is expressed directly through a handler.
-    with interpreter(intp):
-        assert evaluate(term) == expected
-    assert intp_impl.calls == 2
+        # The root cache is checked before its children are traversed, including
+        # when evaluation is expressed directly through a handler.
+        with interpreter(intp):
+            assert evaluate(term) == expected
+        assert intp_impl.calls == 2
 
-    # Child results are cached independently and can be reused directly.
-    assert interpreter(intp)(evaluate)(term.args[0]) == expected[1][0]
-    assert intp_impl.calls == 2
+        # Child results are cached independently and can be reused directly.
+        assert interpreter(intp)(evaluate)(term.args[0]) == expected[1][0]
+        assert intp_impl.calls == 2
 
-    # A composition has a distinct identity even when its added handler is not
-    # used while evaluating this term.
-    combined_intp = coproduct(intp, {plus_1: lambda x: x})
-    assert interpreter(combined_intp)(evaluate)(term) == expected
-    assert intp_impl.calls == 4
+        # A composition has a distinct identity even when its added handler is not
+        # used while evaluating this term.
+        combined_intp = coproduct(intp, {plus_1: lambda x: x})
+        assert interpreter(combined_intp)(evaluate)(term) == expected
+        assert intp_impl.calls == 4
 
-    # A separate pure interpretation has its own cache namespace.
-    other_intp_impl = Intp()
-    other_intp = PureInterpretation(other_intp_impl)
-    assert interpreter(other_intp)(evaluate)(term) == expected
-    assert other_intp_impl.calls == 2
+        # A separate pure interpretation has its own cache namespace.
+        other_intp_impl = Intp()
+        other_intp = PureInterpretation(other_intp_impl)
+        assert interpreter(other_intp)(evaluate)(term) == expected
+        assert other_intp_impl.calls == 2
 
 
 def test_memoized_interpretation_does_not_cache_failures():
-    from effectful.internals.runtime import interpreter
+    from effectful.internals.runtime import cache, interpreter
 
     @defop
     def node() -> object:
@@ -542,13 +545,16 @@ def test_memoized_interpretation_does_not_cache_failures():
 
     intp_impl = Intp()
     intp = PureInterpretation(intp_impl)
-    with pytest.raises(ValueError, match="failed analysis"):
-        interpreter(intp)(evaluate)(term)
+    with cache():
+        with pytest.raises(ValueError, match="failed analysis"):
+            interpreter(intp)(evaluate)(term)
 
-    assert interpreter(intp)(evaluate)(term) == "success"
-    assert intp_impl.calls == 2
-    assert interpreter(intp)(evaluate)(term) == "success"
-    assert intp_impl.calls == 2
+        # The failure left nothing behind, so the retry recomputes; the result of
+        # that retry is what gets cached and reused.
+        assert interpreter(intp)(evaluate)(term) == "success"
+        assert intp_impl.calls == 2
+        assert interpreter(intp)(evaluate)(term) == "success"
+        assert intp_impl.calls == 2
 
 
 @pytest.mark.parametrize(
@@ -773,6 +779,8 @@ def test_defdata_large(benchmark):
     """Test defdata with large nested operations that form a binary tree of arbitrary size."""
     import random
 
+    from effectful.internals.runtime import cache
+
     @defop
     def f[T, A, B](
         v: Annotated[Operation[[], int], Scoped[A]],
@@ -807,7 +815,14 @@ def test_defdata_large(benchmark):
         return f(defop(int), left, right)
 
     # Test a very large tree (depth 8 = 255 leaf nodes)
-    benchmark(functools.partial(build_tree, 7))
+    def run():
+        # A scope per iteration rather than one around ``benchmark``: each round
+        # builds fresh objects, so a shared cache would only accumulate entries
+        # that can never be hit.
+        with cache():
+            return build_tree(7)
+
+    benchmark(run)
 
 
 def test_evaluate_deep():
@@ -899,8 +914,16 @@ def test_typeof_literal():
         typeof(get_mixed())
 
 
+@pytest.mark.timeout(20)
 def test_evaluate_dag_no_exponential_blowup():
-    """A DAG of nested tuples sharing the same Term is O(n), not O(2^n)."""
+    """A DAG of nested tuples sharing the same Term is O(n), not O(2^n).
+
+    Bounded by a timeout because the regression this guards against does not
+    fail, it hangs: losing memoization turns the depth-20 DAG below into 2**20
+    evaluations.
+    """
+    from effectful.internals.runtime import cache
+
     call_count = 0
 
     @defop
@@ -919,11 +942,15 @@ def test_evaluate_dag_no_exponential_blowup():
     for _ in range(depth):
         node = (node, node)
 
-    call_count = 0
-    with handler({counted: counted_handler}):
-        result = evaluate(node)
+    # One cache scope spanning both the evaluation and the term construction
+    # below. Without it each would install its own, so nothing computed by the
+    # first would be available to the second.
+    with cache():
+        call_count = 0
+        with handler({counted: counted_handler}):
+            result = evaluate(node)
 
-    deffn(node, counted)(0)
+        deffn(node, counted)(0)
 
     # The handler should only be called once (the shared Term)
     assert call_count == 1

--- a/tests/test_ops_syntax.py
+++ b/tests/test_ops_syntax.py
@@ -1418,6 +1418,7 @@ def test_defop_forward_ref_mutual_recursion():
 
 def test_bench_term_construction(benchmark):
     """Benchmark polymorphic type checking during term construction."""
+    from effectful.internals.runtime import cache
 
     @defop
     def _benchmark_identity[T](value: T) -> T:
@@ -1455,7 +1456,14 @@ def test_bench_term_construction(benchmark):
         assert isinstance(value, Term)
         return value
 
-    result = benchmark(_make_benchmark_term, 25)
+    def run():
+        # A scope per iteration rather than one around ``benchmark``: each round
+        # builds fresh objects, so a shared cache would only accumulate entries
+        # that can never be hit.
+        with cache():
+            return _make_benchmark_term(25)
+
+    result = benchmark(run)
     assert isinstance(result, Term)
 
 
@@ -1471,6 +1479,7 @@ def test_bench_nested_binder_construction(benchmark):
     reaches this path -- it is fast even when nested construction is
     exponential in depth.
     """
+    from effectful.internals.runtime import cache
 
     @defop
     def _benchmark_let[S, T, A](
@@ -1497,5 +1506,186 @@ def test_bench_nested_binder_construction(benchmark):
         assert isinstance(body, Term)
         return body
 
-    result = benchmark(_make_nested_term, 10)
+    def run():
+        with cache():
+            return _make_nested_term(10)
+
+    result = benchmark(run)
+    assert isinstance(result, Term)
+
+
+# ---------------------------------------------------------------------------
+# Operation calls whose arguments are large dataclasses.
+#
+# ``_build_term`` computes a node's dispatch type with ``typeof``, which is a
+# full recursive traversal of every argument, so an operation call costs O(size
+# of its arguments). These model a robotics workload -- a component tree built
+# up one part at a time -- where that traversal dominated the run time.
+
+
+@dataclasses.dataclass(frozen=True)
+class _Pose:
+    """Leaf payload, mirroring a rigid-body transform."""
+
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+
+@dataclasses.dataclass(frozen=True)
+class _Part:
+    """One child of an assembly, holding an unsolved pose."""
+
+    name: str
+    pose: _Pose
+
+
+@dataclasses.dataclass(frozen=True)
+class _Assembly:
+    """Container that accumulates children, like a robot component."""
+
+    parts: tuple[_Part, ...] = ()
+
+    def add(self, part: "_Part") -> "_Assembly":
+        return _Assembly(self.parts + (part,))
+
+
+@defop
+def _link(parent: _Assembly, child: _Part, delta: _Pose) -> None:
+    """Unhandled, so calling it builds a term via ``defdata`` -> ``_build_term``."""
+    raise NotHandled
+
+
+def _free_pose() -> _Pose:
+    """A free variable of type ``_Pose``, standing for a component's unsolved pose."""
+    return defop(_Pose)()
+
+
+def _make_assembly(k: int) -> _Assembly:
+    """An assembly of ``k`` parts, each with a distinct free pose."""
+    a = _Assembly()
+    for i in range(k):
+        a = a.add(_Part(f"p{i}", _free_pose()))
+    return a
+
+
+def test_typeof_dataclass_is_cached_within_a_scope(monkeypatch):
+    """Repeating ``typeof`` on the same dataclass does no work inside one scope.
+
+    Counted rather than timed: the property is that the second traversal is
+    free, which a call count states exactly where a wall-clock threshold would
+    only approximate it and would be flaky besides.
+
+    Before evaluation was memoized this was the central problem -- ``Term``
+    arguments were cached but plain dataclasses were re-walked on every call, so
+    an operation taking a large dataclass paid for the whole traversal every
+    time it was called.
+    """
+    from effectful.internals.runtime import cache
+    from effectful.ops import semantics
+
+    traversals = 0
+    original = semantics._evaluate_dataclass
+
+    def counting(expr, **kwargs):
+        nonlocal traversals
+        traversals += 1
+        return original(expr, **kwargs)
+
+    monkeypatch.setattr(semantics, "_evaluate_dataclass", counting)
+
+    assembly = _make_assembly(8)
+    with cache():
+        typeof(assembly)
+        after_first = traversals
+        typeof(assembly)
+        after_second = traversals
+
+    # The first call walks the container and every part inside it.
+    assert after_first > 8
+    # The second visits nothing.
+    assert after_second == after_first
+
+
+def test_bench_dataclass_argument_op_call(benchmark):
+    """Benchmark one operation call whose argument is a large dataclass.
+
+    Expected to stay O(k) in the number of children: the dispatch type of the
+    node genuinely depends on every one of them, so no cache can remove the
+    traversal of an argument being seen for the first time. Caching addresses
+    repeat visits, which is what the two tests below exercise.
+    """
+    from effectful.internals.runtime import cache
+
+    assembly = _make_assembly(160)
+    child, delta = _Part("t", _free_pose()), _Pose(1.0)
+
+    def run():
+        # A fresh scope per round, so this stays the cost of a *cold* call
+        # rather than a cache hit on the previous round.
+        with cache():
+            return _link(assembly, child, delta)
+
+    result = benchmark(run)
+    assert isinstance(result, Term)
+
+
+def test_bench_dataclass_growing_container(benchmark):
+    """Benchmark N operation calls against a container that grows by one per call.
+
+    This is the shape that motivated memoizing evaluation: a model assembled
+    component by component, where every call re-analyses the whole container.
+    Holding one :func:`cache` scope across the loop turns each element into a
+    cache hit rather than a fresh traversal, which is worth roughly 4x here.
+
+    It is a constant-factor win and not an asymptotic one, so this benchmark is
+    expected to remain quadratic in ``n``. Call ``i`` still visits all ``i``
+    elements: ``_Assembly.add`` allocates a new instance wrapping a new tuple
+    every call, and a new container has no cache entry of its own. Making this
+    linear needs the container's own analysis to be reusable -- structural
+    sharing so a new tuple shares a cached prefix, or a container-type rule that
+    does not inspect every element.
+
+    ``test_bench_dataclass_fixed_container`` is the control: same call count,
+    argument size held constant.
+    """
+    from effectful.internals.runtime import cache
+
+    n = 100
+
+    def run():
+        a, delta = _Assembly(), _Pose(1.0)
+        term = None
+        with cache():
+            for i in range(n):
+                child = _Part(f"c{i}", _free_pose())
+                term = _link(a, child, delta)
+                a = a.add(child)
+        return term
+
+    result = benchmark(run)
+    assert isinstance(result, Term)
+
+
+def test_bench_dataclass_fixed_container(benchmark):
+    """Control for :func:`test_bench_dataclass_growing_container`.
+
+    The same number of operation calls, but the container argument stays one
+    element wide, so this is linear in ``n``. The gap between the two is the
+    cost attributable to argument size rather than to call count.
+    """
+    from effectful.internals.runtime import cache
+
+    n = 100
+
+    def run():
+        hub = _Assembly((_Part("hub", _free_pose()),))
+        delta = _Pose(1.0)
+        term = None
+        with cache():
+            for i in range(n):
+                term = _link(hub, _Part(f"c{i}", _free_pose()), delta)
+        return term
+
+    result = benchmark(run)
     assert isinstance(result, Term)


### PR DESCRIPTION
Addresses #633 

This PR implements a new `weakref`-based caching system that unifies and generalizes those introduced in #726 and #594 

Specifically, it adds a new context manager `effectful.internals.runtime.cache` such that within a `cache()`-delimited block, repeated calls to `evaluate` with the same expression or data structure and active interpretation are cached.

This new mechanism is backed by a new standalone utility module `effectful.internals.weak`, based on a [similar utility module `torch.utils.weak` in PyTorch](https://github.com/pytorch/pytorch/blob/708f706e7ac19247a4d6f26e81c9c706ac14d50d/torch/utils/weak.py), which implements a couple of different cache data structures generalizing `weakref.WeakKeyDictionary`:
- `WeakIdKeyDictionary` behaves like `WeakKeyDictionary` (including forbidding keys which cannot be `weakref.ref`ed, like `tuple`s and `int`s) but uses object identity rather than object equality/hashing to discriminate between keys. (This is the main thing provided by `torch.utils.weak`)
- `IdKeyDictionary`, which stores strong references to keys that it discriminates between using identity
- `AutoIdKeyDictionary`, which extends `WeakIdKeyDictionary` and `IdKeyDictionary`'s identity-based semantics by attempting to use a weak reference for a new key and falling back to a strong reference when that is disallowed by the key type, and ensuring that weak reference and strong reference keys cannot conflict with one another.
- `weak_memoize`, a helper function that can use these data structures to memoize a single-argument function analogous to `functools.cache`

The PR also includes a number of small caching-related semantics-preserving performance fixes, and a benchmark derived from a RoboTL issue illustrating both asymptotic and constant-factor improvements on a representative workload.