### PR TITLE
Add `Group` and associated rules

### DIFF
--- a/effectful/handlers/jax/_handlers.py
+++ b/effectful/handlers/jax/_handlers.py
@@ -107,6 +107,7 @@ def _register_jax_op[**P, T](jax_fn: Callable[P, T]):
             _jax_op is jax_getitem
             and not isinstance(args[0], Term)
             and sized_fvs
+            and not isinstance(args[1], Term)
             and args[1]
             and all(
                 (isinstance(k, Term) and k.op in sized_fvs)
@@ -115,7 +116,7 @@ def _register_jax_op[**P, T](jax_fn: Callable[P, T]):
             )
         ):
             raise NotHandled
-        elif _jax_op is jax_getitem and not args[1]:
+        elif _jax_op is jax_getitem and not isinstance(args[1], Term) and not args[1]:
             return args[0]
         elif sized_fvs and set(sized_fvs.keys()) == fvsof(tm) - {jax_getitem, _jax_op}:
             # note: this cast is a lie. partial_eval can return non-arrays, as

--- a/effectful/handlers/jax/_terms.py
+++ b/effectful/handlers/jax/_terms.py
@@ -68,6 +68,7 @@ def _embed_array(ty, op, *args, **kwargs):
     if (
         op is jax_getitem
         and not isinstance(args[0], Term)
+        and not isinstance(args[1], Term)
         and all(not k.args and not k.kwargs for k in args[1] if isinstance(k, Term))
     ):
         return _EagerArrayTerm(jax_getitem, args[0], args[1])

--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -109,8 +109,6 @@ class SumPlusJax(ObjectInterpretation):
             return fwd()
         return functools.reduce(jnp.add, args)
 
-
-class SumInverseJax(ObjectInterpretation):
     @implements(Sum.inverse)
     def inverse(self, value):
         if not _jax_args((value,)):
@@ -803,7 +801,6 @@ def einsum(
 
 EvaluateIntp.extend(
     SumPlusJax(),
-    SumInverseJax(),
     ProductPlusJax(),
     MinPlusJax(),
     MaxPlusJax(),

--- a/effectful/handlers/jax/monoid.py
+++ b/effectful/handlers/jax/monoid.py
@@ -110,6 +110,14 @@ class SumPlusJax(ObjectInterpretation):
         return functools.reduce(jnp.add, args)
 
 
+class SumInverseJax(ObjectInterpretation):
+    @implements(Sum.inverse)
+    def inverse(self, value):
+        if not _jax_args((value,)):
+            return fwd()
+        return jnp.negative(value)
+
+
 class ProductPlusJax(ObjectInterpretation):
     @implements(Product.plus)
     def plus(self, *args):
@@ -795,6 +803,7 @@ def einsum(
 
 EvaluateIntp.extend(
     SumPlusJax(),
+    SumInverseJax(),
     ProductPlusJax(),
     MinPlusJax(),
     MaxPlusJax(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -170,6 +170,16 @@ class Monoid[W]:
         raise NotHandled
 
 
+class Group[T](Monoid[T]):
+    """A monoid in which every element has an inverse."""
+
+    @Operation.define
+    def inverse(self, value: T) -> T:
+        if value is self.identity:
+            return self.identity
+        raise NotHandled
+
+
 class MonoidWithZero[T](Monoid[T]):
     zero: T
 
@@ -182,7 +192,7 @@ Min = Monoid(name="Min", identity=float("inf"))
 Max = Monoid(name="Max", identity=-float("inf"))
 ArgMin = Monoid(name="ArgMin", identity=(Min.identity, None))
 ArgMax = Monoid(name="ArgMax", identity=(Max.identity, None))
-Sum = Monoid(name="Sum", identity=0)
+Sum = Group(name="Sum", identity=0)
 Product = MonoidWithZero(name="Product", identity=1, zero=0)
 LogSumExp = Monoid(name="LogSumExp", identity=float("-inf"))
 CartesianProduct: MonoidWithZero[Sequence[Mapping]] = MonoidWithZero(
@@ -329,6 +339,55 @@ class MaskFusion(ObjectInterpretation):
 
 
 is_equality = _ExtensiblePredicate({_NumberTerm.__eq__})
+
+
+def solve_group_equality(equality: Term[bool], index: int) -> Term[bool]:
+    """Isolate one argument of a group ``plus`` in an equality.
+
+    Given ``G.plus(a0, ..., an) == b``, isolate the argument at ``index``.
+    Negative indices follow normal Python indexing. The group expression may
+    occur on either side of the equality.
+    """
+    if not (
+        isinstance(equality, Term)
+        and is_equality(equality.op)
+        and len(equality.args) == 2
+        and not equality.kwargs
+    ):
+        raise TypeError("expected an equality Term")
+    if not isinstance(index, int):
+        raise TypeError("argument index must be an integer")
+
+    left, right = equality.args
+
+    def group_plus(value):
+        if not (isinstance(value, Term) and _is_monoid_plus(value.op)):
+            return None
+        monoid = value.op.__self__
+        return monoid if isinstance(monoid, Group) else None
+
+    monoid = group_plus(left)
+    if monoid is not None:
+        plus_term, other = left, right
+    elif (monoid := group_plus(right)) is not None:
+        plus_term, other = right, left
+    else:
+        raise TypeError("expected an equality containing a Group.plus Term")
+
+    assert isinstance(plus_term, Term)
+    try:
+        target = plus_term.args[index]
+    except IndexError:
+        raise IndexError("group argument index out of range") from None
+    if index < 0:
+        index += len(plus_term.args)
+
+    isolated = monoid.plus(
+        *(monoid.inverse(a) for a in reversed(plus_term.args[:index])),
+        other,
+        *(monoid.inverse(a) for a in reversed(plus_term.args[index + 1 :])),
+    )
+    return equality.op(target, isolated)
 
 
 class ReduceEqualityMaskRange(ObjectInterpretation):
@@ -482,6 +541,55 @@ class PlusAssoc(ObjectInterpretation):
             )
             assert len(args) > 0
             return monoid.plus(*flat_args)
+        return fwd()
+
+
+class InverseInverse(ObjectInterpretation):
+    """G.inverse(G.inverse(x)) = x"""
+
+    @implements(Group.inverse)
+    def inverse(self, monoid, value):
+        if isinstance(value, Term) and value.op is monoid.inverse:
+            return value.args[0]
+        return fwd()
+
+
+class InversePlus(ObjectInterpretation):
+    """G.inverse(G.plus(a, ..., z)) = G.plus(G.inverse(z), ..., G.inverse(a))."""
+
+    @implements(Group.inverse)
+    def inverse(self, monoid, value):
+        if isinstance(value, Term) and value.op is monoid.plus:
+            return monoid.plus(*(monoid.inverse(a) for a in reversed(value.args)))
+        return fwd()
+
+
+class PlusInverseCancellation(ObjectInterpretation):
+    """Cancel adjacent inverse pairs in a group plus."""
+
+    @staticmethod
+    def _are_inverses(monoid, left, right):
+        return (
+            isinstance(right, Term)
+            and right.op is monoid.inverse
+            and syntactic_eq(left, right.args[0])
+        ) or (
+            isinstance(left, Term)
+            and left.op is monoid.inverse
+            and syntactic_eq(left.args[0], right)
+        )
+
+    @implements(Monoid.plus)
+    def plus(self, monoid, *args):
+        if not isinstance(monoid, Group):
+            return fwd()
+
+        pairs = zip(range(len(args) - 1), range(1, len(args)), strict=True)
+        for left, right in pairs:
+            if self._are_inverses(monoid, args[left], args[right]):
+                return monoid.plus(
+                    *(a for i, a in enumerate(args) if i not in (left, right))
+                )
         return fwd()
 
 
@@ -1157,6 +1265,16 @@ class SumPlus(ObjectInterpretation):
         return sum(args)
 
 
+class SumInverse(ObjectInterpretation):
+    """Scalar implementation of :meth:`Sum.inverse`."""
+
+    @implements(Sum.inverse)
+    def inverse(self, value):
+        if isinstance(value, Term) or not isinstance(value, int | float):
+            return fwd()
+        return -value
+
+
 class MinPlus(ObjectInterpretation):
     """Scalar implementation of :data:`Min`."""
 
@@ -1728,6 +1846,7 @@ EvaluateIntp = _ExtensibleInterpretation().extend(
     ReducePartial(),
     DeltaConcrete(),
     SumPlus(),
+    SumInverse(),
     MinPlus(),
     MaxPlus(),
     ProductPlus(),
@@ -1776,6 +1895,9 @@ NormalizeIntp = _ExtensibleInterpretation().extend(
     PlusEmpty(),
     PlusSingle(),
     PlusAssoc(),
+    InverseInverse(),
+    InversePlus(),
+    PlusInverseCancellation(),
     PlusDistr(),
     PlusConsecutiveDups(),
     PlusOrder(),

--- a/effectful/ops/monoid.py
+++ b/effectful/ops/monoid.py
@@ -1264,10 +1264,6 @@ class SumPlus(ObjectInterpretation):
             return fwd()
         return sum(args)
 
-
-class SumInverse(ObjectInterpretation):
-    """Scalar implementation of :meth:`Sum.inverse`."""
-
     @implements(Sum.inverse)
     def inverse(self, value):
         if isinstance(value, Term) or not isinstance(value, int | float):
@@ -1846,7 +1842,6 @@ EvaluateIntp = _ExtensibleInterpretation().extend(
     ReducePartial(),
     DeltaConcrete(),
     SumPlus(),
-    SumInverse(),
     MinPlus(),
     MaxPlus(),
     ProductPlus(),

--- a/tests/test_ops_monoid.py
+++ b/tests/test_ops_monoid.py
@@ -1,5 +1,6 @@
 import functools
 import math
+import operator
 import sys
 import typing
 from collections.abc import Iterable, Mapping
@@ -16,6 +17,9 @@ from effectful.ops.monoid import (
     EliminateSingletonStreams,
     EvaluateIntp,
     Factor,
+    Group,
+    InverseInverse,
+    InversePlus,
     Max,
     Min,
     Monoid,
@@ -27,6 +31,7 @@ from effectful.ops.monoid import (
     PlusConsecutiveDups,
     PlusDistr,
     PlusEmpty,
+    PlusInverseCancellation,
     PlusOrder,
     PlusSingle,
     Product,
@@ -49,6 +54,7 @@ from effectful.ops.monoid import (
     WhereHoist,
     distributes_over,
     is_commutative,
+    solve_group_equality,
 )
 from effectful.ops.semantics import coproduct, evaluate, fvsof, handler
 from effectful.ops.syntax import as_dict, ite, range_, syntactic_eq
@@ -290,6 +296,80 @@ def test_zero_absorbs(monoid, backend: Backend, data):
     with handler(NormalizeIntp):
         assert backend.eq(monoid.plus(monoid.zero, a), monoid.zero)
         assert backend.eq(monoid.plus(a, monoid.zero), monoid.zero)
+
+
+def test_group_inverse_inverse(backend: Backend):
+    a = backend.define_vars("a", ret="scalar")
+    backend.check_rewrite(
+        lhs=Sum.inverse(Sum.inverse(a())), rhs=a(), rule=InverseInverse()
+    )
+
+
+def test_group_inverse_plus(backend: Backend):
+    a, b, c = backend.define_vars("a", "b", "c", ret="scalar")
+    backend.check_rewrite(
+        lhs=Sum.inverse(Sum.plus(a(), b(), c())),
+        rhs=Sum.plus(Sum.inverse(c()), Sum.inverse(b()), Sum.inverse(a())),
+        rule=InversePlus(),
+    )
+
+
+def test_group_inverse_cancellation(backend: Backend):
+    a, b = backend.define_vars("a", "b", ret="scalar")
+    backend.check_rewrite(
+        lhs=Sum.plus(b(), a(), Sum.inverse(a())),
+        rhs=Sum.plus(b()),
+        rule=PlusInverseCancellation(),
+    )
+
+
+def test_group_inverse_cancellation_noncommutative(backend: Backend):
+    group = Group(name="Group", identity=0)
+    a, b = backend.define_vars("a", "b", ret="scalar")
+    evaluate_group = {
+        group.plus: lambda *args: sum(args),
+        group.inverse: operator.neg,
+    }
+
+    backend.check_rewrite(
+        lhs=group.plus(a(), group.inverse(a()), b()),
+        rhs=group.plus(b()),
+        rule=PlusInverseCancellation(),
+        normalize=evaluate_group,
+    )
+
+    nonadjacent = group.plus(a(), b(), group.inverse(a()))
+    backend.check_rewrite(
+        lhs=nonadjacent,
+        rhs=nonadjacent,
+        rule=PlusInverseCancellation(),
+        normalize=evaluate_group,
+    )
+
+
+def test_solve_group_equality(backend: Backend):
+    a, b, c, result = backend.define_vars("a", "b", "c", "result", ret="scalar")
+    equality = Sum.plus(a(), b(), c()) == result()
+    expected = b() == Sum.plus(Sum.inverse(a()), result(), Sum.inverse(c()))
+    assert syntactic_eq(solve_group_equality(equality, 1), expected)
+
+
+def test_solve_group_equality_reversed_and_negative_index(backend: Backend):
+    a, b, result = backend.define_vars("a", "b", "result", ret="scalar")
+    equality = result() == Sum.plus(a(), b())
+    expected = b() == Sum.plus(Sum.inverse(a()), result())
+    assert syntactic_eq(solve_group_equality(equality, -1), expected)
+
+
+def test_solve_group_equality_errors(backend: Backend):
+    a, b, result = backend.define_vars("a", "b", "result", ret="scalar")
+
+    with pytest.raises(TypeError, match="equality Term"):
+        solve_group_equality(Sum.plus(a(), b()), 0)
+    with pytest.raises(TypeError, match="Group.plus"):
+        solve_group_equality(Product.plus(a(), b()) == result(), 0)
+    with pytest.raises(IndexError, match="out of range"):
+        solve_group_equality(Sum.plus(a(), b()) == result(), 2)
 
 
 @pytest.mark.parametrize("monoid", ALL_MONOIDS)


### PR DESCRIPTION
Adds `Group`s (monoids with inverses) and normalization rules. The first intended user of this code is in the pose solver in RobotL.